### PR TITLE
Improve documentation about services in the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ These are services that handle HTTP requests and responses.
 
 ### Data Services
 
-These are services that make sure the data being served is present and up-to-date by keeping the database in sync with [0x Mesh](https://github.com/0xProject/0x-mesh) and Ethereum. The endpoints above technically run without this data, but would be providing degraded or non-functional service. There is nothing stateful about 0x API -- all the data comes from Mesh or the Ethereum blockchain.
+These are services that make sure the data being served is present and up-to-date by keeping the database in sync with [0x Mesh](https://github.com/0xProject/0x-mesh) and Ethereum. With the exception of the Staking HTTP service, which has a hard dependency on the [Staking Event Pipeline](https://github.com/0xProject/0x-event-pipeline), the endpoints above run without this data, but would be providing degraded or non-functional service. There is nothing stateful about 0x API -- all the data comes from [0x Mesh](https://github.com/0xProject/0x-mesh) or the Ethereum blockchain.
 
 | Name                                                                      |  Run Command                                         | Requires [0x Mesh](https://github.com/0xProject/0x-mesh)? | Requires Ethereum JSON RPC Provider? | Requires Relational Database? |
 |---------------------------------------------------------------------------|------------------------------------------------------|-----------------------------------------------------------|--------------------------------------|-------------------------------|
 | Order Watcher (keep database in sync with Mesh)                           | `yarn start:service:order_watcher`                   |                          Yes                              |  No                                  | Yes                           |
-| [Staking Events Pipeline](https://github.com/0xProject/0x-event-pipeline) |  `docker run 0xorg/event-pipeline:latest`            |                          No                               |  Yes                                 | Yes                           |
+| [Staking Event Pipeline](https://github.com/0xProject/0x-event-pipeline)  |  `docker run 0xorg/event-pipeline:latest`            |                          No                               |  Yes                                 | Yes                           |
 
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -1,13 +1,48 @@
 ![alt text](https://raw.githubusercontent.com/0xProject/0x-api/master/0x-api.png "0x API")
 
 ## Table of contents
+
+- [Introduction](#introduction)
+- [Services](#services)
+    - [HTTP Services](#http-services)
+    - [Data Services](#data-services)
 - [Getting started](#getting-started)
-        - [Pre-requirements](#pre-requirements)
-        - [Developing](#developing)
+    - [Pre-requirements](#pre-requirements)
+    - [Developing](#developing)
 - [Commands](#commands)
 - [Database](#database)
 - [Deployment](#deployment)
 - [Legal Disclaimer](#legal-disclaimer)
+
+## Introduction
+
+The 0x API is a collection of services and endpoints that can be run together or separately. In aggregate, the APIs provide interfaces to 0x liquidity, 0x staking data and more.
+Everything can be run monolithically via `yarn start` and `docker-compose` up as described in [Getting Started](#getting-started).
+
+## Services
+
+The API contains different services that serve a collection of HTTP or websocket endpoints and keep your database in sync with [0x Mesh](https://github.com/0xProject/0x-mesh) and Ethereum state.
+
+### HTTP Services
+
+These are services that handle HTTP requests and responses.
+
+| Name                                                  | Path          |  Run Command                          | Requires [0x Mesh](https://github.com/0xProject/0x-mesh)? | Requires Ethereum JSON RPC Provider? | Requires Relational Database? |
+|-------------------------------------------------------|---------------|---------------------------------------|-----------------------------------------------------------|--------------------------------------|-------------------------------|
+| All HTTP Services                                     | `/*`          | `yarn start:service:http`             |                          Yes                              |  Yes                                 | Yes                           |
+| [Swap](https://0x.org/docs/api#swap)                  | `/swap`       | `yarn start:service:staking_http`     |                          Yes                              |  Yes                                 | Yes                           |
+| [Standard Relayer API](https://0x.org/docs/api#sra)   | `/sra`        | `yarn start:service:sra_http`         |                          Yes                              |  No                                  | Yes                           |
+| Staking (Not Public)                                  | `/staking`    | `yarn start:service:staking_http`     |                          No                               |  No                                  | Yes                           |
+
+### Data Services
+
+These are services that make sure the data being served is present and up-to-date by keeping the database in sync with [0x Mesh](https://github.com/0xProject/0x-mesh) and Ethereum. The endpoints above technically run without this data, but would be providing degraded or non-functional service.
+
+| Name                                                                      |  Run Command                                         | Requires [0x Mesh](https://github.com/0xProject/0x-mesh)? | Requires Ethereum JSON RPC Provider? | Requires Relational Database? |
+|---------------------------------------------------------------------------|------------------------------------------------------|-----------------------------------------------------------|--------------------------------------|-------------------------------|
+| Order Watcher (keep database in sync with Mesh)                           | `yarn start:service:order_watcher`                   |                          Yes                              |  No                                  | Yes                           |
+| [Staking Events Pipeline](https://github.com/0xProject/0x-event-pipeline) |  `docker run 0xorg/event-pipeline:latest`            |                          No                               |  Yes                                 | Yes                           |
+
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ These are services that handle HTTP requests and responses.
 
 ### Data Services
 
-These are services that make sure the data being served is present and up-to-date by keeping the database in sync with [0x Mesh](https://github.com/0xProject/0x-mesh) and Ethereum. The endpoints above technically run without this data, but would be providing degraded or non-functional service.
+These are services that make sure the data being served is present and up-to-date by keeping the database in sync with [0x Mesh](https://github.com/0xProject/0x-mesh) and Ethereum. The endpoints above technically run without this data, but would be providing degraded or non-functional service. There is nothing stateful about 0x API -- all the data comes from Mesh or the Ethereum blockchain.
 
 | Name                                                                      |  Run Command                                         | Requires [0x Mesh](https://github.com/0xProject/0x-mesh)? | Requires Ethereum JSON RPC Provider? | Requires Relational Database? |
 |---------------------------------------------------------------------------|------------------------------------------------------|-----------------------------------------------------------|--------------------------------------|-------------------------------|

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
         "prettier": "prettier --write 'src/**/*.ts' --config .prettierrc",
         "start": "node -r dotenv/config lib/src/index.js",
         "start:service:http": "node -r dotenv/config lib/src/runners/http_service_runner.js",
+        "start:service:sra_http": "node -r dotenv/config lib/src/runners/http_sra_service_runner.js",
+        "start:service:staking_http": "node -r dotenv/config lib/src/runners/http_staking_service_runner.js",
+        "start:service:swap_http": "node -r dotenv/config lib/src/runners/http_swap_service_runner.js",
         "start:service:order_watcher": "node -r dotenv/config lib/src/runners/order_watcher_service_runner.js",
         "lint": "tslint --project . --format stylish"
     },


### PR DESCRIPTION
Would like to have this before we slap a deprecated sign onto launch-kit backend.