### PR TITLE
Add option to configure `time` field in default logger

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import { BigNumber } from '0x.js';
 import { assert } from '@0x/assert';
 import * as _ from 'lodash';
 
-import { DEFAULT_LOCAL_POSTGRES_URI, NULL_ADDRESS, NULL_BYTES } from './constants';
+import { DEFAULT_LOCAL_POSTGRES_URI, DEFAULT_LOGGER_INCLUDE_TIMESTAMP, NULL_ADDRESS, NULL_BYTES } from './constants';
 
 enum EnvVarType {
     Port,
@@ -60,6 +60,10 @@ export const TAKER_FEE_ASSET_DATA = _.isEmpty(process.env.TAKER_FEE_ASSET_DATA)
 export const POSTGRES_URI = _.isEmpty(process.env.POSTGRES_URI)
     ? DEFAULT_LOCAL_POSTGRES_URI
     : assertEnvVarType('POSTGRES_URI', process.env.POSTGRES_URI, EnvVarType.Url);
+// Should the logger include time field in the output logs, defaults to true.
+export const LOGGER_INCLUDE_TIMESTAMP = _.isEmpty(process.env.LOGGER_INCLUDE_TIMESTAMP)
+    ? DEFAULT_LOGGER_INCLUDE_TIMESTAMP
+    : assertEnvVarType('LOGGER_INCLUDE_TIMESTAMP', process.env.LOGGER_INCLUDE_TIMESTAMP, EnvVarType.Boolean);
 
 // Max number of entities per page
 export const MAX_PER_PAGE = 1000;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ export const DEFAULT_PER_PAGE = 20;
 export const ZERO = new BigNumber(0);
 export const MAX_TOKEN_SUPPLY_POSSIBLE = new BigNumber(2).pow(256); // tslint:disable-line custom-no-magic-numbers
 export const DEFAULT_LOCAL_POSTGRES_URI = 'postgresql://api:api@localhost/api';
+export const DEFAULT_LOGGER_INCLUDE_TIMESTAMP = true;
 
 // API namespaces
 export const SRA_PATH = '/sra';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,6 @@
 import * as pino from 'pino';
 
-import { LOGGER_INCLUDE_TIME } from './config';
+import { LOGGER_INCLUDE_TIMESTAMP } from './config';
 
 export const logger = pino({
     useLevelLabels: true,

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,8 @@
 import * as pino from 'pino';
 
+import { LOGGER_INCLUDE_TIME } from './config';
+
 export const logger = pino({
     useLevelLabels: true,
+    timestamp: LOGGER_INCLUDE_TIMESTAMP,
 });


### PR DESCRIPTION
About
===

This PR adds an envvar `DEFAULT_LOGGER_INCLUDE_TIMESTAMP` which if set to `false` will make sure `pino` will not include the timestamp in its output.