### PR TITLE
Rename /mesh_gateway to /sra

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,5 +8,7 @@ export const DEFAULT_PER_PAGE = 20;
 export const ZERO = new BigNumber(0);
 export const MAX_TOKEN_SUPPLY_POSSIBLE = new BigNumber(2).pow(256); // tslint:disable-line custom-no-magic-numbers
 export const DEFAULT_LOCAL_POSTGRES_URI = 'postgresql://api:api@localhost/api';
-export const MESH_GATEWAY_PATH = '/mesh_gateway';
+
+// API namespaces
+export const SRA_PATH = '/sra';
 export const STAKING_PATH = '/staking';

--- a/src/handlers/sra_handlers.ts
+++ b/src/handlers/sra_handlers.ts
@@ -11,7 +11,7 @@ import { orderUtils } from '../utils/order_utils';
 import { paginationUtils } from '../utils/pagination_utils';
 import { schemaUtils } from '../utils/schema_utils';
 
-export class MeshGatewayHandlers {
+export class SRAHandlers {
     private readonly _orderBook: OrderBookService;
     public static feeRecipients(req: express.Request, res: express.Response): void {
         const { page, perPage } = paginationUtils.parsePaginationConfig(req);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,12 @@ import { WSClient } from '@0x/mesh-rpc-client';
 import * as express from 'express';
 
 import * as config from './config';
-import { MESH_GATEWAY_PATH } from './constants';
+import { SRA_PATH } from './constants';
 import { getDBConnectionAsync } from './db_connection';
 import { logger } from './logger';
-import { MeshGatewayHttpService } from './services/mesh_gateway_http_service';
 import { OrderWatcherService } from './services/order_watcher_service';
 import { OrderBookService } from './services/orderbook_service';
+import { SRAHttpService } from './services/sra_http_service';
 import { StakingDataService } from './services/staking_data_service';
 import { StakingHttpService } from './services/staking_http_service';
 import { WebsocketService } from './services/websocket_service';
@@ -31,13 +31,13 @@ import { WebsocketService } from './services/websocket_service';
     try {
         meshClient = new WSClient(config.MESH_WEBSOCKET_URI);
         // tslint:disable-next-line:no-unused-expression
-        new WebsocketService(server, meshClient, { path: MESH_GATEWAY_PATH });
+        new WebsocketService(server, meshClient, { path: SRA_PATH });
     } catch (err) {
         logger.error(err);
     }
     const orderBookService = new OrderBookService(connection, meshClient);
     // tslint:disable-next-line:no-unused-expression
-    new MeshGatewayHttpService(app, orderBookService);
+    new SRAHttpService(app, orderBookService);
     if (meshClient) {
         const orderWatcherService = new OrderWatcherService(connection, meshClient);
         await orderWatcherService.syncOrderbookAsync();

--- a/src/routers/sra_router.ts
+++ b/src/routers/sra_router.ts
@@ -1,12 +1,12 @@
 import * as express from 'express';
 import * as asyncHandler from 'express-async-handler';
 
-import { MeshGatewayHandlers } from '../handlers/mesh_gateway_handlers';
+import { SRAHandlers } from '../handlers/sra_handlers';
 import { OrderBookService } from '../services/orderbook_service';
 
-export const createMeshGatewayRouter = (orderBook: OrderBookService): express.Router => {
+export const createSRARouter = (orderBook: OrderBookService): express.Router => {
     const router = express.Router();
-    const handlers = new MeshGatewayHandlers(orderBook);
+    const handlers = new SRAHandlers(orderBook);
     /**
      * GET AssetPairs endpoint retrieves a list of available asset pairs and the information required to trade them.
      * http://sra-spec.s3-website-us-east-1.amazonaws.com/#operation/getAssetPairs
@@ -26,12 +26,12 @@ export const createMeshGatewayRouter = (orderBook: OrderBookService): express.Ro
      * GET FeeRecepients endpoint retrieves a collection of all fee recipient addresses for a relayer.
      * http://sra-spec.s3-website-us-east-1.amazonaws.com/v3/fee_recipients
      */
-    router.get('/fee_recipients', MeshGatewayHandlers.feeRecipients.bind(MeshGatewayHandlers));
+    router.get('/fee_recipients', SRAHandlers.feeRecipients.bind(SRAHandlers));
     /**
      * POST Order config endpoint retrives the values for order fields that the relayer requires.
      * http://sra-spec.s3-website-us-east-1.amazonaws.com/#operation/getOrderConfig
      */
-    router.post('/order_config', MeshGatewayHandlers.orderConfig.bind(MeshGatewayHandlers));
+    router.post('/order_config', SRAHandlers.orderConfig.bind(SRAHandlers));
     /**
      * POST Order endpoint submits an order to the Relayer.
      * http://sra-spec.s3-website-us-east-1.amazonaws.com/#operation/postOrder

--- a/src/runners/http_service_runner.ts
+++ b/src/runners/http_service_runner.ts
@@ -4,8 +4,8 @@ import * as express from 'express';
 import * as config from '../config';
 import { getDBConnectionAsync } from '../db_connection';
 import { logger } from '../logger';
-import { MeshGatewayHttpService } from '../services/mesh_gateway_http_service';
 import { OrderBookService } from '../services/orderbook_service';
+import { SRAHttpService } from '../services/sra_http_service';
 import { StakingDataService } from '../services/staking_data_service';
 import { StakingHttpService } from '../services/staking_http_service';
 
@@ -36,5 +36,5 @@ import { StakingHttpService } from '../services/staking_http_service';
     }
     const orderBookService = new OrderBookService(connection, meshClient);
     // tslint:disable-next-line:no-unused-expression
-    new MeshGatewayHttpService(app, orderBookService);
+    new SRAHttpService(app, orderBookService);
 })().catch(error => logger.error(error));

--- a/src/services/sra_http_service.ts
+++ b/src/services/sra_http_service.ts
@@ -3,17 +3,18 @@ import * as cors from 'cors';
 // tslint:disable-next-line:no-implicit-dependencies
 import * as core from 'express-serve-static-core';
 
-import { MESH_GATEWAY_PATH } from '../constants';
+import { SRA_PATH } from '../constants';
 import { errorHandler } from '../middleware/error_handling';
-import { createMeshGatewayRouter } from '../routers/mesh_gateway_router';
-import { OrderBookService } from '../services/orderbook_service';
+import { createSRARouter } from '../routers/sra_router';
+
+import { OrderBookService } from './orderbook_service';
 
 // tslint:disable-next-line:no-unnecessary-class
-export class MeshGatewayHttpService {
+export class SRAHttpService {
     constructor(app: core.Express, orderBook: OrderBookService) {
         app.use(cors());
         app.use(bodyParser.json());
-        app.use(MESH_GATEWAY_PATH, createMeshGatewayRouter(orderBook));
+        app.use(SRA_PATH, createSRARouter(orderBook));
         app.use(errorHandler);
     }
 }

--- a/src/services/websocket_service.ts
+++ b/src/services/websocket_service.ts
@@ -36,6 +36,12 @@ const DEFAULT_OPTS: WebsocketSRAOpts = {
 
 type ALL_SUBSCRIPTION_OPTS = 'ALL_SUBSCRIPTION_OPTS';
 
+/* A websocket server that sends order updates to subscribed
+ * clients. The server listens on the supplied path for
+ * subscription requests from relayers. It also subscribes to
+ * Mesh using mesh-rpc-client. It filters Mesh updates and sends
+ * relevant orders to the subscribed clients in real time.
+ */
 export class WebsocketService {
     private readonly _server: WebSocket.Server;
     private readonly _meshClient: WSClient;


### PR DESCRIPTION
This PR renames `/mesh_gateway` endpoints to `/sra`. Also renames files and classes.
Motivation for this is the `MeshGateway` endpoints support the SRA spec. Connection to Mesh is more of an implementation detail. 