### PR TITLE
Add `excludedSources` to control sources used by 0x API + add addresses to response.

### DIFF
--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -34,7 +34,7 @@ export class SwapHandlers {
             takerAddress,
             slippagePercentage,
             gasPrice,
-            discluded,
+            excludedSources,
         } = parseGetSwapQuoteRequestParams(req);
         const isETHSell = isETHSymbol(sellToken);
         const sellTokenAddress = findTokenAddressOrThrowApiError(sellToken, 'sellToken', CHAIN_ID);
@@ -49,7 +49,7 @@ export class SwapHandlers {
                 isETHSell,
                 slippagePercentage,
                 gasPrice,
-                excludedSources: discluded,
+                excludedSources,
             });
             res.status(HttpStatus.OK).send(swapQuote);
         } catch (e) {
@@ -115,8 +115,8 @@ const findTokenAddressOrThrowApiError = (address: string, field: string, chainId
     }
 };
 
-const parseStringArrForERC20BridgeSources = (discluded: string[]): ERC20BridgeSource[] => {
-    return discluded.filter((source: string) => source in ERC20BridgeSource) as ERC20BridgeSource[];
+const parseStringArrForERC20BridgeSources = (excludedSources: string[]): ERC20BridgeSource[] => {
+    return excludedSources.filter((source: string) => source in ERC20BridgeSource) as ERC20BridgeSource[];
 };
 
 const parseGetSwapQuoteRequestParams = (req: express.Request): GetSwapQuoteRequestParams => {
@@ -129,6 +129,6 @@ const parseGetSwapQuoteRequestParams = (req: express.Request): GetSwapQuoteReque
     const buyAmount = req.query.buyAmount === undefined ? undefined : new BigNumber(req.query.buyAmount);
     const gasPrice = req.query.gasPrice === undefined ? undefined : new BigNumber(req.query.gasPrice);
     const slippagePercentage = Number.parseFloat(req.query.slippagePercentage || DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE);
-    const discluded = req.query.discluded === undefined ? undefined : parseStringArrForERC20BridgeSources(req.query.discluded.split(','));
-    return { takerAddress, sellToken, buyToken, sellAmount, buyAmount, slippagePercentage, gasPrice, discluded };
+    const excludedSources = req.query.excludedSources === undefined ? undefined : parseStringArrForERC20BridgeSources(req.query.excludedSources.split(','));
+    return { takerAddress, sellToken, buyToken, sellAmount, buyAmount, slippagePercentage, gasPrice, excludedSources };
 };

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -116,10 +116,7 @@ const findTokenAddressOrThrowApiError = (address: string, field: string, chainId
 };
 
 const parseStringArrForERC20BridgeSources = (discluded: string[]): ERC20BridgeSource[] => {
-    return discluded.filter((source: string) => source in ERC20BridgeSource).map((source: string): ERC20BridgeSource => {
-        // HACK: to return ERC20BridgeSource enum matched with source
-        return (ERC20BridgeSource as any)[source];
-    });
+    return discluded.filter((source: string) => source in ERC20BridgeSource) as ERC20BridgeSource[];
 };
 
 const parseGetSwapQuoteRequestParams = (req: express.Request): GetSwapQuoteRequestParams => {
@@ -132,6 +129,6 @@ const parseGetSwapQuoteRequestParams = (req: express.Request): GetSwapQuoteReque
     const buyAmount = req.query.buyAmount === undefined ? undefined : new BigNumber(req.query.buyAmount);
     const gasPrice = req.query.gasPrice === undefined ? undefined : new BigNumber(req.query.gasPrice);
     const slippagePercentage = Number.parseFloat(req.query.slippagePercentage || DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE);
-    const discluded = req.query.discluded === undefined ? undefined : parseStringArrForERC20BridgeSources(req.query.discluded);
+    const discluded = req.query.discluded === undefined ? undefined : parseStringArrForERC20BridgeSources(req.query.discluded.split(','));
     return { takerAddress, sellToken, buyToken, sellAmount, buyAmount, slippagePercentage, gasPrice, discluded };
 };

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -1,4 +1,4 @@
-import { SwapQuoterError, ERC20BridgeSource } from '@0x/asset-swapper';
+import { ERC20BridgeSource, SwapQuoterError } from '@0x/asset-swapper';
 import { BigNumber, NULL_ADDRESS } from '@0x/utils';
 import * as express from 'express';
 import * as HttpStatus from 'http-status-codes';

--- a/src/schemas/swap_quote_request_schema.json
+++ b/src/schemas/swap_quote_request_schema.json
@@ -16,7 +16,7 @@
         "slippage": {
             "$ref": "/numberSchema"
         },
-        "discluded": {
+        "excludedSources": {
             "type": "string"
         }
     },

--- a/src/schemas/swap_quote_request_schema.json
+++ b/src/schemas/swap_quote_request_schema.json
@@ -15,6 +15,12 @@
         },
         "slippage": {
             "$ref": "/numberSchema"
+        },
+        "discluded": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
         }
     },
     "required": ["sellToken", "buyToken"],

