### PR TITLE
Liquidity provider integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,6 @@ jobs:
             - restore_cache:
                   keys:
                       - v1-dependencies-{{ checksum "yarn.lock" }}
-                      # fallback to using the latest cache if no exact match is found
-                      - v1-dependencies-
             - run: yarn install
             - save_cache:
                   paths:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
         "lint": "tslint --project . --format stylish"
     },
     "resolutions": {
-        "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-b8ec7f5e2"
+        "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-58b6c25d5",
+        "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-58b6c25d5",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-58b6c25d5"
     },
     "devDependencies": {
         "@0x/dev-utils": "^3.1.1",
@@ -59,10 +61,10 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-e8fd4b39f",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-58b6c25d5",
         "@0x/connect": "^6.0.4",
-        "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-b8ec7f5e2",
-        "@0x/contract-wrappers": "^13.6.3",
+        "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-58b6c25d5",
+        "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-58b6c25d5",
         "@0x/json-schemas": "^5.0.4",
         "@0x/mesh-rpc-client": "^9.0.1",
         "@0x/order-utils": "^10.1.1",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     },
     "resolutions": {
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-58b6c25d5",
-        "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-58b6c25d5",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-58b6c25d5"
+        "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-58b6c25d5"
     },
     "devDependencies": {
         "@0x/dev-utils": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     },
     "resolutions": {
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-58b6c25d5",
-        "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-58b6c25d5"
+        "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-e3f3bb670"
     },
     "devDependencies": {
         "@0x/dev-utils": "^3.1.1",
@@ -63,7 +63,7 @@
         "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-58b6c25d5",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-58b6c25d5",
-        "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-58b6c25d5",
+        "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-e3f3bb670",
         "@0x/json-schemas": "^5.0.4",
         "@0x/mesh-rpc-client": "^9.0.1",
         "@0x/order-utils": "^10.1.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-58b6c25d5",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-plp-58b6c25d5",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-58b6c25d5",
         "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-e3f3bb670",

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,11 +89,15 @@ export const LOGGER_INCLUDE_TIMESTAMP = _.isEmpty(process.env.LOGGER_INCLUDE_TIM
     ? DEFAULT_LOGGER_INCLUDE_TIMESTAMP
     : assertEnvVarType('LOGGER_INCLUDE_TIMESTAMP', process.env.LOGGER_INCLUDE_TIMESTAMP, EnvVarType.Boolean);
 
-export const LIQUIDITY_POOL_REGISTRY_ADDRESS: string | undefined = _.isEmpty(process.env.LIQUIDITY_POOL_REGISTRY_ADDRESS)
+export const LIQUIDITY_POOL_REGISTRY_ADDRESS: string | undefined = _.isEmpty(
+    process.env.LIQUIDITY_POOL_REGISTRY_ADDRESS,
+)
     ? undefined
-    : assertEnvVarType('LIQUIDITY_POOL_REGISTRY_ADDRESS', process.env.LIQUIDITY_POOL_REGISTRY_ADDRESS, EnvVarType.ETHAddressHex);
-
-
+    : assertEnvVarType(
+          'LIQUIDITY_POOL_REGISTRY_ADDRESS',
+          process.env.LIQUIDITY_POOL_REGISTRY_ADDRESS,
+          EnvVarType.ETHAddressHex,
+      );
 
 // Max number of entities per page
 export const MAX_PER_PAGE = 1000;

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,7 +124,7 @@ const sourceFees: { [key in ERC20BridgeSource]: BigNumber } = {
     [ERC20BridgeSource.CurveUsdcDaiUsdtTusd]: new BigNumber(8e5),
     [ERC20BridgeSource.CurveUsdcDaiUsdtBusd]: new BigNumber(8e5),
     [ERC20BridgeSource.Kyber]: new BigNumber(8e5),
-    [ERC20BridgeSource.LiquidityProvider]: new BigNumber(25e4),
+    [ERC20BridgeSource.LiquidityProvider]: new BigNumber(4e5),
 };
 
 export const ASSET_SWAPPER_MARKET_ORDERS_OPTS: Partial<SwapQuoteRequestOpts> = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -114,6 +114,7 @@ const sourceFees: { [key in ERC20BridgeSource]: BigNumber } = {
     [ERC20BridgeSource.CurveUsdcDaiUsdtTusd]: new BigNumber(8e5),
     [ERC20BridgeSource.CurveUsdcDaiUsdtBusd]: new BigNumber(8e5),
     [ERC20BridgeSource.Kyber]: new BigNumber(8e5),
+    [ERC20BridgeSource.LiquidityProvider]: new BigNumber(8e5),
 };
 
 export const ASSET_SWAPPER_MARKET_ORDERS_OPTS: Partial<SwapQuoteRequestOpts> = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,7 +124,7 @@ const sourceFees: { [key in ERC20BridgeSource]: BigNumber } = {
     [ERC20BridgeSource.CurveUsdcDaiUsdtTusd]: new BigNumber(8e5),
     [ERC20BridgeSource.CurveUsdcDaiUsdtBusd]: new BigNumber(8e5),
     [ERC20BridgeSource.Kyber]: new BigNumber(8e5),
-    [ERC20BridgeSource.LiquidityProvider]: new BigNumber(4e5),
+    [ERC20BridgeSource.LiquidityProvider]: new BigNumber(4.5e5),
 };
 
 export const ASSET_SWAPPER_MARKET_ORDERS_OPTS: Partial<SwapQuoteRequestOpts> = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,7 @@ enum EnvVarType {
     AddressList,
     Port,
     ChainId,
-    FeeRecipient,
+    ETHAddressHex,
     UnitAmount,
     Url,
     WhitelistAllTokens,
@@ -63,7 +63,7 @@ export const MESH_HTTP_URI = _.isEmpty(process.env.MESH_HTTP_URI)
 // The fee recipient for orders
 export const FEE_RECIPIENT_ADDRESS = _.isEmpty(process.env.FEE_RECIPIENT_ADDRESS)
     ? NULL_ADDRESS
-    : assertEnvVarType('FEE_RECIPIENT_ADDRESS', process.env.FEE_RECIPIENT_ADDRESS, EnvVarType.FeeRecipient);
+    : assertEnvVarType('FEE_RECIPIENT_ADDRESS', process.env.FEE_RECIPIENT_ADDRESS, EnvVarType.ETHAddressHex);
 // A flat fee that should be charged to the order maker
 export const MAKER_FEE_UNIT_AMOUNT = _.isEmpty(process.env.MAKER_FEE_UNIT_AMOUNT)
     ? new BigNumber(0)
@@ -88,6 +88,12 @@ export const POSTGRES_URI = _.isEmpty(process.env.POSTGRES_URI)
 export const LOGGER_INCLUDE_TIMESTAMP = _.isEmpty(process.env.LOGGER_INCLUDE_TIMESTAMP)
     ? DEFAULT_LOGGER_INCLUDE_TIMESTAMP
     : assertEnvVarType('LOGGER_INCLUDE_TIMESTAMP', process.env.LOGGER_INCLUDE_TIMESTAMP, EnvVarType.Boolean);
+
+export const LIQUIDITY_POOL_REGISTRY_ADDRESS: string | undefined = _.isEmpty(process.env.LIQUIDITY_POOL_REGISTRY_ADDRESS)
+    ? undefined
+    : assertEnvVarType('LIQUIDITY_POOL_REGISTRY_ADDRESS', process.env.LIQUIDITY_POOL_REGISTRY_ADDRESS, EnvVarType.ETHAddressHex);
+
+
 
 // Max number of entities per page
 export const MAX_PER_PAGE = 1000;
@@ -150,7 +156,7 @@ function assertEnvVarType(name: string, value: any, expectedType: EnvVarType): a
                 throw new Error(`${name} must be a valid integer, found ${value}.`);
             }
             return returnValue;
-        case EnvVarType.FeeRecipient:
+        case EnvVarType.ETHAddressHex:
             assert.isETHAddressHex(name, value);
             return value;
         case EnvVarType.Url:

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,7 +124,7 @@ const sourceFees: { [key in ERC20BridgeSource]: BigNumber } = {
     [ERC20BridgeSource.CurveUsdcDaiUsdtTusd]: new BigNumber(8e5),
     [ERC20BridgeSource.CurveUsdcDaiUsdtBusd]: new BigNumber(8e5),
     [ERC20BridgeSource.Kyber]: new BigNumber(8e5),
-    [ERC20BridgeSource.LiquidityProvider]: new BigNumber(8e5),
+    [ERC20BridgeSource.LiquidityProvider]: new BigNumber(25e4),
 };
 
 export const ASSET_SWAPPER_MARKET_ORDERS_OPTS: Partial<SwapQuoteRequestOpts> = {

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -8,13 +8,14 @@ import {
     SwapQuoteConsumer,
     SwapQuoteOrdersBreakdown,
     SwapQuoter,
+    SwapQuoterOpts,
 } from '@0x/asset-swapper';
 import { assetDataUtils, SupportedProvider } from '@0x/order-utils';
 import { AbiEncoder, BigNumber, decodeThrownErrorAsRevertError, RevertError } from '@0x/utils';
 import { TxData, Web3Wrapper } from '@0x/web3-wrapper';
 import * as _ from 'lodash';
 
-import { ASSET_SWAPPER_MARKET_ORDERS_OPTS, CHAIN_ID, FEE_RECIPIENT_ADDRESS } from '../config';
+import { ASSET_SWAPPER_MARKET_ORDERS_OPTS, CHAIN_ID, FEE_RECIPIENT_ADDRESS, LIQUIDITY_POOL_REGISTRY_ADDRESS } from '../config';
 import {
     DEFAULT_TOKEN_DECIMALS,
     GAS_LIMIT_BUFFER_PERCENTAGE,
@@ -41,9 +42,10 @@ export class SwapService {
     private readonly _web3Wrapper: Web3Wrapper;
     constructor(orderbook: Orderbook, provider: SupportedProvider) {
         this._provider = provider;
-        const swapQuoterOpts = {
+        const swapQuoterOpts: Partial<SwapQuoterOpts> = {
             chainId: CHAIN_ID,
             expiryBufferMs: QUOTE_ORDER_EXPIRATION_BUFFER_MS,
+            liquidityProviderRegistryAddress: LIQUIDITY_POOL_REGISTRY_ADDRESS,
         };
         this._swapQuoter = new SwapQuoter(this._provider, orderbook, swapQuoterOpts);
         this._swapQuoteConsumer = new SwapQuoteConsumer(this._provider, swapQuoterOpts);

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -15,7 +15,12 @@ import { AbiEncoder, BigNumber, decodeThrownErrorAsRevertError, RevertError } fr
 import { TxData, Web3Wrapper } from '@0x/web3-wrapper';
 import * as _ from 'lodash';
 
-import { ASSET_SWAPPER_MARKET_ORDERS_OPTS, CHAIN_ID, FEE_RECIPIENT_ADDRESS, LIQUIDITY_POOL_REGISTRY_ADDRESS } from '../config';
+import {
+    ASSET_SWAPPER_MARKET_ORDERS_OPTS,
+    CHAIN_ID,
+    FEE_RECIPIENT_ADDRESS,
+    LIQUIDITY_POOL_REGISTRY_ADDRESS,
+} from '../config';
 import {
     DEFAULT_TOKEN_DECIMALS,
     GAS_LIMIT_BUFFER_PERCENTAGE,

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,8 +47,23 @@
   resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/c5fe08a1a6df83d6818d5fb8455f45ceed8fdb1a"
   dependencies:
     "@0x/assert" "^3.0.7"
-    "@0x/contract-addresses" "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-58b6c25d5"
-    "@0x/contract-wrappers" "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-58b6c25d5"
+    "@0x/contract-addresses" "^4.9.0"
+    "@0x/contract-wrappers" "^13.6.3"
+    "@0x/json-schemas" "^5.0.7"
+    "@0x/order-utils" "^10.2.4"
+    "@0x/orderbook" "^2.2.5"
+    "@0x/utils" "^5.4.1"
+    "@0x/web3-wrapper" "^7.0.7"
+    heartbeats "^5.0.1"
+    lodash "^4.17.11"
+
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-plp-58b6c25d5":
+  version "4.4.0-plp"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/380db71d0e828f93a1bde8513ed2d3e43fb1c0a0"
+  dependencies:
+    "@0x/assert" "^3.0.7"
+    "@0x/contract-addresses" "^4.9.0"
+    "@0x/contract-wrappers" "^13.6.3"
     "@0x/json-schemas" "^5.0.7"
     "@0x/order-utils" "^10.2.4"
     "@0x/orderbook" "^2.2.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9065,3 +9065,4 @@ yauzl@^2.4.2:
 yn@^3.0.0:
   version "3.1.1"
   resolved "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -127,9 +127,10 @@
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@0x/contract-artifacts/-/contract-artifacts-3.2.0.tgz#a013ab50862f6c4d16fbbaa2bfc2299c630379d8"
 
-"@0x/contract-wrappers@0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-58b6c25d5", "@0x/contract-wrappers@^13.3.0", "@0x/contract-wrappers@^13.4.0", "@0x/contract-wrappers@^13.6.3":
+"@0x/contract-wrappers@0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-58b6c25d5", "@0x/contract-wrappers@0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-e3f3bb670", "@0x/contract-wrappers@^13.3.0", "@0x/contract-wrappers@^13.4.0", "@0x/contract-wrappers@^13.6.3":
   version "13.6.3"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/e68574ae48e045e073d32089e052ac00a7eeb786"
+  uid eda9bb7e81dc9dc7e63f23e6332858e322786235
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/eda9bb7e81dc9dc7e63f23e6332858e322786235"
   dependencies:
     "@0x/assert" "^3.0.7"
     "@0x/base-contract" "^6.2.1"
@@ -9065,4 +9066,3 @@ yauzl@^2.4.2:
 yn@^3.0.0:
   version "3.1.1"
   resolved "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,13 +42,13 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-e8fd4b39f":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-58b6c25d5":
   version "4.4.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/8f0f2e0d3c6229bc0de983bbbc40b3bdc9440791"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/c5fe08a1a6df83d6818d5fb8455f45ceed8fdb1a"
   dependencies:
     "@0x/assert" "^3.0.7"
-    "@0x/contract-addresses" "^4.9.0"
-    "@0x/contract-wrappers" "^13.6.3"
+    "@0x/contract-addresses" "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-58b6c25d5"
+    "@0x/contract-wrappers" "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-58b6c25d5"
     "@0x/json-schemas" "^5.0.7"
     "@0x/order-utils" "^10.2.4"
     "@0x/orderbook" "^2.2.5"
@@ -65,22 +65,6 @@
     "@0x/json-schemas" "^5.0.3"
     "@0x/utils" "^5.1.2"
     "@0x/web3-wrapper" "^7.0.3"
-    ethereumjs-account "^3.0.0"
-    ethereumjs-blockstream "^7.0.0"
-    ethereumjs-util "^5.1.1"
-    ethereumjs-vm "^4.0.0"
-    ethers "~4.0.4"
-    js-sha3 "^0.7.0"
-    uuid "^3.3.2"
-
-"@0x/base-contract@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@0x/base-contract/-/base-contract-6.1.0.tgz#5d416573295f633f622c3224ffc310541066d9b7"
-  dependencies:
-    "@0x/assert" "^3.0.4"
-    "@0x/json-schemas" "^5.0.4"
-    "@0x/utils" "^5.2.0"
-    "@0x/web3-wrapper" "^7.0.4"
     ethereumjs-account "^3.0.0"
     ethereumjs-blockstream "^7.0.0"
     ethereumjs-util "^5.1.1"
@@ -135,31 +119,17 @@
     uuid "^3.3.2"
     websocket "^1.0.26"
 
-"@0x/contract-addresses@0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-b8ec7f5e2", "@0x/contract-addresses@^4.1.0", "@0x/contract-addresses@^4.3.0", "@0x/contract-addresses@^4.9.0":
+"@0x/contract-addresses@0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-58b6c25d5", "@0x/contract-addresses@^4.1.0", "@0x/contract-addresses@^4.9.0":
   version "4.9.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/2476269a83bfc215b9e0e1e7eb03fd1fbbff1d33"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/096dbd5f387d7fa1af6691805ba8d597da08e7b4"
 
 "@0x/contract-artifacts@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@0x/contract-artifacts/-/contract-artifacts-3.2.0.tgz#a013ab50862f6c4d16fbbaa2bfc2299c630379d8"
 
-"@0x/contract-wrappers@^13.3.0", "@0x/contract-wrappers@^13.4.0":
-  version "13.4.0"
-  resolved "https://registry.yarnpkg.com/@0x/contract-wrappers/-/contract-wrappers-13.4.0.tgz#0b3ba04fb07fd359a22d74c3ce64f22a7934e502"
-  dependencies:
-    "@0x/assert" "^3.0.4"
-    "@0x/base-contract" "^6.1.0"
-    "@0x/contract-addresses" "^4.3.0"
-    "@0x/json-schemas" "^5.0.4"
-    "@0x/types" "^3.1.1"
-    "@0x/utils" "^5.2.0"
-    "@0x/web3-wrapper" "^7.0.4"
-    ethereum-types "^3.0.0"
-    ethers "~4.0.4"
-
-"@0x/contract-wrappers@^13.6.3":
+"@0x/contract-wrappers@0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-58b6c25d5", "@0x/contract-wrappers@^13.3.0", "@0x/contract-wrappers@^13.4.0", "@0x/contract-wrappers@^13.6.3":
   version "13.6.3"
-  resolved "https://registry.yarnpkg.com/@0x/contract-wrappers/-/contract-wrappers-13.6.3.tgz#82333bc473615c871aaf1c222a20750b8d332eca"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/e68574ae48e045e073d32089e052ac00a7eeb786"
   dependencies:
     "@0x/assert" "^3.0.7"
     "@0x/base-contract" "^6.2.1"


### PR DESCRIPTION
This PR upgrades 0x API to the latest `AssetSwapper` (package is not released yet) and provides a path to add private liquidity providers to 0x API. Private liquidity providers can now be added to 0x API by setting the `LIQUIDITY_POOL_REGISTRY_ADDRESS` environment variable to the liquidity provider's registry contract.