### PR TITLE
the 7-day fee pool query should only return 1 pool

### DIFF
--- a/src/queries/staking_queries.ts
+++ b/src/queries/staking_queries.ts
@@ -77,7 +77,9 @@ export const poolSevenDayProtocolFeesGeneratedQuery = `
         p.pool_id
         , COALESCE(f.protocol_fees, 0) AS seven_day_protocol_fees_generated_in_eth
     FROM events.staking_pool_created_events p
-    LEFT JOIN pool_7d_fills f ON f.pool_id = p.pool_id;
+    LEFT JOIN pool_7d_fills f ON f.pool_id = p.pool_id
+    WHERE
+        p.pool_id = $1;
 `;
 
 export const sevenDayProtocolFeesGeneratedQuery = `


### PR DESCRIPTION
The pool/id endpoint was not returning the correct 7-day fee value, because the associated query returned all pools.