### PR TITLE
Align slippage parameters

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,13 @@ import { ERC20BridgeSource, SwapQuoteRequestOpts } from '@0x/asset-swapper';
 import { BigNumber } from '@0x/utils';
 import * as _ from 'lodash';
 
-import { DEFAULT_LOCAL_POSTGRES_URI, DEFAULT_LOGGER_INCLUDE_TIMESTAMP, NULL_ADDRESS, NULL_BYTES } from './constants';
+import {
+    DEFAULT_LOCAL_POSTGRES_URI,
+    DEFAULT_LOGGER_INCLUDE_TIMESTAMP,
+    DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE,
+    NULL_ADDRESS,
+    NULL_BYTES,
+} from './constants';
 import { TokenMetadatasForChains } from './token_metadatas_for_networks';
 import { ChainId } from './types';
 
@@ -89,7 +95,8 @@ export const ASSET_SWAPPER_MARKET_ORDERS_OPTS: Partial<SwapQuoteRequestOpts> = {
     noConflicts: true,
     excludedSources: EXCLUDED_SOURCES,
     runLimit: 2 ** 15,
-    bridgeSlippage: 0.01,
+    bridgeSlippage: DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE,
+    slippagePercentage: DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE,
     dustFractionThreshold: 0.0025,
     numSamples: 13,
     sampleDistributionBase: 1.05,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,7 +18,7 @@ export const TEN_MINUTES_MS = ONE_MINUTE_MS * 10;
 // Swap Quoter
 export const QUOTE_ORDER_EXPIRATION_BUFFER_MS = ONE_SECOND_MS * 90; // Ignore orders that expire in 90 seconds
 export const GAS_LIMIT_BUFFER_PERCENTAGE = 0.2; // Add 20% to the estimated gas limit
-export const DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE = 0.2; // 20% Slippage
+export const DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE = 0.01; // 1% Slippage
 export const ETH_SYMBOL = 'ETH';
 export const ADDRESS_HEX_LENGTH = 42;
 export const DEFAULT_TOKEN_DECIMALS = 18;

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -66,6 +66,7 @@ export class SwapService {
         const assetSwapperOpts = {
             ...ASSET_SWAPPER_MARKET_ORDERS_OPTS,
             slippagePercentage,
+            bridgeSlippage: slippagePercentage,
             gasPrice: providedGasPrice,
             excludedSources, // TODO(dave4506): overrides the excluded sources selected by chainId
         };


### PR DESCRIPTION
`slippagePercentage` in AssetSwapper really is more of an over-buy percentage. So instead of requesting to sell 100 tokens, we request to sell 120 tokens. The history of this parameter predates Sampler and was to fetch MORE 0x orders than necessary, in the event that some were cancelled or filled. There would be "backup" orders to fill. 

Unfortunately this has a few issues:
* It is not guaranteed to fetch MORE orders (the same order could be for 200 tokens as an example)
* It is not guaranteed to fetch DISTINCT orders (the same maker could've cancelled ALL orders)
* It messes with gas estimation (you estimate against the first few orders succeeding, not against the first first orders failing and the last few orders filling)
* On large fills it can fetch a lot of orders
* A user adjusting this `slippagePercentage` would have no effect on `bridgeSlippage`

I propose we align this parameter with bridge slippage and reduce it from 20% to 1%. So the effects are:
* We sample to sell up to 101 tokens
* This can be overwritten and we fetch more and allow for more bridge slippage
* OOG reverts due to orders being cancelled result in other classes of reverts (unfillable)


TODO:
- [ ] Update website documentation
- [ ] Upstream the changes to asset-swapper