### PR TITLE
Add request logging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import * as express from 'express';
 import * as config from './config';
 import { SRA_PATH } from './constants';
 import { getDBConnectionAsync } from './db_connection';
-import { logger } from './logger';
+import { logger, logMiddleware } from './logger';
 import { OrderWatcherService } from './services/order_watcher_service';
 import { OrderBookService } from './services/orderbook_service';
 import { SRAHttpService } from './services/sra_http_service';
@@ -15,6 +15,7 @@ import { WebsocketService } from './services/websocket_service';
 (async () => {
     const connection = await getDBConnectionAsync();
     const app = express();
+    app.use(logMiddleware());
     const server = app.listen(config.HTTP_PORT, () => {
         logger.info(
             `API (HTTP) listening on port ${config.HTTP_PORT}!\nConfig: ${JSON.stringify(

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,3 +1,45 @@
+// tslint:disable-next-line:no-implicit-dependencies
+import * as core from 'express-serve-static-core';
 import * as pino from 'pino';
 
 export const logger = pino();
+
+/**
+ * log middleware
+ */
+export function logMiddleware(): core.RequestHandler {
+    const handler = (req: any, res: any, next: core.NextFunction) => {
+        const startTime = Date.now();
+        function writeLog(): void {
+            const responseTime = Date.now() - startTime;
+            res.removeListener('finish', writeLog);
+            res.removeListener('close', writeLog);
+            const logMsg = {
+                req: {
+                    url: req.originalUrl.split('?')[0],
+                    method: req.method,
+                    headers: {
+                        'user-agent': req.headers['user-agent'],
+                        host: req.headers.host,
+                    },
+                    body: req.body,
+                    params: req.params,
+                    query: req.query,
+                },
+                res: {
+                    statusCode: res.statusCode,
+                    statusMessage: res.statusMessage,
+                    error: res.error,
+                },
+                responseTime,
+                timestamp: Date.now(),
+            };
+            logger.info(logMsg);
+        }
+        res.on('finish', writeLog);
+        res.on('close', writeLog);
+        req.log = logger;
+        next();
+    };
+    return handler;
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,3 +1,4 @@
+import * as express from 'express';
 // tslint:disable-next-line:no-implicit-dependencies
 import * as core from 'express-serve-static-core';
 import * as pino from 'pino';
@@ -8,7 +9,7 @@ export const logger = pino();
  * log middleware
  */
 export function logMiddleware(): core.RequestHandler {
-    const handler = (req: any, res: any, next: core.NextFunction) => {
+    const handler = (req: express.Request, res: express.Response, next: core.NextFunction) => {
         const startTime = Date.now();
         function writeLog(): void {
             const responseTime = Date.now() - startTime;
@@ -29,7 +30,6 @@ export function logMiddleware(): core.RequestHandler {
                 res: {
                     statusCode: res.statusCode,
                     statusMessage: res.statusMessage,
-                    error: res.error,
                 },
                 responseTime,
                 timestamp: Date.now(),
@@ -38,7 +38,6 @@ export function logMiddleware(): core.RequestHandler {
         }
         res.on('finish', writeLog);
         res.on('close', writeLog);
-        req.log = logger;
         next();
     };
     return handler;


### PR DESCRIPTION
This PR adds logging for incoming requests. 

I tried out using `express-pino-logger` but found it too restrictive. The supported serializers coerced `Express.Request` and `Express.Response` into `IncomingMessage` and `ServerResponse` from the native 'http' module, which doesn't easily expose the request body or params. 

So instead I wrote our own little middleware. It's pretty simple but hopefully useful.

One of the features is that all requests have the logger object attached. So you can do:

```
public async ordersAsync(req: express.Request, res: express.Response): Promise<void> {
    req.logger.info(`Retrieving orders!`);
    // handle the request
}
```

Some examples of the logs produced:

<img width="1207" alt="Screen Shot 2019-12-04 at 5 03 45 PM" src="https://user-images.githubusercontent.com/8582774/70194682-10362980-16b8-11ea-8c54-9a26f80c4120.png">

<img width="1291" alt="Screen Shot 2019-12-04 at 5 29 49 PM" src="https://user-images.githubusercontent.com/8582774/70195850-b899bd00-16bb-11ea-9b00-6fe3c9bf6c71.png">

(With pino-pretty in dev mode; actual logs won't have so much whitespace)

@alexkroeger , I'm not separating the namespace (e.g. `/sra`) from the path e.g. (`/orders`) like we discussed. I did some experimentation and found that they don't resolve reliably. Specifically, express seems to have trouble resolving the `baseUrl` for POST methods. So we would have some logs with `{ namespace: '/sra', path: '/orders }` and some logs with `{namespace: undefined, path: '/sra/orders' }`. I figured it would be better to be consistent and make them *all* `{ path: '/sra/orders' }`.