### PR TITLE
[Kovan] Fix DevUtils Invalid opcode with a stipend

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "@0x/assert": "^3.0.4",
         "@0x/asset-swapper": "^4.1.1",
         "@0x/connect": "^6.0.4",
-        "@0x/contract-addresses": "^4.3.0",
+        "@0x/contract-addresses": "^4.4.0",
         "@0x/contract-wrappers": "^13.4.0",
         "@0x/json-schemas": "^5.0.4",
         "@0x/mesh-rpc-client": "^8.1.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -77,9 +77,8 @@ export const DEFAULT_ERC20_TOKEN_PRECISION = 18;
 const EXCLUDED_SOURCES = (() => {
     switch (CHAIN_ID) {
     case ChainId.Mainnet:
-        return [];
     case ChainId.Kovan:
-        return [ERC20BridgeSource.Kyber];
+        return [];
     default:
         return [ERC20BridgeSource.Eth2Dai, ERC20BridgeSource.Kyber, ERC20BridgeSource.Uniswap];
 }

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -38,7 +38,7 @@ export class SwapService {
                 // it contains a gas stipend on the DevUtils contract
                 erc20BridgeSampler:
                     CHAIN_ID === ChainId.Kovan
-                        ? '0x39f2a0dba5e6ea855369e2f09967169032173470'
+                        ? '0x76a3d21fc9c16afd29eb12a5bdcedd5ddbf24357'
                         : contractAddresses.erc20BridgeSampler,
             },
         };

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -36,10 +36,23 @@ export class SwapService {
                 ...contractAddresses,
                 // HACK(dekz): We are temporarily setting the Kovan sampler to this fixed address
                 // it contains a gas stipend on the DevUtils contract
+                // This dependency is returning 0x00.. on deployment, pulling in 4.3.0?
                 erc20BridgeSampler:
                     CHAIN_ID === ChainId.Kovan
                         ? '0x76a3d21fc9c16afd29eb12a5bdcedd5ddbf24357'
                         : contractAddresses.erc20BridgeSampler,
+                uniswapBridge:
+                    CHAIN_ID === ChainId.Kovan
+                        ? '0x8224aa8fe5c9f07d5a59c735386ff6cc6aaeb568'
+                        : contractAddresses.uniswapBridge,
+                eth2DaiBridge:
+                    CHAIN_ID === ChainId.Kovan
+                        ? '0x9485d65c6a2fae0d519cced5bd830e57c41998a9'
+                        : contractAddresses.eth2DaiBridge,
+                kyberBridge:
+                    CHAIN_ID === ChainId.Kovan
+                        ? '0xde7b2747624a647600fdb349184d0448ab954929'
+                        : contractAddresses.kyberBridge,
             },
         };
         this._swapQuoter = new SwapQuoter(this._provider, orderbook, swapQuoterOpts);


### PR DESCRIPTION
Set the Kovan sampler to a specially deployed version with a stipend on the DevUtils contract. 

Fix is coming up in https://github.com/0xProject/0x-monorepo/pull/2474. Once published (Note the eth2dai change makes this time sensitive), we can remove the hack 

Rest is just formatting.
