### PR TITLE
Fix query typo

### DIFF
--- a/src/services/staking_data_service.ts
+++ b/src/services/staking_data_service.ts
@@ -178,7 +178,7 @@ const nextEpochQuery = `
     SELECT
         ce.epoch_id + 1 AS epoch_id
         , ce.starting_block_number + cp.epoch_duration_in_seconds::NUMERIC / 15::NUMERIC AS starting_block_number
-        , ce.starting_block_timestamp + ((cp.epoch_duration_in_seconds)::VARCHAR || ' seconds')::INTERVAL AS starting_timestamp
+        , ce.starting_block_timestamp + ((cp.epoch_duration_in_seconds)::VARCHAR || ' seconds')::INTERVAL AS starting_block_timestamp
         , zd.zrx_deposited
         , zs.zrx_staked
     FROM staking.current_epoch ce


### PR DESCRIPTION
{
currentEpoch: {
epochId: 9,
epochStart: {
blockNumber: 15393965,
txHash: "0x7894c41084156e223aa6f331ec6ad759870dd804e24e4552411cdae0c27a00df",
timestamp: "2019-12-12T00:47:32.000Z"
},
zrxDeposited: 39163.23,
zrxStaked: 38096.48,
protocolFeesGeneratedInEth: 0
},
nextEpoch: {
epochId: 10,
epochStart: {
blockNumber: 15422765,
timestamp: "2019-12-17T00:47:32.000Z"
},
zrxDeposited: 39164.23,
zrxStaked: 38096.48,
protocolFeesGeneratedInEth: 0
}
}