### PR TITLE
/prices endpoint

### DIFF
--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -102,8 +102,8 @@ export class SwapHandlers {
         res.status(HttpStatus.OK).send({ records: filteredTokens });
     }
     // tslint:disable-next-line:prefer-function-over-method
-    public async getTokenPricesAsync(_req: express.Request, res: express.Response): Promise<void> {
-        const prices = await this._swapService.getTokenPricesAsync();
+    public async getTokenPricesAsync(req: express.Request, res: express.Response): Promise<void> {
+        const prices = await this._swapService.getTokenPricesAsync(req.query.sellToken || 'WETH');
         res.status(HttpStatus.OK).send({ prices });
     }
 }

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -101,6 +101,11 @@ export class SwapHandlers {
         const filteredTokens = tokens.filter(t => t.address !== NULL_ADDRESS);
         res.status(HttpStatus.OK).send({ records: filteredTokens });
     }
+    // tslint:disable-next-line:prefer-function-over-method
+    public async getTokenPricesAsync(_req: express.Request, res: express.Response): Promise<void> {
+        const prices = await this._swapService.getTokenPricesAsync();
+        res.status(HttpStatus.OK).send({ prices });
+    }
 }
 
 const findTokenAddressOrThrowApiError = (address: string, field: string, chainId: ChainId): string => {

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -13,7 +13,7 @@ import { SwapService } from '../services/swap_service';
 import { TokenMetadatasForChains } from '../token_metadatas_for_networks';
 import { ChainId, GetSwapQuoteRequestParams } from '../types';
 import { schemaUtils } from '../utils/schema_utils';
-import { findTokenAddress, isETHSymbol } from '../utils/token_metadata_utils';
+import { findTokenAddress, getTokenMetadataIfExists, isETHSymbol } from '../utils/token_metadata_utils';
 
 export class SwapHandlers {
     private readonly _swapService: SwapService;
@@ -103,8 +103,20 @@ export class SwapHandlers {
     }
     // tslint:disable-next-line:prefer-function-over-method
     public async getTokenPricesAsync(req: express.Request, res: express.Response): Promise<void> {
-        const prices = await this._swapService.getTokenPricesAsync(req.query.sellToken || 'WETH');
-        res.status(HttpStatus.OK).send({ prices });
+        const symbolOrAddress = req.query.sellToken || 'WETH';
+        const baseAsset = getTokenMetadataIfExists(symbolOrAddress, CHAIN_ID);
+        if (!baseAsset) {
+            throw new ValidationError([
+                {
+                    field: 'sellToken',
+                    code: ValidationErrorCodes.ValueOutOfRange,
+                    reason: `Could not find token ${symbolOrAddress}`,
+                },
+            ]);
+        }
+        const unitAmount = new BigNumber(1);
+        const records = await this._swapService.getTokenPricesAsync(baseAsset, unitAmount);
+        res.status(HttpStatus.OK).send({ records });
     }
 }
 

--- a/src/ormconfig.ts
+++ b/src/ormconfig.ts
@@ -12,4 +12,7 @@ export const config: ConnectionOptions = {
     synchronize: true,
     logging: true,
     logger: 'debug',
+    extra: {
+        connectionLimit: 50,
+    },
 };

--- a/src/routers/swap_router.ts
+++ b/src/routers/swap_router.ts
@@ -11,6 +11,6 @@ export function createSwapRouter(swapService: SwapService): express.Router {
     router.get('/', asyncHandler(SwapHandlers.rootAsync.bind(SwapHandlers)));
     router.get('/quote', asyncHandler(handlers.getSwapQuoteAsync.bind(handlers)));
     router.get('/tokens', asyncHandler(handlers.getSwapTokensAsync.bind(handlers)));
-    router.get('/price', asyncHandler(handlers.getTokenPricesAsync.bind(handlers)));
+    router.get('/prices', asyncHandler(handlers.getTokenPricesAsync.bind(handlers)));
     return router;
 }

--- a/src/routers/swap_router.ts
+++ b/src/routers/swap_router.ts
@@ -11,5 +11,6 @@ export function createSwapRouter(swapService: SwapService): express.Router {
     router.get('/', asyncHandler(SwapHandlers.rootAsync.bind(SwapHandlers)));
     router.get('/quote', asyncHandler(handlers.getSwapQuoteAsync.bind(handlers)));
     router.get('/tokens', asyncHandler(handlers.getSwapTokensAsync.bind(handlers)));
+    router.get('/price', asyncHandler(handlers.getTokenPricesAsync.bind(handlers)));
     return router;
 }

--- a/src/services/orderbook_service.ts
+++ b/src/services/orderbook_service.ts
@@ -13,7 +13,7 @@ import { paginationUtils } from '../utils/pagination_utils';
 
 export class OrderBookService {
     private readonly _meshClient?: WSClient;
-    private _connection: Connection;
+    private readonly _connection: Connection;
     public async getOrderByHashIfExistsAsync(orderHash: string): Promise<APIOrder | undefined> {
         const signedOrderEntityIfExists = await this._connection.manager.findOne(SignedOrderEntity, orderHash);
         if (signedOrderEntityIfExists === undefined) {

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -143,7 +143,7 @@ export class SwapService {
         // Equivalent to performing multiple swap quotes selling sellToken and buying 1 whole buy token
         const takerAssetData = assetDataUtils.encodeERC20AssetData(sellToken.tokenAddress);
         const queryAssetData = TokenMetadatasForChains.filter(m => m.symbol !== sellToken.symbol);
-        const chunkSize = 10;
+        const chunkSize = 20;
         const assetDataChunks = _.chunk(queryAssetData, chunkSize);
         const allResults = _.flatten(
             await Promise.all(

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -12,10 +12,12 @@ import {
 import { assetDataUtils, SupportedProvider } from '@0x/order-utils';
 import { AbiEncoder, BigNumber, decodeThrownErrorAsRevertError, RevertError } from '@0x/utils';
 import { TxData, Web3Wrapper } from '@0x/web3-wrapper';
+import * as _ from 'lodash';
 
 import { ASSET_SWAPPER_MARKET_ORDERS_OPTS, CHAIN_ID, FEE_RECIPIENT_ADDRESS } from '../config';
-import { DEFAULT_TOKEN_DECIMALS, PERCENTAGE_SIG_DIGITS, QUOTE_ORDER_EXPIRATION_BUFFER_MS } from '../constants';
+import { DEFAULT_TOKEN_DECIMALS, PERCENTAGE_SIG_DIGITS, QUOTE_ORDER_EXPIRATION_BUFFER_MS, ZERO } from '../constants';
 import { logger } from '../logger';
+import { TokenMetadatasForChains } from '../token_metadatas_for_networks';
 import { CalculateSwapQuoteParams, GetSwapQuoteResponse, GetSwapQuoteResponseLiquiditySource } from '../types';
 import { orderUtils } from '../utils/order_utils';
 import { findTokenDecimalsIfExists } from '../utils/token_metadata_utils';
@@ -134,7 +136,50 @@ export class SwapService {
         };
         return apiSwapQuote;
     }
-
+    public async getTokenPricesAsync(): Promise<Array<{ symbol: string; price: BigNumber }>> {
+        const baseAssetSymbol = 'WETH';
+        const unitAmount = new BigNumber(1);
+        const baseAsset = TokenMetadatasForChains.find(m => m.symbol === baseAssetSymbol);
+        if (!baseAsset) {
+            throw new Error('Invalid Base Asset');
+        }
+        const takerAssetData = assetDataUtils.encodeERC20AssetData(baseAsset.tokenAddresses[CHAIN_ID]); // WETH
+        const queryAssetData = TokenMetadatasForChains.filter(m => m.symbol !== baseAssetSymbol);
+        // tslint:disable-next-line:custom-no-magic-numbers
+        const tokenMetadataChunks = _.chunk(queryAssetData, 30);
+        const allResults = _.flatten(
+            await Promise.all(
+                tokenMetadataChunks.map(async chunk => {
+                    const makerAssetDatas = chunk.map(m =>
+                        assetDataUtils.encodeERC20AssetData(m.tokenAddresses[CHAIN_ID]),
+                    );
+                    const amounts = chunk.map(m => Web3Wrapper.toBaseUnitAmount(unitAmount, m.decimals));
+                    return this._swapQuoter.getBatchMarketBuySwapQuoteForAssetDataAsync(
+                        makerAssetDatas,
+                        takerAssetData,
+                        amounts,
+                        { slippagePercentage: 0 },
+                    );
+                }),
+            ),
+        );
+        const prices = allResults.map((quote, i) => {
+            if (!quote) {
+                return { symbol: queryAssetData[i].symbol, price: ZERO };
+            }
+            const buyTokenDecimals = queryAssetData[i].decimals;
+            const sellTokenDecimals = baseAsset.decimals;
+            const { makerAssetAmount, totalTakerAssetAmount } = quote.bestCaseQuoteInfo;
+            const makerAssetUnitAmount = Web3Wrapper.toUnitAmount(makerAssetAmount, buyTokenDecimals);
+            const takerAssetUnitAmount = Web3Wrapper.toUnitAmount(totalTakerAssetAmount, sellTokenDecimals);
+            const price = makerAssetUnitAmount.dividedBy(takerAssetUnitAmount).decimalPlaces(sellTokenDecimals);
+            return {
+                symbol: queryAssetData[i].symbol,
+                price,
+            };
+        });
+        return prices;
+    }
     // tslint:disable-next-line: prefer-function-over-method
     private _convertSourceBreakdownToArray(sourceBreakdown: SwapQuoteOrdersBreakdown): GetSwapQuoteResponseLiquiditySource[] {
         const breakdown: GetSwapQuoteResponseLiquiditySource[] = [];

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -15,7 +15,7 @@ import { TxData, Web3Wrapper } from '@0x/web3-wrapper';
 import * as _ from 'lodash';
 
 import { ASSET_SWAPPER_MARKET_ORDERS_OPTS, CHAIN_ID, FEE_RECIPIENT_ADDRESS } from '../config';
-import { DEFAULT_TOKEN_DECIMALS, PERCENTAGE_SIG_DIGITS, QUOTE_ORDER_EXPIRATION_BUFFER_MS, ZERO } from '../constants';
+import { DEFAULT_TOKEN_DECIMALS, PERCENTAGE_SIG_DIGITS, QUOTE_ORDER_EXPIRATION_BUFFER_MS } from '../constants';
 import { logger } from '../logger';
 import { TokenMetadatasForChains } from '../token_metadatas_for_networks';
 import { CalculateSwapQuoteParams, GetSwapQuoteResponse, GetSwapQuoteResponseLiquiditySource,  GetTokenPricesResponse, TokenMetadata } from '../types';
@@ -170,7 +170,7 @@ export class SwapService {
 
         const prices = allResults.map((quote, i) => {
             if (!quote) {
-                return { symbol: queryAssetData[i].symbol, price: ZERO };
+                return undefined;
             }
             const buyTokenDecimals = queryAssetData[i].decimals;
             const sellTokenDecimals = sellToken.decimals;
@@ -184,7 +184,7 @@ export class SwapService {
                 symbol: queryAssetData[i].symbol,
                 price,
             };
-        });
+        }).filter(p => p) as GetTokenPricesResponse;
         return prices;
     }
     // tslint:disable-next-line: prefer-function-over-method

--- a/src/token_metadatas_for_networks.ts
+++ b/src/token_metadatas_for_networks.ts
@@ -379,7 +379,7 @@ export const TokenMetadatasForChains: TokenMetadataAndChainAddresses[] = [
     },
     {
         decimals: 8,
-        symbol: 'cSAI',
+        symbol: 'cDAI',
         name: 'Compound Dai',
         tokenAddresses: {
             [ChainId.Mainnet]: '0x5d3a536e4d6dbd6114cc1ead35777bab948e3643',

--- a/src/token_metadatas_for_networks.ts
+++ b/src/token_metadatas_for_networks.ts
@@ -379,7 +379,7 @@ export const TokenMetadatasForChains: TokenMetadataAndChainAddresses[] = [
     },
     {
         decimals: 8,
-        symbol: 'cDAI',
+        symbol: 'cSAI',
         name: 'Compound Dai',
         tokenAddresses: {
             [ChainId.Mainnet]: '0x5d3a536e4d6dbd6114cc1ead35777bab948e3643',

--- a/src/types.ts
+++ b/src/types.ts
@@ -301,6 +301,13 @@ export interface GetSwapQuoteResponse {
     from?: string;
 }
 
+export interface Price {
+    symbol: string;
+    price: BigNumber;
+}
+
+export type GetTokenPricesResponse = Price[];
+
 export interface GetSwapQuoteRequestParams {
     sellToken: string;
     buyToken: string;

--- a/src/utils/order_store_db_adapter.ts
+++ b/src/utils/order_store_db_adapter.ts
@@ -33,10 +33,20 @@ export class OrderStoreDbAdapter extends OrderStore {
         }
         // Currently not handling deletes as this is handled by Mesh
     }
-    public async hasAsync(assetPairKey: string): Promise<boolean> {
-        const [assetA, assetB] = OrderStore.assetPairKeyToAssets(assetPairKey);
-        const pairs = await this._orderbookService.getAssetPairsAsync(FIRST_PAGE, MAX_QUERY_SIZE, assetA, assetB);
-        return pairs.total !== 0;
+    // tslint:disable-next-line:prefer-function-over-method
+    public async hasAsync(_assetPairKey: string): Promise<boolean> {
+        return true;
+        // const [assetA, assetB] = OrderStore.assetPairKeyToAssets(assetPairKey);
+        // const { bids, asks } = await this._orderbookService.getOrderBookAsync(
+        //     FIRST_PAGE,
+        //     MAX_QUERY_SIZE,
+        //     assetA,
+        //     assetB,
+        // );
+        // return bids.total !== 0 || asks.total !== 0;
+        // const [assetA, assetB] = OrderStore.assetPairKeyToAssets(assetPairKey);
+        // const pairs = await this._orderbookService.getAssetPairsAsync(FIRST_PAGE, MAX_QUERY_SIZE, assetA, assetB);
+        // return pairs.total !== 0;
     }
     public async valuesAsync(assetPairKey: string): Promise<APIOrder[]> {
         return Array.from((await this.getOrderSetForAssetPairAsync(assetPairKey)).values());

--- a/src/utils/order_store_db_adapter.ts
+++ b/src/utils/order_store_db_adapter.ts
@@ -33,20 +33,30 @@ export class OrderStoreDbAdapter extends OrderStore {
         }
         // Currently not handling deletes as this is handled by Mesh
     }
+    public async getBatchOrderSetsForAssetsAsync(
+        makerAssetDatas: string[],
+        takerAssetDatas: string[],
+    ): Promise<OrderSet[]> {
+        const { records: apiOrders } = await this._orderbookService.getBatchOrdersAsync(
+            FIRST_PAGE,
+            MAX_QUERY_SIZE,
+            makerAssetDatas,
+            takerAssetDatas,
+        );
+        const orderSets: { [makerAssetData: string]: OrderSet } = {};
+        makerAssetDatas.forEach(m =>
+            takerAssetDatas.forEach(t => (orderSets[OrderStore.getKeyForAssetPair(m, t)] = new OrderSet())),
+        );
+        await Promise.all(
+            apiOrders.map(async o =>
+                orderSets[OrderStore.getKeyForAssetPair(o.order.makerAssetData, o.order.takerAssetData)].addAsync(o),
+            ),
+        );
+        return Object.values(orderSets);
+    }
     // tslint:disable-next-line:prefer-function-over-method
     public async hasAsync(_assetPairKey: string): Promise<boolean> {
         return true;
-        // const [assetA, assetB] = OrderStore.assetPairKeyToAssets(assetPairKey);
-        // const { bids, asks } = await this._orderbookService.getOrderBookAsync(
-        //     FIRST_PAGE,
-        //     MAX_QUERY_SIZE,
-        //     assetA,
-        //     assetB,
-        // );
-        // return bids.total !== 0 || asks.total !== 0;
-        // const [assetA, assetB] = OrderStore.assetPairKeyToAssets(assetPairKey);
-        // const pairs = await this._orderbookService.getAssetPairsAsync(FIRST_PAGE, MAX_QUERY_SIZE, assetA, assetB);
-        // return pairs.total !== 0;
     }
     public async valuesAsync(assetPairKey: string): Promise<APIOrder[]> {
         return Array.from((await this.getOrderSetForAssetPairAsync(assetPairKey)).values());


### PR DESCRIPTION

Currently fetching prices of 1 unit of each token on with a base asset pair (defaults to WETH). I.e buying 1 USDC with WETH. We could make the `unitAmount` configurable by param.

In essence this is similar to performing a quote on every asset with the base asset. So in essence we use Native and Bridge orders. We do this in batches, as at writing this results in concurrent ~4 RPC requests. Currently this takes approximately ~~3.5-5~~ 0.8 seconds to serve the result.

Note:
* We're performing a buy operation (this excludes Kyber)
* We do not perform multiple samples, just the entire amount 
* Base asset defaults to WETH though an alternative base can be supplied. E.g DAI or ZRX
* Some batches are heavier than others due to the order of our Metadata, i.e one batch gets DAI,USDC,ZRX,WBTC and can take longer than a batch which has less native 0x orders.

```json
{
  "records": [
    {
      "symbol": "ZRX",
      "price": "0.236163269460202302"
    },
    {
      "symbol": "WETH",
      "price": "173.60906274565"
    },
    {
      "symbol": "USDC",
      "price": "1.0014178"
    },
    {
      "symbol": "REP",
      "price": "14.960892941419549045"
    },
    {
      "symbol": "BAT",
      "price": "0.226468941872908147"
    },
    {
      "symbol": "MKR",
      "price": "511.244597947585170695"
    },
    {
      "symbol": "WBTC",
      "price": "9429.613550419299758978"
    },
    {
      "symbol": "SNX",
      "price": "1.206704957537004611"
    },
    {
      "symbol": "SUSD",
      "price": "0"
    },
    {
      "symbol": "KNC",
      "price": "0.292187720041790738"
    },
    {
      "symbol": "BNT",
      "price": "0.247097767988558581"
    },
    {
      "symbol": "GNO",
      "price": "13.262758986270229453"
    },
    {
      "symbol": "LINK",
      "price": "2.662818213761736781"
    },
    {
      "symbol": "REN",
      "price": "0.043421732202252796"
    },
    {
      "symbol": "OMG",
      "price": "0"
    },
    {
      "symbol": "ANT",
      "price": "0.652467493582113766"
    },
    {
      "symbol": "SAI",
      "price": "1.011433228749002679"
    },
    {
      "symbol": "CVL",
      "price": "0.004493489821836914"
    },
    {
      "symbol": "DTH",
      "price": "0.00237372494026652"
    },
    {
      "symbol": "FOAM",
      "price": "0.021644772854356194"
    },
    {
      "symbol": "AST",
      "price": "0.019088117413905174"
    },
    {
      "symbol": "GEN",
      "price": "0.139065317870529154"
    },
    {
      "symbol": "STORJ",
      "price": "0.114971244075358828"
    },
    {
      "symbol": "MANA",
      "price": "0.035897758799774541"
    },
    {
      "symbol": "ENTRP",
      "price": "0.698231373357677776"
    },
    {
      "symbol": "MLN",
      "price": "6.054717525181436224"
    },
    {
      "symbol": "LOOM",
      "price": "0.018287607933776055"
    },
    {
      "symbol": "CELR",
      "price": "0.003656190108206738"
    },
    {
      "symbol": "RLC",
      "price": "0.509953183050306052"
    },
    {
      "symbol": "DGD",
      "price": "31.586487605764545281"
    },
    {
      "symbol": "ZIL",
      "price": "0.010404865027214572"
    },
    {
      "symbol": "cBAT",
      "price": "0.005469334634742278"
    },
    {
      "symbol": "cSAI",
      "price": "0.020367839992946705"
    },
    {
      "symbol": "cSAI",
      "price": "0.021504356859570453"
    },
    {
      "symbol": "cETH",
      "price": "3.477011082422843025"
    },
    {
      "symbol": "cUSDC",
      "price": "0.021115501873979603"
    },
    {
      "symbol": "cZRX",
      "price": "0.004821894418576017"
    },
    {
      "symbol": "0xBTC",
      "price": "0.127406745124729286"
    },
    {
      "symbol": "SNT",
      "price": "0.011065190592788876"
    },
    {
      "symbol": "SPANK",
      "price": "0.003108800198118512"
    },
    {
      "symbol": "BOOTY",
      "price": "0.058353852162690072"
    },
    {
      "symbol": "BNB",
      "price": "6.574486616745281429"
    },
    {
      "symbol": "NMR",
      "price": "6.101405008792310903"
    },
    {
      "symbol": "GUSD",
      "price": "1.274566010501262615"
    },
    {
      "symbol": "FUN",
      "price": "0.003051938411077114"
    },
    {
      "symbol": "PAX",
      "price": "1.030249646987991769"
    },
    {
      "symbol": "TUSD",
      "price": "1.004938117938229358"
    },
    {
      "symbol": "LPT",
      "price": "2.525573245390085536"
    },
    {
      "symbol": "ENJ",
      "price": "0.090251282521339027"
    },
    {
      "symbol": "POWR",
      "price": "0.042595647573863637"
    },
    {
      "symbol": "REQ",
      "price": "0.013208264467134681"
    },
    {
      "symbol": "DNT",
      "price": "0.017624902664240927"
    },
    {
      "symbol": "MATIC",
      "price": "0.019577923256901625"
    },
    {
      "symbol": "LRC",
      "price": "0.025550301228465698"
    },
    {
      "symbol": "RDN",
      "price": "0.126877838427880865"
    },
    {
      "symbol": "USDT",
      "price": "0"
    }
  ]
}

```
### Perf

#### Staging
```
λ hey -n 50 -c 1 'https://staging.api.0x.org/swap/v0/price'                                                                                                                     master

Summary:
  Total:	44.9667 secs
  Slowest:	1.9547 secs
  Fastest:	0.6047 secs
  Average:	0.8992 secs
  Requests/sec:	1.1119


Response time histogram:
  0.605 [1]	|■■
  0.740 [11]	|■■■■■■■■■■■■■■■■■■■■■
  0.875 [21]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  1.010 [7]	|■■■■■■■■■■■■■
  1.145 [2]	|■■■■
  1.280 [4]	|■■■■■■■■
  1.415 [1]	|■■
  1.550 [1]	|■■
  1.685 [1]	|■■
  1.820 [0]	|
  1.955 [1]	|■■

```

#### MY (slow) machine
```
Summary:
  Total:	451.8158 secs
  Slowest:	7.3228 secs
  Fastest:	2.0762 secs
  Average:	4.5181 secs
  Requests/sec:	0.2213

  Total data:	261000 bytes
  Size/request:	2610 bytes

Response time histogram:
  2.076 [1]	|■■
  2.601 [2]	|■■■
  3.126 [3]	|■■■■■
  3.650 [14]	|■■■■■■■■■■■■■■■■■■■■■■
  4.175 [21]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  4.700 [26]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  5.224 [11]	|■■■■■■■■■■■■■■■■■
  5.749 [7]	|■■■■■■■■■■■
  6.274 [7]	|■■■■■■■■■■■
  6.798 [4]	|■■■■■■
  7.323 [4]	|■■■■■■
```