### PR TITLE
Fix staking delegator support checksummed ETH addresses

### DIFF
--- a/src/handlers/staking_handlers.ts
+++ b/src/handlers/staking_handlers.ts
@@ -59,11 +59,12 @@ export class StakingHandlers {
 
     public async getDelegatorAsync(req: express.Request, res: express.Response): Promise<void> {
         const delegatorAddress = req.params.id;
+        const normalizedAddress = delegatorAddress && delegatorAddress.toLowerCase();
 
         const [forCurrentEpoch, forNextEpoch, allTime] = await Promise.all([
-            this._stakingDataService.getDelegatorCurrentEpochAsync(delegatorAddress),
-            this._stakingDataService.getDelegatorNextEpochAsync(delegatorAddress),
-            this._stakingDataService.getDelegatorAllTimeStatsAsync(delegatorAddress),
+            this._stakingDataService.getDelegatorCurrentEpochAsync(normalizedAddress),
+            this._stakingDataService.getDelegatorNextEpochAsync(normalizedAddress),
+            this._stakingDataService.getDelegatorAllTimeStatsAsync(normalizedAddress),
         ]);
 
         const response: StakingDelegatorResponse = {


### PR DESCRIPTION
Some Web3 providers return checksummed capitalization ETH addresses. Today this leads to nothing being found in the database, however we can support both checksummed and non-checksummed addresses by simply lower casing it before querying the database.