### PR TITLE
Added number of fills to pool stats

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -158,10 +158,13 @@ export interface RawEpochPoolStats {
 export interface EpochPoolStats {
     poolId: string;
     zrxStaked: number;
+    shareOfStake: number;
     operatorShare?: number;
     makerAddresses: string[];
     totalProtocolFeesGeneratedInEth: number;
+    shareOfFees: number;
     numberOfFills: number;
+    shareOfFills: number;
     approximateStakeRatio: number;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,7 +149,9 @@ export interface RawEpochPoolStats {
     total_staked?: string;
     share_of_stake?: string;
     total_protocol_fees_generated_in_eth?: string;
+    number_of_fills: string;
     share_of_fees?: string;
+    share_of_fills?: string;
     approximate_stake_ratio?: string;
 }
 
@@ -159,6 +161,7 @@ export interface EpochPoolStats {
     operatorShare?: number;
     makerAddresses: string[];
     totalProtocolFeesGeneratedInEth: number;
+    numberOfFills: number;
     approximateStakeRatio: number;
 }
 
@@ -177,17 +180,19 @@ export interface PoolEpochRewards extends RewardsStats {
 export interface RawPoolProtocolFeesGenerated {
     pool_id: string;
     seven_day_protocol_fees_generated_in_eth: string;
+    seven_day_number_of_fills: string;
 }
 
 export interface RawPoolTotalProtocolFeesGenerated {
     pool_id: string;
     total_protocol_fees: string;
-    num_fills: string;
+    number_of_fills: string;
 }
 
 export interface PoolProtocolFeesGenerated {
     poolId: string;
     sevenDayProtocolFeesGeneratedInEth: number;
+    sevenDayNumberOfFills: number;
 }
 
 export interface RawAllTimeStakingStats {
@@ -242,6 +247,7 @@ export interface EpochDelegatorStats {
 
 export interface AllTimePoolStats extends RewardsStats {
     protocolFeesGeneratedInEth: number;
+    numberOfFills: number;
 }
 
 export interface AllTimeDelegatorPoolStats {

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,7 +149,7 @@ export interface RawEpochPoolStats {
     total_staked?: string;
     share_of_stake?: string;
     total_protocol_fees_generated_in_eth?: string;
-    number_of_fills: string;
+    number_of_fills?: string;
     share_of_fees?: string;
     share_of_fills?: string;
     approximate_stake_ratio?: string;

--- a/src/utils/staking_utils.ts
+++ b/src/utils/staking_utils.ts
@@ -99,6 +99,7 @@ export const stakingUtils = {
             operator_share,
             zrx_staked,
             total_protocol_fees_generated_in_eth,
+            number_of_fills,
             approximate_stake_ratio,
         } = rawEpochPoolStats;
         return {
@@ -108,6 +109,7 @@ export const stakingUtils = {
             approximateStakeRatio: approximate_stake_ratio ? Number(approximate_stake_ratio) : 0,
             makerAddresses: maker_addresses || [],
             totalProtocolFeesGeneratedInEth: Number(total_protocol_fees_generated_in_eth || 0),
+            numberOfFills: Number(number_of_fills || 0),
         };
     },
     getEpochPoolsStatsFromRaw: (rawEpochPoolsStats: RawEpochPoolStats[]): EpochPoolStats[] => {
@@ -126,10 +128,11 @@ export const stakingUtils = {
     getPoolProtocolFeesGeneratedFromRaw: (
         rawPoolProtocolFeesGenerated: RawPoolProtocolFeesGenerated,
     ): PoolProtocolFeesGenerated => {
-        const { pool_id, seven_day_protocol_fees_generated_in_eth } = rawPoolProtocolFeesGenerated;
+        const { pool_id, seven_day_protocol_fees_generated_in_eth, seven_day_number_of_fills } = rawPoolProtocolFeesGenerated;
         return {
             poolId: pool_id,
             sevenDayProtocolFeesGeneratedInEth: Number(seven_day_protocol_fees_generated_in_eth || 0),
+            sevenDayNumberOfFills: Number(seven_day_number_of_fills || 0),
         };
     },
     getPoolsProtocolFeesGeneratedFromRaw: (
@@ -174,6 +177,7 @@ export const stakingUtils = {
             membersRewardsPaidInEth: Number(_.get(rawAllTimePoolRewards, 'members_reward', 0)),
             totalRewardsPaidInEth: Number(_.get(rawAllTimePoolRewards, 'total_rewards', 0)),
             protocolFeesGeneratedInEth: Number(_.get(rawPoolsProtocolFeesGenerated, 'total_protocol_fees', 0)),
+            numberOfFills: Number(_.get(rawPoolsProtocolFeesGenerated, 'number_of_fills', 0)),
         };
     },
     getAllTimeStakingStatsFromRaw: (rawAllTimeAllTimeStats: RawAllTimeStakingStats): AllTimeStakingStats => {

--- a/src/utils/staking_utils.ts
+++ b/src/utils/staking_utils.ts
@@ -98,18 +98,24 @@ export const stakingUtils = {
             maker_addresses,
             operator_share,
             zrx_staked,
+            share_of_stake,
             total_protocol_fees_generated_in_eth,
+            share_of_fees,
             number_of_fills,
+            share_of_fills,
             approximate_stake_ratio,
         } = rawEpochPoolStats;
         return {
             poolId: pool_id,
             zrxStaked: Number(zrx_staked || 0),
+            shareOfStake: Number(share_of_stake),
             operatorShare: _.isNil(operator_share) ? undefined : Number(operator_share),
             approximateStakeRatio: approximate_stake_ratio ? Number(approximate_stake_ratio) : 0,
             makerAddresses: maker_addresses || [],
             totalProtocolFeesGeneratedInEth: Number(total_protocol_fees_generated_in_eth || 0),
+            shareOfFees: Number(share_of_fees || 0),
             numberOfFills: Number(number_of_fills || 0),
+            shareOfFills: Number(share_of_fills || 0),
         };
     },
     getEpochPoolsStatsFromRaw: (rawEpochPoolsStats: RawEpochPoolStats[]): EpochPoolStats[] => {


### PR DESCRIPTION
Adds to Market maker stats:
- number of fills (to epoch stats, 7-day stats, and all time stats)
- share of stake (to epoch stats)
- share of fees (to epoch stats)
- share of fills (to epoch stats)

Testing:
- [x] Tested queries on hashalytics