### PR TITLE
Catch estimate gas error

### DIFF
--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -201,7 +201,7 @@ export class SwapService {
         // Perform this concurrently
         // if the call fails the gas estimation will also fail, we can throw a more helpful
         // error message than gas estimation failure
-        const estimateGasPromise = this._web3Wrapper.estimateGasAsync(txData);
+        const estimateGasPromise = this._web3Wrapper.estimateGasAsync(txData).catch(_e => 0);
         await this._throwIfCallIsRevertErrorAsync(txData);
         const gas = await estimateGasPromise;
         return new BigNumber(gas);


### PR DESCRIPTION
In the case of someone specifying `takerAddress` we perform an `eth_call` validation and an `estimate_gas` in parallel. The `eth_call` will return a more informative error (sometimes) compared to `estimate_gas` error `The execution failed due to an exception`, so we use prefer to use the `eth_call` response. The promise for estimate_gas is still executing and being logged by our global rejected promise handler.

This just cleans it up a little so it doesn't alert us on this error case, it is assumed we throw a much more informative error as `eth_call` and `estimate_gas` should fail in tandem.