### PR TITLE
Disable Bridge sources for Testnets

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,8 @@
-import { SwapQuoteRequestOpts } from '@0x/asset-swapper';
+import { ERC20BridgeSource, SwapQuoteRequestOpts } from '@0x/asset-swapper';
 import { BigNumber } from '@0x/utils';
+
+import { CHAIN_ID } from './config';
+import { ChainId } from './types';
 
 // tslint:disable:custom-no-magic-numbers
 
@@ -25,7 +28,10 @@ export const DEFAULT_TOKEN_DECIMALS = 18;
 export const FIRST_PAGE = 1;
 export const ASSET_SWAPPER_MARKET_ORDERS_OPTS: Partial<SwapQuoteRequestOpts> = {
     noConflicts: true,
-    excludedSources: [],
+    excludedSources:
+        CHAIN_ID === ChainId.Mainnet
+            ? []
+            : [ERC20BridgeSource.Eth2Dai, ERC20BridgeSource.Kyber, ERC20BridgeSource.Uniswap],
     numSamples: 10,
     runLimit: 4096,
     bridgeSlippage: 0.0005,


### PR DESCRIPTION
Return Native only ordders for testnets by disabling all Bridges. There is some liquidity for Kovan on ZRX.


`curl 'http://localhost:3000/swap/quote?buyToken=ZRX&sellToken=WETH&buyAmount=1000'`
```json
{
  "price": "100",
  "to": "0x61935cbdd02287b511119ddb11aeb42f1593b7ef",
  "data": "0x8bc8efb3000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000003e8000000000000000000000000000000000000000000000000000000000000034000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000a31f3d5d0d8a412084a3f83d253340524f7f88970000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a31f3d5d0d8a412084a3f83d253340524f7f8897000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003635c9adc5dea000000000000000000000000000000000000000000000000000008ac7230489e8000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005e16f3160000000000000000000000000000000000000000000000000000016f847f35f900000000000000000000000000000000000000000000000000000000000001c00000000000000000000000000000000000000000000000000000000000000220000000000000000000000000000000000000000000000000000000000000028000000000000000000000000000000000000000000000000000000000000002800000000000000000000000000000000000000000000000000000000000000024f47261b00000000000000000000000002002d3812f58e35f0ea1ffbf80a75a38c32175fa000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024f47261b0000000000000000000000000d0a1e359811322d97991e03f863a0c30c2cf029c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000421c1406545195808f1ce4048fc6e6aff7beca215e25dfb89a2068ce091f3e3e3ea25e95fb5266dff32d3a4e4e23736ae96de9825ea1d33129bd29b7fe95c76ba48002000000000000000000000000000000000000000000000000000000000000",
  "value": "1200000000000000",
  "gasPrice": "8000000000",
  "protocolFee": "1200000000000000",
  "makerAssetAmount": "1000",
  "totalTakerAssetAmount": "10",
  "orders": [
    {
      "chainId": 42,
      "exchangeAddress": "0x4eacd0af335451709e1e7b570b8ea68edec8bc97",
      "makerAddress": "0xa31f3d5d0d8a412084a3f83d253340524f7f8897",
      "takerAddress": "0x0000000000000000000000000000000000000000",
      "feeRecipientAddress": "0xa31f3d5d0d8a412084a3f83d253340524f7f8897",
      "senderAddress": "0x0000000000000000000000000000000000000000",
      "makerAssetAmount": "1000000000000000000000",
      "takerAssetAmount": "10000000000000000000",
      "makerFee": "0",
      "takerFee": "0",
      "expirationTimeSeconds": "1578562326",
      "salt": "1578475927033",
      "makerAssetData": "0xf47261b00000000000000000000000002002d3812f58e35f0ea1ffbf80a75a38c32175fa",
      "takerAssetData": "0xf47261b0000000000000000000000000d0a1e359811322d97991e03f863a0c30c2cf029c",
      "makerFeeAssetData": "0x",
      "takerFeeAssetData": "0x",
      "signature": "0x1c1406545195808f1ce4048fc6e6aff7beca215e25dfb89a2068ce091f3e3e3ea25e95fb5266dff32d3a4e4e23736ae96de9825ea1d33129bd29b7fe95c76ba48002"
    }
  ]
}

```




No Liquidity for DAI/WETH on Kovan.

`curl http://localhost:3000/swap/quote?buyToken=DAI&sellToken=WETH&buyAmount=1000`
```json
{
  "reason": "Server Error"
}
```