### PR TITLE
Change Internal Server Error to Validation Error

### DIFF
--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -40,6 +40,17 @@ export class SwapHandlers {
         const isETHSell = isETHSymbol(sellToken);
         const sellTokenAddress = findTokenAddressOrThrowApiError(sellToken, 'sellToken', CHAIN_ID);
         const buyTokenAddress = findTokenAddressOrThrowApiError(buyToken, 'buyToken', CHAIN_ID);
+        if (sellTokenAddress === buyTokenAddress) {
+            throw new ValidationError(
+                ['buyToken', 'sellToken'].map(field => {
+                    return {
+                        field,
+                        code: ValidationErrorCodes.RequiredField,
+                        reason: 'buyToken and sellToken must be different',
+                    };
+                }),
+            );
+        }
         try {
             const swapQuote = await this._swapService.calculateSwapQuoteAsync({
                 buyTokenAddress,


### PR DESCRIPTION
## Changes
When using the `swap/quote` endpoint, if `buyToken` and `sellToken` are the same, we return 4xx Validation Error with an informative reason.

## Current Behaviour
We are returning 500 Internal Server Error which makes it seem like the API is broken