### PR TITLE
Fix typo in accessing property

### DIFF
--- a/src/utils/mesh_client.ts
+++ b/src/utils/mesh_client.ts
@@ -38,7 +38,7 @@ export class MeshClient extends WSClient {
 
             // validate the response
             utils.isValidJsonRpcResponseOrThrow(response.data, data);
-            return response.data.results;
+            return response.data.result;
         }
     }
 


### PR DESCRIPTION
I'm having trouble with my local docker at the moment but this seems to be the cause. The validation code above is checking for undefined on `result` whereas we are then passing `results`.

Can someone test this out, or we can test it out on staging.