### PR TITLE
Update SNX to ProxyERC20 contract

### DIFF
--- a/src/token_metadatas_for_networks.ts
+++ b/src/token_metadatas_for_networks.ts
@@ -100,7 +100,7 @@ export const TokenMetadatasForChains: TokenMetadataAndChainAddresses[] = [
         symbol: 'SNX',
         name: 'Synthetix Network Token',
         tokenAddresses: {
-            [ChainId.Mainnet]: '0xc011a72400e58ecd99ee497cf89e3775d4bd732f',
+            [ChainId.Mainnet]: '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f',
             [ChainId.Kovan]: NULL_ADDRESS,
             [ChainId.Ganache]: NULL_ADDRESS,
         },


### PR DESCRIPTION
SNX has a few proxies and a real token. On-chain liquidity sources use the ProxyERC20.

ProxyERC20: https://etherscan.io/address/0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f#readContract
Real target: https://etherscan.io/address/0x7cb89c509001d25da9938999abfea6740212e5f0#readContract
Proxy??: https://etherscan.io/address/0xc011a72400e58ecd99ee497cf89e3775d4bd732f#readContract


https://api.0x.org/swap/v0/quote?buyToken=0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F&sellToken=ETH&sellAmount=1000000000000000&takerAddress=0xab5801a7d398351b8be11c439e05c5b3259aec9b

