### PR TITLE
Implement basic /swap/tokens endpoint

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,8 @@ import { BigNumber } from '@0x/utils';
 import * as _ from 'lodash';
 
 import { DEFAULT_LOCAL_POSTGRES_URI, DEFAULT_LOGGER_INCLUDE_TIMESTAMP, NULL_ADDRESS, NULL_BYTES } from './constants';
+import { TokenMetadatasForChains } from './token_metadatas_for_networks';
+import { ChainId } from './types';
 
 enum EnvVarType {
     Port,
@@ -15,22 +17,20 @@ enum EnvVarType {
     Boolean,
     FeeAssetData,
 }
-// Whitelisted token addresses. Set to a '*' instead of an array to allow all tokens.
-export const WHITELISTED_TOKENS: string[] | '*' = _.isEmpty(process.env.WHITELIST_ALL_TOKENS)
-    ? [
-          '0x2002d3812f58e35f0ea1ffbf80a75a38c32175fa', // ZRX on Kovan
-          '0xd0a1e359811322d97991e03f863a0c30c2cf029c', // WETH on Kovan
-      ]
-    : assertEnvVarType('WHITELIST_ALL_TOKENS', process.env.WHITELIST_ALL_TOKENS, EnvVarType.WhitelistAllTokens);
 
 // Network port to listen on
 export const HTTP_PORT = _.isEmpty(process.env.HTTP_PORT)
     ? 3000
     : assertEnvVarType('HTTP_PORT', process.env.HTTP_PORT, EnvVarType.Port);
 // Default chain id to use when not specified
-export const CHAIN_ID = _.isEmpty(process.env.CHAIN_ID)
-    ? 42
+export const CHAIN_ID: ChainId = _.isEmpty(process.env.CHAIN_ID)
+    ? ChainId.Kovan
     : assertEnvVarType('CHAIN_ID', process.env.CHAIN_ID, EnvVarType.ChainId);
+
+// Whitelisted token addresses. Set to a '*' instead of an array to allow all tokens.
+export const WHITELISTED_TOKENS: string[] | '*' = _.isEmpty(process.env.WHITELIST_ALL_TOKENS)
+    ? TokenMetadatasForChains.map(tm => tm.tokenAddresses[CHAIN_ID])
+    : assertEnvVarType('WHITELIST_ALL_TOKENS', process.env.WHITELIST_ALL_TOKENS, EnvVarType.WhitelistAllTokens);
 
 // Ethereum RPC Url
 export const ETHEREUM_RPC_URL = assertEnvVarType('ETHEREUM_RPC_URL', process.env.ETHEREUM_RPC_URL, EnvVarType.Url);

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -9,9 +9,9 @@ import { InternalServerError, RevertAPIError, ValidationError, ValidationErrorCo
 import { logger } from '../logger';
 import { isAPIError, isRevertError } from '../middleware/error_handling';
 import { SwapService } from '../services/swap_service';
-import { GetSwapQuoteRequestParams } from '../types';
+import { TokenMetadatasForChains } from '../token_metadatas_for_networks';
+import { ChainId, GetSwapQuoteRequestParams } from '../types';
 import { findTokenAddress } from '../utils/token_metadata_utils';
-
 export class SwapHandlers {
     private readonly _swapService: SwapService;
     constructor(swapService: SwapService) {
@@ -75,6 +75,14 @@ export class SwapHandlers {
             logger.info('Uncaught error', e);
             throw new InternalServerError(e.message);
         }
+    }
+    // tslint:disable-next-line:prefer-function-over-method
+    public async getSwapTokensAsync(_req: express.Request, res: express.Response): Promise<void> {
+        const tokens = TokenMetadatasForChains.map(tm => ({
+            symbol: tm.symbol,
+            address: tm.tokenAddresses[CHAIN_ID as ChainId],
+        }));
+        res.status(HttpStatus.OK).send(tokens);
     }
 }
 

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -10,7 +10,7 @@ import { logger } from '../logger';
 import { isAPIError, isRevertError } from '../middleware/error_handling';
 import { SwapService } from '../services/swap_service';
 import { TokenMetadatasForChains } from '../token_metadatas_for_networks';
-import { ChainId, GetSwapQuoteRequestParams } from '../types';
+import { GetSwapQuoteRequestParams } from '../types';
 import { findTokenAddress } from '../utils/token_metadata_utils';
 export class SwapHandlers {
     private readonly _swapService: SwapService;
@@ -80,7 +80,7 @@ export class SwapHandlers {
     public async getSwapTokensAsync(_req: express.Request, res: express.Response): Promise<void> {
         const tokens = TokenMetadatasForChains.map(tm => ({
             symbol: tm.symbol,
-            address: tm.tokenAddresses[CHAIN_ID as ChainId],
+            address: tm.tokenAddresses[CHAIN_ID],
         }));
         res.status(HttpStatus.OK).send(tokens);
     }

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -1,5 +1,5 @@
 import { SwapQuoterError } from '@0x/asset-swapper';
-import { BigNumber } from '@0x/utils';
+import { BigNumber, NULL_ADDRESS } from '@0x/utils';
 import * as express from 'express';
 import * as HttpStatus from 'http-status-codes';
 
@@ -82,7 +82,8 @@ export class SwapHandlers {
             symbol: tm.symbol,
             address: tm.tokenAddresses[CHAIN_ID],
         }));
-        res.status(HttpStatus.OK).send(tokens);
+        const filteredTokens = tokens.filter(t => t.address !== NULL_ADDRESS);
+        res.status(HttpStatus.OK).send({ tokens: filteredTokens });
     }
 }
 

--- a/src/routers/swap_router.ts
+++ b/src/routers/swap_router.ts
@@ -8,5 +8,6 @@ export const createSwapRouter = (swapService: SwapService): express.Router => {
     const router = express.Router();
     const handlers = new SwapHandlers(swapService);
     router.get('/quote', asyncHandler(handlers.getSwapQuoteAsync.bind(handlers)));
+    router.get('/tokens', asyncHandler(handlers.getSwapTokensAsync.bind(handlers)));
     return router;
 };


### PR DESCRIPTION
Basic functionality for lighter clients to discover a list of all tokens available and their symbol.

This does not check for any available liquidity in either the database or in bridges. 

Rather than have a list of 2 tokens in the whitelist (when `WHITELIST_ALL_TOKENS` is unspecified) use the token metadata to populate this list.