### PR TITLE
More cleanup and hardening

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "@0x/contract-addresses": "^3.3.0-beta.0",
         "@0x/contract-wrappers": "^12.2.0-beta.0",
         "@0x/json-schemas": "^4.1.0-beta.0",
-        "@0x/mesh-rpc-client": "6.0.0-beta-v3",
+        "@0x/mesh-rpc-client": "^6.0.0-beta-v3",
         "@0x/order-utils": "^8.5.0-beta.0",
         "@0x/order-watcher": "^4.0.17",
         "@0x/subproviders": "^5.1.0-beta.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "@0x/contract-addresses": "^3.3.0-beta.0",
         "@0x/contract-wrappers": "^12.2.0-beta.0",
         "@0x/json-schemas": "^4.1.0-beta.0",
-        "@0x/mesh-rpc-client": "^5.0.0-beta-v3",
+        "@0x/mesh-rpc-client": "6.0.0-beta-v3",
         "@0x/order-utils": "^8.5.0-beta.0",
         "@0x/order-watcher": "^4.0.17",
         "@0x/subproviders": "^5.1.0-beta.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,8 +65,6 @@ export const POSTGRES_URI = _.isEmpty(process.env.POSTGRES_URI)
 export const MAX_PER_PAGE = 1000;
 // Default ERC20 token precision
 export const DEFAULT_ERC20_TOKEN_PRECISION = 18;
