### PR TITLE
Fix/swap quote schema validation

### DIFF
--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -8,8 +8,10 @@ import { DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE, ETH_SYMBOL } from '../constants';
 import { InternalServerError, RevertAPIError, ValidationError, ValidationErrorCodes } from '../errors';
 import { logger } from '../logger';
 import { isAPIError, isRevertError } from '../middleware/error_handling';
+import { schemas } from '../schemas/schemas';
 import { SwapService } from '../services/swap_service';
 import { GetSwapQuoteRequestParams } from '../types';
+import { schemaUtils } from '../utils/schema_utils';
 import { findTokenAddress } from '../utils/token_metadata_utils';
 
 export class SwapHandlers {
@@ -79,6 +81,8 @@ export class SwapHandlers {
 }
 
 const parseGetSwapQuoteRequestParams = (req: express.Request): GetSwapQuoteRequestParams => {
+    // HACK typescript typing does not allow this valid json-schema
+    schemaUtils.validateSchema(req.query, schemas.swapQuoteRequestSchema as any);
     const takerAddress = req.query.takerAddress;
     const sellToken = req.query.sellToken;
     const buyToken = req.query.buyToken;

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -1,0 +1,5 @@
+import * as swapQuoteRequestSchema from './swap_quote_request_schema.json';
+
+export const schemas = {
+    swapQuoteRequestSchema,
+};

--- a/src/schemas/swap_quote_request_schema.json
+++ b/src/schemas/swap_quote_request_schema.json
@@ -9,6 +9,12 @@
         },
         "takerAddress": {
             "$ref": "/addressSchema"
+        },
+        "gasPrice": {
+            "$ref": "/wholeNumberSchema"
+        },
+        "slippage": {
+            "$ref": "/numberSchema"
         }
     },
     "required": ["sellToken", "buyToken"],

--- a/src/schemas/swap_quote_request_schema.json
+++ b/src/schemas/swap_quote_request_schema.json
@@ -1,0 +1,36 @@
+{
+    "id": "/SwapQuoteRequestSchema",
+    "properties": {
+        "sellToken": {
+            "type": "string"
+        },
+        "buyToken": {
+            "type": "string"
+        },
+        "takerAddress": {
+            "$ref": "/addressSchema"
+        }
+    },
+    "required": ["sellToken", "buyToken"],
+    "oneOf": [
+        {
+            "id": "sellAmount",
+            "properties": {
+                "sellAmount": {
+                    "$ref": "/wholeNumberSchema"
+                }
+            },
+            "required": ["sellAmount"]
+        },
+        {
+            "id": "buyAmount",
+            "properties": {
+                "buyAmount": {
+                    "$ref": "/wholeNumberSchema"
+                }
+            },
+            "required": ["buyAmount"]
+        }
+    ],
+    "type": "object"
+}

--- a/src/utils/schema_utils.ts
+++ b/src/utils/schema_utils.ts
@@ -23,7 +23,6 @@ export const schemaUtils = {
 };
 
 function schemaValidationErrorToValidationErrorItem(schemaValidationError: SchemaValidationError): ValidationErrorItem {
-    console.log(schemaValidationError);
     if (
         [
             'type',

--- a/src/utils/schema_utils.ts
+++ b/src/utils/schema_utils.ts
@@ -1,6 +1,5 @@
 import { Schema, SchemaValidator } from '@0x/json-schemas';
 import { ValidationError as SchemaValidationError } from 'jsonschema';
-import * as _ from 'lodash';
 
 import { ValidationError, ValidationErrorCodes, ValidationErrorItem } from '../errors';
 
@@ -9,38 +8,37 @@ const schemaValidator = new SchemaValidator();
 export const schemaUtils = {
     validateSchema(instance: any, schema: Schema): void {
         const validationResult = schemaValidator.validate(instance, schema);
-        if (_.isEmpty(validationResult.errors)) {
+        if (validationResult.errors.length === 0) {
             return;
         } else {
-            const validationErrorItems = _.map(
-                validationResult.errors,
-                (schemaValidationError: SchemaValidationError) =>
-                    schemaValidationErrorToValidationErrorItem(schemaValidationError),
+            const validationErrorItems = validationResult.errors.map((schemaValidationError: SchemaValidationError) =>
+                schemaValidationErrorToValidationErrorItem(schemaValidationError),
             );
             throw new ValidationError(validationErrorItems);
         }
     },
+    addSchema(schema: Schema): void {
+        schemaValidator.addSchema(schema);
+    },
 };
 
 function schemaValidationErrorToValidationErrorItem(schemaValidationError: SchemaValidationError): ValidationErrorItem {
+    console.log(schemaValidationError);
     if (
-        _.includes(
-            [
-                'type',
-                'anyOf',
-                'allOf',
-                'oneOf',
-                'additionalProperties',
-                'minProperties',
-                'maxProperties',
-                'pattern',
-                'format',
-                'uniqueItems',
-                'items',
-                'dependencies',
-            ],
-            schemaValidationError.name,
-        )
+        [
+            'type',
+            'anyOf',
+            'allOf',
+            'oneOf',
+            'additionalProperties',
+            'minProperties',
+            'maxProperties',
+            'pattern',
+            'format',
+            'uniqueItems',
+            'items',
+            'dependencies',
+        ].includes(schemaValidationError.name)
     ) {
         return {
             field: schemaValidationError.property,
@@ -48,8 +46,7 @@ function schemaValidationErrorToValidationErrorItem(schemaValidationError: Schem
             reason: schemaValidationError.message,
         };
     } else if (
-        _.includes(
-            ['minimum', 'maximum', 'minLength', 'maxLength', 'minItems', 'maxItems', 'enum', 'const'],
+        ['minimum', 'maximum', 'minLength', 'maxLength', 'minItems', 'maxItems', 'enum', 'const'].includes(
             schemaValidationError.name,
         )
     ) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,9 @@
         "experimentalDecorators": true,
         "sourceMap": false,
         "typeRoots": ["./node_modules/@0x/typescript-typings/types", "./node_modules/@types"],
-        "noUnusedParameters": true
+        "noUnusedParameters": true,
+        "resolveJsonModule": true
     },
-    "include": ["src/**/*.ts"]
+    "include": ["src/**/*.ts"],
+    "files": ["./src/schemas/swap_quote_request_schema.json"]
 }


### PR DESCRIPTION
Had to do more of a roundabout schema to avoid a generic `is not any of [subschema 0],[subschema 1]`. This can still occur with `/wholeNumberSchema`.

The typings also do not seem to allow this schema, so `as any` is required for now.

Resolves #51