### PR TITLE
add .drone.yml for Docker build and ship to ECR

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,4 @@
-name: trident-pipeline
+name: 0x-api-pipeline
 kind: pipeline
 type: docker
 
@@ -16,7 +16,7 @@ steps:
       tags:
         - ${DRONE_COMMIT_SHA}
 ---
-name: trident-pipeline
+name: 0x-api-pipeline
 kind: pipeline
 type: docker
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ platform:
   arch: amd64
 
 steps:
-  - name: publish  
+  - name: publish-sha
     image: plugins/ecr
     settings:
       repo: ${ECR_REPO}

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,35 @@
+name: trident-pipeline
+kind: pipeline
+type: docker
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+  - name: publish  
+    image: plugins/ecr
+    settings:
+      repo: ${ECR_REPO}
+      registry: ${ECR_REGISTRY}
+      region: us-east-1
+      tags:
+        - ${DRONE_COMMIT_SHA}
+---
+name: trident-pipeline
+kind: pipeline
+type: docker
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+  - name: publish  
+    image: plugins/ecr
+    settings:
+      repo: ${ECR_REPO}
+      registry: ${ECR_REGISTRY}
+      region: us-east-1
+      tags:
+        - latest

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,4 @@
-name: 0x-api-pipeline
+name: 0x-api-pipeline-sha
 kind: pipeline
 type: docker
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -33,3 +33,10 @@ steps:
       region: us-east-1
       tags:
         - latest
+
+trigger:
+  branch:
+  - master
+  event:
+    include:
+      - push

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,8 +10,10 @@ steps:
   - name: publish-sha
     image: plugins/ecr
     settings:
-      repo: ${ECR_REPO}
-      registry: ${ECR_REGISTRY}
+      repo:
+        from_secret: ecr_repo
+      registry:
+        from_secret: ecr_registry
       region: us-east-1
       tags:
         - ${DRONE_COMMIT_SHA}
@@ -28,8 +30,10 @@ steps:
   - name: publish  
     image: plugins/ecr
     settings:
-      repo: ${ECR_REPO}
-      registry: ${ECR_REGISTRY}
+      repo:
+        from_secret: ecr_repo
+      registry:
+        from_secret: ecr_registry
       region: us-east-1
       tags:
         - latest


### PR DESCRIPTION
About
===

This PR adds a simple `.drone.yml` config that builds the images and ships them to ECR,

Note:
- The repository itself needs to be activated on Drone.
- `ECR_REPO` and `ECR_REGISTRY` need to be set in the Drone secrets first.