### PR TITLE
Return 404 when user requests a non-existent staking pool id

### DIFF
--- a/src/services/staking_data_service.ts
+++ b/src/services/staking_data_service.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import { Connection } from 'typeorm';
 
+import { NotFoundError } from '../errors';
 import * as queries from '../queries/staking_queries';
 import {
     AllTimeDelegatorStats,
@@ -59,7 +60,7 @@ export class StakingDataService {
         );
 
         if (!rawPool) {
-            throw new Error(`Could not find pool with pool_id ${poolId}`);
+            throw new NotFoundError(`Could not find pool with pool_id ${poolId}`);
         }
 
         const pool = stakingUtils.getPoolFromRaw(rawPool);


### PR DESCRIPTION
Currently returns 500 with reason:
```
{
  "reason": "Could not find pool with pool_id 600"
}
```

Should be a 404; 500 should be reserved for critical errors that need our attention