### PR TITLE
Staking/stats, staking/epochs, change staking/pools

### DIFF
--- a/src/handlers/staking_handlers.ts
+++ b/src/handlers/staking_handlers.ts
@@ -25,9 +25,9 @@ export class StakingHandlers {
         res.status(HttpStatus.OK).send(response);
     }
     public async getStakingStatsAsync(_req: express.Request, res: express.Response): Promise<void> {
-        const overallStakingStats = await this._stakingDataService.getOverallStakingStatsAsync();
+        const allTimeStakingStats = await this._stakingDataService.getAllTimeStakingStatsAsync();
         const response: StakingStatsResponse = {
-            overall: overallStakingStats,
+            allTime: allTimeStakingStats,
         };
         res.status(HttpStatus.OK).send(response);
     }

--- a/src/handlers/staking_handlers.ts
+++ b/src/handlers/staking_handlers.ts
@@ -2,7 +2,7 @@ import * as express from 'express';
 import * as HttpStatus from 'http-status-codes';
 
 import { StakingDataService } from '../services/staking_data_service';
-import { StakingEpochsResponse, StakingPoolsResponse } from '../types';
+import { StakingEpochsResponse, StakingPoolsResponse, StakingStatsResponse } from '../types';
 
 export class StakingHandlers {
     private readonly _stakingDataService: StakingDataService;
@@ -21,6 +21,13 @@ export class StakingHandlers {
         const response: StakingEpochsResponse = {
             currentEpoch,
             nextEpoch,
+        };
+        res.status(HttpStatus.OK).send(response);
+    }
+    public async getStakingStatsAsync(_req: express.Request, res: express.Response): Promise<void> {
+        const overallStakingStats = await this._stakingDataService.getOverallStakingStatsAsync();
+        const response: StakingStatsResponse = {
+            overall: overallStakingStats,
         };
         res.status(HttpStatus.OK).send(response);
     }

--- a/src/handlers/staking_handlers.ts
+++ b/src/handlers/staking_handlers.ts
@@ -2,20 +2,25 @@ import * as express from 'express';
 import * as HttpStatus from 'http-status-codes';
 
 import { StakingDataService } from '../services/staking_data_service';
-import { StakingPoolsResponse } from '../types';
+import { StakingEpochsResponse, StakingPoolsResponse } from '../types';
 
 export class StakingHandlers {
     private readonly _stakingDataService: StakingDataService;
     public async getStakingPoolsAsync(_req: express.Request, res: express.Response): Promise<void> {
-        const [currentEpoch, approximateNextEpoch, stakingPools] = await Promise.all([
+        const stakingPools = await this._stakingDataService.getStakingPoolsWithStatsAsync();
+        const response: StakingPoolsResponse = {
+            stakingPools,
+        };
+        res.status(HttpStatus.OK).send(response);
+    }
+    public async getStakingEpochsAsync(_req: express.Request, res: express.Response): Promise<void> {
+        const [currentEpoch, nextEpoch] = await Promise.all([
             this._stakingDataService.getCurrentEpochAsync(),
             this._stakingDataService.getNextEpochAsync(),
-            this._stakingDataService.getStakingPoolsWithStatsAsync(),
         ]);
-        const response: StakingPoolsResponse = {
+        const response: StakingEpochsResponse = {
             currentEpoch,
-            approximateNextEpoch,
-            stakingPools,
+            nextEpoch,
         };
         res.status(HttpStatus.OK).send(response);
     }

--- a/src/routers/staking_router.ts
+++ b/src/routers/staking_router.ts
@@ -9,5 +9,6 @@ export const createStakingRouter = (stakingDataService: StakingDataService): exp
     const handlers = new StakingHandlers(stakingDataService);
     router.get('/pools', asyncHandler(handlers.getStakingPoolsAsync.bind(handlers)));
     router.get('/epochs', asyncHandler(handlers.getStakingEpochsAsync.bind(handlers)));
+    router.get('/stats', asyncHandler(handlers.getStakingStatsAsync.bind(handlers)));
     return router;
 };

--- a/src/routers/staking_router.ts
+++ b/src/routers/staking_router.ts
@@ -8,5 +8,6 @@ export const createStakingRouter = (stakingDataService: StakingDataService): exp
     const router = express.Router();
     const handlers = new StakingHandlers(stakingDataService);
     router.get('/pools', asyncHandler(handlers.getStakingPoolsAsync.bind(handlers)));
+    router.get('/epochs', asyncHandler(handlers.getStakingEpochsAsync.bind(handlers)));
     return router;
 };

--- a/src/services/staking_data_service.ts
+++ b/src/services/staking_data_service.ts
@@ -61,15 +61,61 @@ export class StakingDataService {
     }
 }
 
-const currentEpochQuery = `SELECT * FROM staking.current_epoch;`;
+const currentEpochQuery = `
+    WITH zrx_staked AS (
+        SELECT
+            SUM(esps.zrx_delegated) AS zrx_staked
+        FROM staking.epoch_start_pool_status esps
+        JOIN staking.current_epoch ce ON ce.epoch_id = esps.epoch_id
+    )
+    , protocol_fees AS (
+        SELECT
+            SUM(protocol_fee_paid) / 1e18::NUMERIC AS protocol_fees_generated_in_eth
+        FROM events.fill_events fe
+        JOIN staking.current_epoch ce
+            ON fe.block_number > ce.starting_block_number
+            OR (fe.block_number = ce.starting_block_number AND fe.transaction_index > ce.starting_transaction_index)
+    )
+    , zrx_deposited AS (
+        SELECT
+            SUM(scc.amount) AS zrx_deposited
+        FROM staking.zrx_staking_contract_changes scc
+        JOIN staking.current_epoch ce
+            ON scc.block_number < ce.starting_block_number
+            OR (scc.block_number = ce.starting_block_number AND scc.transaction_index < ce.starting_transaction_index)
+    )
+    SELECT
+        ce.*
+        , zd.zrx_deposited
+        , zs.zrx_staked
+        , pf.protocol_fees_generated_in_eth
+    FROM staking.current_epoch ce
+    CROSS JOIN zrx_deposited zd
+    CROSS JOIN zrx_staked zs
+    CROSS JOIN protocol_fees pf;`;
 
 const nextEpochQuery = `
+    WITH
+    zrx_staked AS (
+        SELECT
+            SUM(amount) AS zrx_staked
+        FROM staking.zrx_staking_changes
+    )
+    , zrx_deposited AS (
+        SELECT
+            SUM(scc.amount) AS zrx_deposited
+        FROM staking.zrx_staking_contract_changes scc
+    )
     SELECT
-    ce.epoch_id + 1 AS epoch_id
-    , ce.starting_block_number + cp.epoch_duration_in_seconds::NUMERIC / 15::NUMERIC AS starting_block_number
-    , ce.starting_block_timestamp + ((cp.epoch_duration_in_seconds)::VARCHAR || ' seconds')::INTERVAL AS starting_block_timestamp
+        ce.epoch_id + 1 AS epoch_id
+        , ce.starting_block_number + cp.epoch_duration_in_seconds::NUMERIC / 15::NUMERIC AS starting_block_number
+        , ce.starting_block_timestamp + ((cp.epoch_duration_in_seconds)::VARCHAR || ' seconds')::INTERVAL AS starting_timestamp
+        , zd.zrx_deposited
+        , zs.zrx_staked
     FROM staking.current_epoch ce
-    CROSS JOIN staking.current_params cp;`;
+    CROSS JOIN staking.current_params cp
+    CROSS JOIN zrx_staked zs
+    CROSS JOIN zrx_deposited zd;`;
 
 const stakingPoolsQuery = `SELECT * FROM staking.pool_info;`;
 

--- a/src/services/staking_data_service.ts
+++ b/src/services/staking_data_service.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import { Connection } from 'typeorm';
 
-import { Epoch, AllTimeStakingStats, Pool, PoolWithStats, RawEpoch, RawAllTimeStakingStats, RawPool } from '../types';
+import { AllTimeStakingStats, Epoch, Pool, PoolWithStats, RawAllTimeStakingStats, RawEpoch, RawPool } from '../types';
 import { stakingUtils } from '../utils/staking_utils';
 import { utils } from '../utils/utils';
 

--- a/src/services/staking_data_service.ts
+++ b/src/services/staking_data_service.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import { Connection } from 'typeorm';
 
-import { Epoch, OverallStakingStats, Pool, PoolWithStats, RawEpoch, RawOverallStakingStats, RawPool } from '../types';
+import { Epoch, AllTimeStakingStats, Pool, PoolWithStats, RawEpoch, RawAllTimeStakingStats, RawPool } from '../types';
 import { stakingUtils } from '../utils/staking_utils';
 import { utils } from '../utils/utils';
 
@@ -31,13 +31,13 @@ export class StakingDataService {
         const pools = stakingUtils.getPoolsFromRaw(rawPools);
         return pools;
     }
-    public async getOverallStakingStatsAsync(): Promise<OverallStakingStats> {
-        const rawOverallStats: RawOverallStakingStats | undefined = _.head(await this._connection.query(overallStatQuery));
-        if (!rawOverallStats) {
-            throw new Error('Could not find overall staking statistics.');
+    public async getAllTimeStakingStatsAsync(): Promise<AllTimeStakingStats> {
+        const rawAllTimeStats: RawAllTimeStakingStats | undefined = _.head(await this._connection.query(allTimeStatQuery));
+        if (!rawAllTimeStats) {
+            throw new Error('Could not find allTime staking statistics.');
         }
-        const allTimeOverallStats: OverallStakingStats = stakingUtils.getOverallStakingStatsFromRaw(rawOverallStats);
-        return allTimeOverallStats;
+        const allTimeAllTimeStats: AllTimeStakingStats = stakingUtils.getAllTimeStakingStatsFromRaw(rawAllTimeStats);
+        return allTimeAllTimeStats;
     }
     public async getStakingPoolsWithStatsAsync(): Promise<PoolWithStats[]> {
         const [
@@ -267,7 +267,7 @@ const nextEpochPoolStatsQuery = `
         CROSS JOIN total_rewards tr;
 `;
 
-const overallStatQuery = `
+const allTimeStatQuery = `
     SELECT SUM(
         COALESCE(operator_reward,0)
         + COALESCE(members_reward,0)

--- a/src/services/staking_data_service.ts
+++ b/src/services/staking_data_service.ts
@@ -32,7 +32,7 @@ export class StakingDataService {
         return pools;
     }
     public async getAllTimeStakingStatsAsync(): Promise<AllTimeStakingStats> {
-        const rawAllTimeStats: RawAllTimeStakingStats | undefined = _.head(await this._connection.query(allTimeStatQuery));
+        const rawAllTimeStats: RawAllTimeStakingStats | undefined = _.head(await this._connection.query(allTimeStatsQuery));
         if (!rawAllTimeStats) {
             throw new Error('Could not find allTime staking statistics.');
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,10 +152,10 @@ export interface PoolProtocolFeesGenerated {
     sevenDayProtocolFeesGeneratedInEth: number;
 }
 
-export interface RawOverallStakingStats {
+export interface RawAllTimeStakingStats {
     total_rewards_paid: string;
 }
-export interface OverallStakingStats {
+export interface AllTimeStakingStats {
     totalRewardsPaid: number;
 }
 
@@ -168,7 +168,7 @@ export interface StakingEpochsResponse {
     nextEpoch: Epoch;
 }
 export interface StakingStatsResponse {
-    overall: OverallStakingStats;
+    allTime: AllTimeStakingStats;
 }
 
 export interface ObjectMap<T> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,12 +152,15 @@ export interface PoolProtocolFeesGenerated {
     sevenDayProtocolFeesGeneratedInEth: number;
 }
 
-export interface StakingPoolsResponse {
-    stakingPools: PoolWithStats[];
+export interface RawOverallStakingStats {
+    total_rewards_paid: string;
+}
+export interface OverallStakingStats {
+    totalRewardsPaid: number;
 }
 
-export interface AllTimeOverallStats {
-    totalRewardsPaid: number;
+export interface StakingPoolsResponse {
+    stakingPools: PoolWithStats[];
 }
 
 export interface StakingEpochsResponse {
@@ -165,7 +168,7 @@ export interface StakingEpochsResponse {
     nextEpoch: Epoch;
 }
 export interface StakingStatsResponse {
-    allTime: AllTimeOverallStats;
+    overall: OverallStakingStats;
 }
 
 export interface ObjectMap<T> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,7 +156,7 @@ export interface RawAllTimeStakingStats {
     total_rewards_paid: string;
 }
 export interface AllTimeStakingStats {
-    totalRewardsPaid: number;
+    totalRewardsPaidInEth: number;
 }
 
 export interface StakingPoolsResponse {

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,9 @@ export interface RawEpoch {
     ending_transaction_index?: null;
     ending_block_number?: null;
     ending_block_timestamp?: null;
+    zrx_deposited?: string;
+    zrx_staked?: string;
+    protocol_fees_generated_in_eth?: string;
 }
 
 export interface TransactionDate {
@@ -75,6 +78,10 @@ export interface TransactionDate {
 export interface Epoch {
     epochId: number;
     epochStart: TransactionDate;
+    epochEnd?: TransactionDate;
+    zrxStaked: number;
+    zrxDeposited: number;
+    protocolFeesGeneratedInEth: number;
 }
 
 export interface RawPool {
@@ -146,9 +153,19 @@ export interface PoolProtocolFeesGenerated {
 }
 
 export interface StakingPoolsResponse {
-    currentEpoch: Epoch;
-    approximateNextEpoch: Epoch;
     stakingPools: PoolWithStats[];
+}
+
+export interface AllTimeOverallStats {
+    totalRewardsPaid: number;
+}
+
+export interface StakingEpochsResponse {
+    currentEpoch: Epoch;
+    nextEpoch: Epoch;
+}
+export interface StakingStatsResponse {
+    allTime: AllTimeOverallStats;
 }
 
 export interface ObjectMap<T> {

--- a/src/utils/staking_utils.ts
+++ b/src/utils/staking_utils.ts
@@ -1,12 +1,12 @@
 import {
     Epoch,
     EpochPoolStats,
-    OverallStakingStats,
+    AllTimeStakingStats,
     Pool,
     PoolProtocolFeesGenerated,
     RawEpoch,
     RawEpochPoolStats,
-    RawOverallStakingStats,
+    RawAllTimeStakingStats,
     RawPool,
     RawPoolProtocolFeesGenerated,
     TransactionDate,
@@ -115,8 +115,8 @@ export const stakingUtils = {
     ): PoolProtocolFeesGenerated[] => {
         return rawPoolsProtocolFeesGenerated.map(stakingUtils.getPoolProtocolFeesGeneratedFromRaw);
     },
-    getOverallStakingStatsFromRaw: (rawAllTimeOverallStats: RawOverallStakingStats): OverallStakingStats => {
-        const { total_rewards_paid } = rawAllTimeOverallStats;
+    getAllTimeStakingStatsFromRaw: (rawAllTimeAllTimeStats: RawAllTimeStakingStats): AllTimeStakingStats => {
+        const { total_rewards_paid } = rawAllTimeAllTimeStats;
         return {
             totalRewardsPaid: Number(total_rewards_paid || 0),
         };

--- a/src/utils/staking_utils.ts
+++ b/src/utils/staking_utils.ts
@@ -7,11 +7,31 @@ import {
     RawEpochPoolStats,
     RawPool,
     RawPoolProtocolFeesGenerated,
+    TransactionDate,
 } from '../types';
 
 export const stakingUtils = {
     getEpochFromRaw: (rawEpoch: RawEpoch): Epoch => {
-        const { epoch_id, starting_transaction_hash, starting_block_number, starting_block_timestamp } = rawEpoch;
+        const {
+            epoch_id,
+            starting_transaction_hash,
+            starting_block_number,
+            starting_block_timestamp,
+            ending_transaction_hash,
+            ending_block_number,
+            ending_block_timestamp,
+            zrx_deposited,
+            zrx_staked,
+            protocol_fees_generated_in_eth,
+        } = rawEpoch;
+        let epochEnd: TransactionDate | undefined;
+        if (ending_transaction_hash && ending_block_number) {
+            epochEnd = {
+                blockNumber: parseInt(ending_block_number, 10),
+                txHash: ending_transaction_hash,
+                timestamp: ending_block_timestamp || undefined,
+            };
+        }
         return {
             epochId: parseInt(epoch_id, 10),
             epochStart: {
@@ -19,6 +39,10 @@ export const stakingUtils = {
                 txHash: starting_transaction_hash,
                 timestamp: starting_block_timestamp || undefined,
             },
+            epochEnd,
+            zrxDeposited: Number(zrx_deposited || 0),
+            zrxStaked: Number(zrx_staked || 0),
+            protocolFeesGeneratedInEth: Number(protocol_fees_generated_in_eth || 0),
         };
     },
     getPoolFromRaw: (rawPool: RawPool): Pool => {

--- a/src/utils/staking_utils.ts
+++ b/src/utils/staking_utils.ts
@@ -1,12 +1,12 @@
 import {
+    AllTimeStakingStats,
     Epoch,
     EpochPoolStats,
-    AllTimeStakingStats,
     Pool,
     PoolProtocolFeesGenerated,
+    RawAllTimeStakingStats,
     RawEpoch,
     RawEpochPoolStats,
-    RawAllTimeStakingStats,
     RawPool,
     RawPoolProtocolFeesGenerated,
     TransactionDate,
@@ -118,7 +118,7 @@ export const stakingUtils = {
     getAllTimeStakingStatsFromRaw: (rawAllTimeAllTimeStats: RawAllTimeStakingStats): AllTimeStakingStats => {
         const { total_rewards_paid } = rawAllTimeAllTimeStats;
         return {
-            totalRewardsPaid: Number(total_rewards_paid || 0),
+            totalRewardsPaidInEth: Number(total_rewards_paid || 0),
         };
     },
 };

--- a/src/utils/staking_utils.ts
+++ b/src/utils/staking_utils.ts
@@ -1,10 +1,12 @@
 import {
     Epoch,
     EpochPoolStats,
+    OverallStakingStats,
     Pool,
     PoolProtocolFeesGenerated,
     RawEpoch,
     RawEpochPoolStats,
+    RawOverallStakingStats,
     RawPool,
     RawPoolProtocolFeesGenerated,
     TransactionDate,
@@ -112,5 +114,11 @@ export const stakingUtils = {
         rawPoolsProtocolFeesGenerated: RawPoolProtocolFeesGenerated[],
     ): PoolProtocolFeesGenerated[] => {
         return rawPoolsProtocolFeesGenerated.map(stakingUtils.getPoolProtocolFeesGeneratedFromRaw);
+    },
+    getOverallStakingStatsFromRaw: (rawAllTimeOverallStats: RawOverallStakingStats): OverallStakingStats => {
+        const { total_rewards_paid } = rawAllTimeOverallStats;
+        return {
+            totalRewardsPaid: Number(total_rewards_paid || 0),
+        };
     },
 };


### PR DESCRIPTION
Once we agree with the format we will have to change the frontend as well.
**staking/pools**
```
{
stakingPools: [
{
poolId: "1",
operatorAddress: "0x5409ed021d9299bf6814279a6a1411a7e866a631",
createdAt: {
blockNumber: 14491738,
txHash: "0xea30da4f4a5ccb209fe7861c71b0c365684af076924a23e48a9028c8b7e13e5b"
},
metaData: {
name: "Over 9000",
bio: "All your stake are belong to us",
location: "San Francisco, CA",
isVerified: false,
logoUrl: "https://github.com/0xProject/0x-staking-pool-registry/raw/master/logos/0x.png",
websiteUrl: "http://0x.org"
},
sevenDayProtocolFeesGeneratedInEth: 0,
currentEpochStats: {
poolId: "1",
zrxStaked: 31260.31,
operatorShare: 0.000004,
approximateStakeRatio: 0,
makerAddresses: [ ],
totalProtocolFeesGeneratedInEth: 0
},
nextEpochStats: {
poolId: "1",
zrxStaked: 31660.06,
operatorShare: 0.000004,
approximateStakeRatio: 0,
makerAddresses: [ ],
totalProtocolFeesGeneratedInEth: 0
}
}
```

**staking/epochs**
```
{
currentEpoch: {
epochId: 8,
epochStart: {
blockNumber: 15285624,
txHash: "0x143ba628cbf6ce5940f79b62022b1bba73467d3548b526bb87b29d87753b74f8",
timestamp: "2019-12-07T00:17:32.000Z"
},
zrxDeposited: 33211.06,
zrxStaked: 31960.31,
protocolFeesGeneratedInEth: 0.0018
},
nextEpoch: {
epochId: 9,
epochStart: {
blockNumber: 15314424
},
zrxDeposited: 38157.23,
zrxStaked: 37090.48,
protocolFeesGeneratedInEth: 0
}
}
```

**staking/stats**
```
{
allTime: {
totalRewardsPaid: 0.1122
}
}
```

