### PR TITLE
Append Affiliate info to the call data if specified

### DIFF
--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -35,6 +35,7 @@ export class SwapHandlers {
             slippagePercentage,
             gasPrice,
             excludedSources,
+            affiliateAddress,
         } = parseGetSwapQuoteRequestParams(req);
         const isETHSell = isETHSymbol(sellToken);
         const sellTokenAddress = findTokenAddressOrThrowApiError(sellToken, 'sellToken', CHAIN_ID);
@@ -50,6 +51,7 @@ export class SwapHandlers {
                 slippagePercentage,
                 gasPrice,
                 excludedSources,
+                affiliateAddress,
             });
             res.status(HttpStatus.OK).send(swapQuote);
         } catch (e) {
@@ -130,5 +132,6 @@ const parseGetSwapQuoteRequestParams = (req: express.Request): GetSwapQuoteReque
     const gasPrice = req.query.gasPrice === undefined ? undefined : new BigNumber(req.query.gasPrice);
     const slippagePercentage = Number.parseFloat(req.query.slippagePercentage || DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE);
     const excludedSources = req.query.excludedSources === undefined ? undefined : parseStringArrForERC20BridgeSources(req.query.excludedSources.split(','));
-    return { takerAddress, sellToken, buyToken, sellAmount, buyAmount, slippagePercentage, gasPrice, excludedSources };
+    const affiliateAddress = req.query.affiliateAddress;
+    return { takerAddress, sellToken, buyToken, sellAmount, buyAmount, slippagePercentage, gasPrice, excludedSources, affiliateAddress };
 };

--- a/src/schemas/swap_quote_request_schema.json
+++ b/src/schemas/swap_quote_request_schema.json
@@ -10,6 +10,9 @@
         "takerAddress": {
             "$ref": "/addressSchema"
         },
+        "affiliateAddress": {
+            "$ref": "/addressSchema"
+        },
         "gasPrice": {
             "$ref": "/wholeNumberSchema"
         },

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -183,9 +183,7 @@ export class SwapService {
 
     // tslint:disable-next-line:prefer-function-over-method
     private _attributeCallData(data: string, affiliateAddress?: string): string {
-        if (!affiliateAddress) {
-            return data;
-        }
+        const affiliateAddressOrDefault = affiliateAddress ? affiliateAddress : FEE_RECIPIENT_ADDRESS;
         const affiliateCallDataEncoder = new AbiEncoder.Method({
             constant: true,
             outputs: [],
@@ -195,7 +193,7 @@ export class SwapService {
             stateMutability: 'view',
             type: 'function',
         });
-        const encodedAffiliateData = affiliateCallDataEncoder.encode([affiliateAddress]);
+        const encodedAffiliateData = affiliateCallDataEncoder.encode([affiliateAddressOrDefault]);
         const affiliatedData = `${data}${encodedAffiliateData.slice(2)}`;
         return affiliatedData;
     }

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -47,6 +47,7 @@ export class SwapService {
             isETHSell,
             from,
             excludedSources,
+            affiliateAddress,
         } = params;
         const assetSwapperOpts = {
             slippagePercentage,
@@ -89,6 +90,8 @@ export class SwapService {
             useExtensionContract: extensionContractType,
         });
 
+        const affiliatedData = this._attributeCallData(data, affiliateAddress);
+
         let gas;
         if (from) {
             // Force a revert error if the takerAddress does not have enough ETH.
@@ -97,7 +100,7 @@ export class SwapService {
                 : value;
             gas = await this._estimateGasOrThrowRevertErrorAsync({
                 to,
-                data,
+                data: affiliatedData,
                 from,
                 value: txDataValue,
                 gasPrice,
@@ -116,7 +119,7 @@ export class SwapService {
         const apiSwapQuote: GetSwapQuoteResponse = {
             price,
             to,
-            data,
+            data: affiliatedData,
             value,
             gas,
             from,
@@ -176,6 +179,25 @@ export class SwapService {
             orders: attributedOrders,
         };
         return attributedSwapQuote;
+    }
+
+    // tslint:disable-next-line:prefer-function-over-method
+    private _attributeCallData(data: string, affiliateAddress?: string): string {
+        if (!affiliateAddress) {
+            return data;
+        }
+        const affiliateCallDataEncoder = new AbiEncoder.Method({
+            constant: true,
+            outputs: [],
+            name: 'ZeroExAPIAffiliate',
+            inputs: [{ name: '', type: 'address' }],
+            payable: false,
+            stateMutability: 'view',
+            type: 'function',
+        });
+        const encodedAffiliateData = affiliateCallDataEncoder.encode([affiliateAddress]);
+        const affiliatedData = `${data}${encodedAffiliateData.slice(2)}`;
+        return affiliatedData;
     }
 
     // tslint:disable-next-line:prefer-function-over-method

--- a/src/types.ts
+++ b/src/types.ts
@@ -310,6 +310,7 @@ export interface GetSwapQuoteRequestParams {
     slippagePercentage?: number;
     gasPrice?: BigNumber;
     excludedSources?: ERC20BridgeSource[];
+    affiliateAddress?: string;
 }
 
 export interface CalculateSwapQuoteParams {
@@ -322,6 +323,7 @@ export interface CalculateSwapQuoteParams {
     slippagePercentage?: number;
     gasPrice?: BigNumber;
     excludedSources?: ERC20BridgeSource[];
+    affiliateAddress?: string;
 }
 
 export interface GetSwapQuoteResponseLiquiditySource {


### PR DESCRIPTION
[Example transaction](https://kovan.etherscan.io/tx/0x436b6466c3a00660fa6f8b8f4624a0281907cf4d187c81624486c1b857783a62)

Calldata appended with 
```
fbc019a70000000000000000000000005409ed021d9299bf6814279a6a1411a7e866a631
aka
ZeroExAPIAffiliate(0x5409ed021d9299bf6814279a6a1411a7e866a631)
```

E.g
```
0xa6c3bf33000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000186a000000000000000000000000000000000000000000000000000000000000003c000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000d5a01c9b4e154d483aa57012a1115613df0032b100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011d8070000000000000000000000000000000000000000000000000000000000001d4c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000967a67f0a2a482894e21ec24e99b0c3bf1a8357290d7fcc15913800324cd550de27dbaeb00000000000000000000000000000000000000000000000000000000000001c000000000000000000000000000000000000000000000000000000000000002a00000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000000a4dc1600f30000000000000000000000004f96fe3b7a6cf9725f59d353f723c1bdb64ca6aa000000000000000000000000d5a01c9b4e154d483aa57012a1115613df0032b100000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000020000000000000000000000000d0a1e359811322d97991e03f863a0c30c2cf029c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024f47261b0000000000000000000000000d0a1e359811322d97991e03f863a0c30c2cf029c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010400000000000000000000000000000000000000000000000000000000000000fbc019a70000000000000000000000005409ed021d9299bf6814279a6a1411a7e866a631
```

Currently this is in the `callData` to the `to` contract (i.e Forwarder or Exchange), as opposed to the `callData` of the Exchange contract. 