--- a/src/schemas/swap_quote_request_schema.json
+++ b/src/schemas/swap_quote_request_schema.json
@@ -17,10 +17,7 @@
             "$ref": "/numberSchema"
         },
         "discluded": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+            "type": "string"
         }
     },
     "required": ["sellToken", "buyToken"],

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -44,11 +44,13 @@ export class SwapService {
             gasPrice: providedGasPrice,
             isETHSell,
             from,
+            excludedSources,
         } = params;
         const assetSwapperOpts = {
             slippagePercentage,
             gasPrice: providedGasPrice,
             ...ASSET_SWAPPER_MARKET_ORDERS_OPTS,
+            excludedSources, // TODO(dave4506): overrides the excluded sources selected by chainId
         };
         if (sellAmount !== undefined) {
             swapQuote = await this._swapQuoter.getMarketSellSwapQuoteAsync(
@@ -118,6 +120,8 @@ export class SwapService {
             from,
             gasPrice,
             protocolFee,
+            buyTokenAddress,
+            sellTokenAddress,
             buyAmount: makerAssetAmount,
             sellAmount: totalTakerAssetAmount,
             orders: this._cleanSignedOrderFields(orders),

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -76,7 +76,6 @@ export class SwapService {
             protocolFeeInWeiAmount: protocolFee,
         } = attributedSwapQuote.bestCaseQuoteInfo;
         const { orders, gasPrice } = attributedSwapQuote;
-
         // If ETH was specified as the token to sell then we use the Forwarder
         const extensionContractType = isETHSell ? ExtensionContractType.Forwarder : ExtensionContractType.None;
         const {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import { AcceptedOrderInfo, RejectedOrderInfo } from '@0x/mesh-rpc-client';
 import { APIOrder, OrdersChannelSubscriptionOpts, SignedOrder, UpdateOrdersChannelMessage } from '@0x/types';
 import { BigNumber } from '@0x/utils';
+import { ERC20BridgeSource } from '@0x/asset-swapper';
 
 export enum OrderWatcherLifeCycleEvents {
     Added,
@@ -292,6 +293,8 @@ export interface GetSwapQuoteResponse {
     orders: SignedOrder[];
     buyAmount: BigNumber;
     sellAmount: BigNumber;
+    buyTokenAddress: string;
+    sellTokenAddress: string;
     value: BigNumber;
     gas?: BigNumber;
     from?: string;
@@ -305,6 +308,7 @@ export interface GetSwapQuoteRequestParams {
     buyAmount?: BigNumber;
     slippagePercentage?: number;
     gasPrice?: BigNumber;
+    discluded?: ERC20BridgeSource[];
 }
 
 export interface CalculateSwapQuoteParams {
@@ -316,4 +320,5 @@ export interface CalculateSwapQuoteParams {
     isETHSell: boolean;
     slippagePercentage?: number;
     gasPrice?: BigNumber;
+    excludedSources?: ERC20BridgeSource[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
+import { ERC20BridgeSource } from '@0x/asset-swapper';
 import { AcceptedOrderInfo, RejectedOrderInfo } from '@0x/mesh-rpc-client';
 import { APIOrder, OrdersChannelSubscriptionOpts, SignedOrder, UpdateOrdersChannelMessage } from '@0x/types';
 import { BigNumber } from '@0x/utils';
-import { ERC20BridgeSource } from '@0x/asset-swapper';
 
 export enum OrderWatcherLifeCycleEvents {
     Added,

--- a/src/types.ts
+++ b/src/types.ts
@@ -308,7 +308,7 @@ export interface GetSwapQuoteRequestParams {
     buyAmount?: BigNumber;
     slippagePercentage?: number;
     gasPrice?: BigNumber;
-    discluded?: ERC20BridgeSource[];
+    excludedSources?: ERC20BridgeSource[];
 }
 
 export interface CalculateSwapQuoteParams {


### PR DESCRIPTION
- Added a `excludedSources` optional parameter to `/swap/quote` to toggle which sources are used by 0x API.
- Added `sellTokenAddress` and `buyTokenAddress` to `/swap/quote` response.