### PR TITLE
stop throwing errors for non-ERC20/ERC721 asset data

### DIFF
--- a/src/utils/order_utils.ts
+++ b/src/utils/order_utils.ts
@@ -41,19 +41,19 @@ const DEFAULT_ERC20_ASSET = {
 
 const DEFAULT_ERC1155_ASSET = {
     minAmount: new BigNumber(0),
-    maxAmount: new BigNumber(1),
+    maxAmount: MAX_TOKEN_SUPPLY_POSSIBLE,
     precision: 0,
 };
 
 const DEFAULT_MULTIASSET = {
     minAmount: new BigNumber(0),
-    maxAmount: new BigNumber(1),
+    maxAmount: MAX_TOKEN_SUPPLY_POSSIBLE,
     precision: 0,
 };
 
 const DEFAULT_STATIC_CALL = {
-    minAmount: new BigNumber(0),
-    maxAmount: new BigNumber(1),
+    minAmount: new BigNumber(1),
+    maxAmount: MAX_TOKEN_SUPPLY_POSSIBLE,
     precision: 0,
 };
 const proxyIdToDefaults: { [id: string]: Partial<Asset> } = {

--- a/src/utils/order_utils.ts
+++ b/src/utils/order_utils.ts
@@ -39,30 +39,42 @@ const DEFAULT_ERC20_ASSET = {
     precision: DEFAULT_ERC20_TOKEN_PRECISION,
 };
 
-const erc721AssetDataToAsset = (assetData: string): Asset => ({
-    ...DEFAULT_ERC721_ASSET,
-    assetData,
-});
+const DEFAULT_ERC1155_ASSET = {
+    minAmount: new BigNumber(0),
+    maxAmount: new BigNumber(1),
+    precision: 0,
+};
 
-const erc20AssetDataToAsset = (assetData: string): Asset => ({
-    ...DEFAULT_ERC20_ASSET,
-    assetData,
-});
+const DEFAULT_MULTIASSET = {
+    minAmount: new BigNumber(0),
+    maxAmount: new BigNumber(1),
+    precision: 0,
+};
+
+const DEFAULT_STATIC_CALL = {
+    minAmount: new BigNumber(0),
+    maxAmount: new BigNumber(1),
+    precision: 0,
+};
+const proxyIdToDefaults: { [id: string]: Partial<Asset> } = {
+    [AssetProxyId.ERC20]: DEFAULT_ERC20_ASSET,
+    [AssetProxyId.ERC721]: DEFAULT_ERC721_ASSET,
+    [AssetProxyId.ERC1155]: DEFAULT_ERC1155_ASSET,
+    [AssetProxyId.MultiAsset]: DEFAULT_MULTIASSET,
+    [AssetProxyId.StaticCall]: DEFAULT_STATIC_CALL,
+    [AssetProxyId.ERC20Bridge]: DEFAULT_ERC20_ASSET,
+};
 
 const assetDataToAsset = (assetData: string): Asset => {
     const decodedAssetData = assetDataUtils.decodeAssetDataOrThrow(assetData);
-    let asset: Asset;
-    switch (decodedAssetData.assetProxyId) {
-        case AssetProxyId.ERC20:
-            asset = erc20AssetDataToAsset(assetData);
-            break;
-        case AssetProxyId.ERC721:
-            asset = erc721AssetDataToAsset(assetData);
-            break;
-        default:
-            throw errorUtils.spawnSwitchErr('assetProxyId', decodedAssetData.assetProxyId);
+    const defaultAsset = proxyIdToDefaults[decodedAssetData.assetProxyId];
+    if (defaultAsset === undefined) {
+        throw errorUtils.spawnSwitchErr('assetProxyId', decodedAssetData.assetProxyId);
     }
-    return asset;
+    return {
+        ...defaultAsset,
+        assetData,
+    } as Asset; // tslint:disable-line:no-object-literal-type-assertion
 };
 
 export const orderUtils = {


### PR DESCRIPTION
This PR adds support for other asset data types, and fixes #57

Initially I tried filtering out non-ERC20/ERC721 orders before retrieving asset pairs, then realised that the related functions in `order_utils.ts` were also used more generally by the orderbook when getting orders or checking for existence of asset pairs. Seems like it would be a non-trivial refactor, and it's unclear to me what the implications of that refactor would be, e.g. seems undesirable if `orderbook.getOrders` only returns ERC20/ERC721 orders.

I'm unsure of the appropriate default values for ERC1155, MultiAsset, StaticCall, and ERC20Bridge, so this PR is a bit of a WIP. 

Deployed to Kovan and it successfully returns ERC1155 asset pairs instead of throwing a server error. Compare with failing screenshot in #57:
![Screen Shot 2020-01-08 at 1 26 55 PM](https://user-images.githubusercontent.com/8582774/72017525-b5de3a80-321a-11ea-9d65-f6e7b9bc259d.png)