-// Address used when simulating transfers from the maker as part of 0x order validation
-export const DEFAULT_TAKER_SIMULATION_ADDRESS = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
 function assertEnvVarType(name: string, value: any, expectedType: EnvVarType): any {
     let returnValue;

--- a/src/handlers/mesh_gateway_handlers.ts
+++ b/src/handlers/mesh_gateway_handlers.ts
@@ -5,7 +5,7 @@ import * as HttpStatus from 'http-status-codes';
 import * as _ from 'lodash';
 
 import { FEE_RECIPIENT_ADDRESS, WHITELISTED_TOKENS } from '../config';
-import { NotFoundError, ValidationError, ValidationErrorCodes } from '../errors';
+import { InternalServerError, NotFoundError, ValidationError, ValidationErrorCodes } from '../errors';
 import { OrderBookService } from '../services/orderbook_service';
 import { orderUtils } from '../utils/order_utils';
 import { paginationUtils } from '../utils/pagination_utils';
@@ -69,7 +69,11 @@ export class MeshGatewayHandlers {
             validateAssetDataIsWhitelistedOrThrow(allowedTokens, signedOrder.makerAssetData, 'makerAssetData');
             validateAssetDataIsWhitelistedOrThrow(allowedTokens, signedOrder.takerAssetData, 'takerAssetData');
         }
-        await this._orderBook.addOrderAsync(signedOrder);
+        try {
+            await this._orderBook.addOrderAsync(signedOrder);
+        } catch (err) {
+            throw new InternalServerError();
+        }
         res.status(HttpStatus.OK).send();
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,5 +45,4 @@ process.on('unhandledRejection', err => {
     if (err) {
         logger.error(err);
     }
-    process.exit(1);
 });

--- a/src/middleware/error_handling.ts
+++ b/src/middleware/error_handling.ts
@@ -14,11 +14,11 @@ import {
  * Wraps an Error with a JSON human readable reason and status code.
  */
 export function generateError(err: Error): ErrorBodyWithHTTPStatusCode {
-    if ((err as any).isRelayerError) {
-        const relayerError = err as APIBaseError;
-        const statusCode = relayerError.statusCode;
-        if (relayerError.statusCode === HttpStatus.BAD_REQUEST) {
-            const badRequestError = relayerError as BadRequestError;
+    if ((err as any).isAPIError) {
+        const apiError = err as APIBaseError;
+        const statusCode = apiError.statusCode;
+        if (apiError.statusCode === HttpStatus.BAD_REQUEST) {
+            const badRequestError = apiError as BadRequestError;
             if (badRequestError.generalErrorCode === GeneralErrorCodes.ValidationError) {
                 const validationError = badRequestError as ValidationError;
                 return {
@@ -42,7 +42,7 @@ export function generateError(err: Error): ErrorBodyWithHTTPStatusCode {
             return {
                 statusCode,
                 errorBody: {
-                    reason: HttpStatus.getStatusText(relayerError.statusCode),
+                    reason: HttpStatus.getStatusText(apiError.statusCode),
                 },
             };
         }
@@ -70,7 +70,7 @@ export function errorHandler(
     if (res.headersSent) {
         return next(err);
     }
-    if ((err as any).isRelayerError || (err as any).statusCode) {
+    if ((err as any).isAPIError || (err as any).statusCode) {
         const { statusCode, errorBody } = generateError(err);
         res.status(statusCode).send(errorBody);
         return;

--- a/src/runners/http_service_runner.ts
+++ b/src/runners/http_service_runner.ts
@@ -23,7 +23,12 @@ import { OrderBookService } from '../services/orderbook_service';
             )}`,
         );
     });
-    const meshClient = new WSClient(config.MESH_WEBSOCKET_URI);
+    let meshClient;
+    try {
+        meshClient = new WSClient(config.MESH_WEBSOCKET_URI);
+    } catch (err) {
+        logger.error(err);
+    }
     const orderBookService = new OrderBookService(meshClient);
     // tslint:disable-next-line:no-unused-expression
     new HttpService(app, orderBookService);

--- a/src/services/orderbook_service.ts
+++ b/src/services/orderbook_service.ts
@@ -174,5 +174,6 @@ export class OrderBookService {
             }
             // Order Watcher Service will handle persistence
         }
+        throw new Error('Could not add order to mesh.');
     }
 }

--- a/src/services/orderbook_service.ts
+++ b/src/services/orderbook_service.ts
@@ -12,7 +12,7 @@ import { orderUtils } from '../utils/order_utils';
 import { paginationUtils } from '../utils/pagination_utils';
 
 export class OrderBookService {
-    private readonly _meshClient: WSClient;
+    private readonly _meshClient?: WSClient;
     public static async getOrderByHashIfExistsAsync(orderHash: string): Promise<APIOrder | undefined> {
         const connection = getDBConnection();
         const signedOrderEntityIfExists = await connection.manager.findOne(SignedOrderEntity, orderHash);
@@ -157,20 +157,22 @@ export class OrderBookService {
         const paginatedApiOrders = paginationUtils.paginate(apiOrders, page, perPage);
         return paginatedApiOrders;
     }
-    constructor(meshClient: WSClient) {
+    constructor(meshClient?: WSClient) {
         this._meshClient = meshClient;
     }
     public async addOrderAsync(signedOrder: SignedOrder): Promise<void> {
-        const { rejected } = await this._meshClient.addOrdersAsync([signedOrder]);
-        if (rejected.length !== 0) {
-            throw new ValidationError([
-                {
-                    field: 'signedOrder',
-                    code: meshUtils.rejectedCodeToSRACode(rejected[0].status.code),
-                    reason: `${rejected[0].status.code}: ${rejected[0].status.message}`,
-                },
-            ]);
+        if (this._meshClient) {
+            const { rejected } = await this._meshClient.addOrdersAsync([signedOrder]);
+            if (rejected.length !== 0) {
+                throw new ValidationError([
+                    {
+                        field: 'signedOrder',
+                        code: meshUtils.rejectedCodeToSRACode(rejected[0].status.code),
+                        reason: `${rejected[0].status.code}: ${rejected[0].status.message}`,
+                    },
+                ]);
+            }
+            // Order Watcher Service will handle persistence
         }
-        // Order Watcher Service will handle persistence
     }
 }

--- a/src/utils/mesh_utils.ts
+++ b/src/utils/mesh_utils.ts
@@ -69,7 +69,7 @@ export const meshUtils = {
             case RejectedCode.OrderHasInvalidSignature: {
                 return ValidationErrorCodes.InvalidSignatureOrHash;
             }
-            case RejectedCode.OrderForIncorrectNetwork: {
+            case RejectedCode.OrderForIncorrectChain: {
                 return ValidationErrorCodes.InvalidAddress;
             }
             default:

--- a/yarn.lock
+++ b/yarn.lock
@@ -309,20 +309,6 @@
     jsonschema "^1.2.0"
     lodash.values "^4.3.0"
 
-"@0x/mesh-rpc-client@6.0.0-beta-v3":
-  version "6.0.0-beta-v3"
-  resolved "https://registry.npmjs.org/@0x/mesh-rpc-client/-/mesh-rpc-client-6.0.0-beta-v3.tgz#782d5ed76a8492e7283d3b56894c7d55593c3ef6"
-  integrity sha512-KnYoxbEmnBetH6moerYIqMRO/faDS5URzJPy9xuf/7km0lcrgcUmWNUbBsEmXs9WbSjrQ/2p2BXGQGezfZ013g==
-  dependencies:
-    "@0x/assert" "2.2.0-beta.0"
-    "@0x/order-utils" "8.5.0-beta.0"
-    "@0x/types" "2.5.0-beta.0"
-    "@0x/typescript-typings" "4.4.0-beta.0"
-    "@0x/utils" "^4.6.0-beta.0"
-    "@0x/web3-providers-fork" "0.0.7"
-    uuid "^3.3.2"
-    websocket "^1.0.29"
-
 "@0x/mesh-rpc-client@^4.0.1-beta":
   version "4.0.1-beta"
   resolved "https://registry.yarnpkg.com/@0x/mesh-rpc-client/-/mesh-rpc-client-4.0.1-beta.tgz#14db219ea398af5232811e63b7a1e5ca1de19a88"
@@ -333,6 +319,20 @@
     "@0x/types" "^2.4.1"
     "@0x/typescript-typings" "^4.2.4"
     "@0x/utils" "^4.4.2"
+    "@0x/web3-providers-fork" "0.0.7"
+    uuid "^3.3.2"
+    websocket "^1.0.29"
+
+"@0x/mesh-rpc-client@^6.0.0-beta-v3":
+  version "6.0.0-beta-v3"
+  resolved "https://registry.npmjs.org/@0x/mesh-rpc-client/-/mesh-rpc-client-6.0.0-beta-v3.tgz#782d5ed76a8492e7283d3b56894c7d55593c3ef6"
+  integrity sha512-KnYoxbEmnBetH6moerYIqMRO/faDS5URzJPy9xuf/7km0lcrgcUmWNUbBsEmXs9WbSjrQ/2p2BXGQGezfZ013g==
+  dependencies:
+    "@0x/assert" "2.2.0-beta.0"
+    "@0x/order-utils" "8.5.0-beta.0"
+    "@0x/types" "2.5.0-beta.0"
+    "@0x/typescript-typings" "4.4.0-beta.0"
+    "@0x/utils" "^4.6.0-beta.0"
     "@0x/web3-providers-fork" "0.0.7"
     uuid "^3.3.2"
     websocket "^1.0.29"

--- a/yarn.lock
+++ b/yarn.lock
@@ -309,6 +309,20 @@
     jsonschema "^1.2.0"
     lodash.values "^4.3.0"
 
+"@0x/mesh-rpc-client@6.0.0-beta-v3":
+  version "6.0.0-beta-v3"
+  resolved "https://registry.npmjs.org/@0x/mesh-rpc-client/-/mesh-rpc-client-6.0.0-beta-v3.tgz#782d5ed76a8492e7283d3b56894c7d55593c3ef6"
+  integrity sha512-KnYoxbEmnBetH6moerYIqMRO/faDS5URzJPy9xuf/7km0lcrgcUmWNUbBsEmXs9WbSjrQ/2p2BXGQGezfZ013g==
+  dependencies:
+    "@0x/assert" "2.2.0-beta.0"
+    "@0x/order-utils" "8.5.0-beta.0"
+    "@0x/types" "2.5.0-beta.0"
+    "@0x/typescript-typings" "4.4.0-beta.0"
+    "@0x/utils" "^4.6.0-beta.0"
+    "@0x/web3-providers-fork" "0.0.7"
+    uuid "^3.3.2"
+    websocket "^1.0.29"
+
 "@0x/mesh-rpc-client@^4.0.1-beta":
   version "4.0.1-beta"
   resolved "https://registry.yarnpkg.com/@0x/mesh-rpc-client/-/mesh-rpc-client-4.0.1-beta.tgz#14db219ea398af5232811e63b7a1e5ca1de19a88"
@@ -319,19 +333,6 @@
     "@0x/types" "^2.4.1"
     "@0x/typescript-typings" "^4.2.4"
     "@0x/utils" "^4.4.2"
-    "@0x/web3-providers-fork" "0.0.7"
-    uuid "^3.3.2"
-    websocket "^1.0.29"
-
-"@0x/mesh-rpc-client@^5.0.0-beta-v3":
-  version "5.0.0-beta-v3"
-  resolved "https://registry.yarnpkg.com/@0x/mesh-rpc-client/-/mesh-rpc-client-5.0.0-beta-v3.tgz#3344dd9e0b24a1c072918e6037b6e7f86a55fc37"
-  dependencies:
-    "@0x/assert" "2.2.0-beta.0"
-    "@0x/order-utils" "8.5.0-beta.0"
-    "@0x/types" "2.5.0-beta.0"
-    "@0x/typescript-typings" "4.4.0-beta.0"
-    "@0x/utils" "^4.6.0-beta.0"
     "@0x/web3-providers-fork" "0.0.7"
     uuid "^3.3.2"
     websocket "^1.0.29"


### PR DESCRIPTION
The main attempt here is to make sure the HTTP service can still run when mesh is down or we cannot connect to mesh. Unfortunately the mesh RPC client has an unhandled promise rejection when the you give it an invalid URL. By default, unhandled promise rejections are warnings, and do not crash your app, so I have implemented the same here for the custom rejection handlers. By default, an uncaught **exception** does crash your app. The point with catching them here is to have all logs be formatted in the same way.
There are also some other clean-up items in here.