### PR TITLE
Fallback path

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-baf637217",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-aaa62beca",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-58b6c25d5",
         "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-e3f3bb670",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-plp-58b6c25d5",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-baf637217",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-58b6c25d5",
         "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-e3f3bb670",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,7 +21,8 @@ export const MESH_ORDERS_BATCH_SIZE = 200;
 // Swap Quoter
 export const QUOTE_ORDER_EXPIRATION_BUFFER_MS = ONE_SECOND_MS * 90; // Ignore orders that expire in 90 seconds
 export const GAS_LIMIT_BUFFER_PERCENTAGE = 0.2; // Add 20% to the estimated gas limit
-export const DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE = 0.01; // 1% Slippage
+export const DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE = 0.015; // 1.5% Slippage
+export const DEFAULT_FALLBACK_SLIPPAGE_PERCENTAGE = 0.015; // 1.5% Slippage in a fallback route
 export const ETH_SYMBOL = 'ETH';
 export const ADDRESS_HEX_LENGTH = 42;
 export const DEFAULT_TOKEN_DECIMALS = 18;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,7 +21,7 @@ export const MESH_ORDERS_BATCH_SIZE = 200;
 // Swap Quoter
 export const QUOTE_ORDER_EXPIRATION_BUFFER_MS = ONE_SECOND_MS * 90; // Ignore orders that expire in 90 seconds
 export const GAS_LIMIT_BUFFER_PERCENTAGE = 0.2; // Add 20% to the estimated gas limit
-export const DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE = 0.015; // 1.5% Slippage
+export const DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE = 0.03; // 3% Slippage
 export const DEFAULT_FALLBACK_SLIPPAGE_PERCENTAGE = 0.015; // 1.5% Slippage in a fallback route
 export const ETH_SYMBOL = 'ETH';
 export const ADDRESS_HEX_LENGTH = 42;

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -99,11 +99,11 @@ export class SwapService {
             makerAssetAmount,
             totalTakerAssetAmount,
             protocolFeeInWeiAmount: protocolFee,
-            gas,
         } = attributedSwapQuote.bestCaseQuoteInfo;
         const {
-            makerAssetAmount: minMakerAssetAmount,
-            totalTakerAssetAmount: minTotalTakerAssetAmount,
+            makerAssetAmount: worstMakerAssetAmount,
+            totalTakerAssetAmount: worstTotalTakerAssetAmount,
+            gas,
         } = attributedSwapQuote.worstCaseQuoteInfo;
         const { orders, gasPrice, sourceBreakdown } = attributedSwapQuote;
 
@@ -149,8 +149,8 @@ export class SwapService {
                 ? unitMakerAssetAmount.dividedBy(unitTakerAssetAMount).decimalPlaces(sellTokenDecimals)
                 : unitTakerAssetAMount.dividedBy(unitMakerAssetAmount).decimalPlaces(buyTokenDecimals);
         // Min price before revert occurs
-        const minUnitMakerAssetAmount = Web3Wrapper.toUnitAmount(minMakerAssetAmount, buyTokenDecimals);
-        const minUnitTakerAssetAMount = Web3Wrapper.toUnitAmount(minTotalTakerAssetAmount, sellTokenDecimals);
+        const minUnitMakerAssetAmount = Web3Wrapper.toUnitAmount(worstMakerAssetAmount, buyTokenDecimals);
+        const minUnitTakerAssetAMount = Web3Wrapper.toUnitAmount(worstTotalTakerAssetAmount, sellTokenDecimals);
         const minPrice =
             buyAmount === undefined
                 ? minUnitMakerAssetAmount.dividedBy(minUnitTakerAssetAMount).decimalPlaces(sellTokenDecimals)

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -99,7 +99,12 @@ export class SwapService {
             makerAssetAmount,
             totalTakerAssetAmount,
             protocolFeeInWeiAmount: protocolFee,
+            gas,
         } = attributedSwapQuote.bestCaseQuoteInfo;
+        const {
+            makerAssetAmount: minMakerAssetAmount,
+            totalTakerAssetAmount: minTotalTakerAssetAmount,
+        } = attributedSwapQuote.worstCaseQuoteInfo;
         const { orders, gasPrice, sourceBreakdown } = attributedSwapQuote;
 
         // If ETH was specified as the token to sell then we use the Forwarder
@@ -114,7 +119,7 @@ export class SwapService {
 
         const affiliatedData = this._attributeCallData(data, affiliateAddress);
 
-        let gas;
+        let suggestedGasEstimate = new BigNumber(gas);
         if (from) {
             // Force a revert error if the takerAddress does not have enough ETH.
             const txDataValue =
@@ -128,24 +133,36 @@ export class SwapService {
                 value: txDataValue,
                 gasPrice,
             });
-            gas = gasEstimate.times(GAS_LIMIT_BUFFER_PERCENTAGE + 1).integerValue();
+            // Take the max of the faux estimate or the real estimate
+            suggestedGasEstimate = BigNumber.max(gasEstimate, suggestedGasEstimate);
         }
+        // Add a buffer to the gas estimate
+        suggestedGasEstimate = suggestedGasEstimate.times(GAS_LIMIT_BUFFER_PERCENTAGE + 1).integerValue();
 
         const buyTokenDecimals = await this._fetchTokenDecimalsIfRequiredAsync(buyTokenAddress);
         const sellTokenDecimals = await this._fetchTokenDecimalsIfRequiredAsync(sellTokenAddress);
         const unitMakerAssetAmount = Web3Wrapper.toUnitAmount(makerAssetAmount, buyTokenDecimals);
         const unitTakerAssetAMount = Web3Wrapper.toUnitAmount(totalTakerAssetAmount, sellTokenDecimals);
+        // Best price
         const price =
             buyAmount === undefined
                 ? unitMakerAssetAmount.dividedBy(unitTakerAssetAMount).decimalPlaces(sellTokenDecimals)
                 : unitTakerAssetAMount.dividedBy(unitMakerAssetAmount).decimalPlaces(buyTokenDecimals);
+        // Min price before revert occurs
+        const minUnitMakerAssetAmount = Web3Wrapper.toUnitAmount(minMakerAssetAmount, buyTokenDecimals);
+        const minUnitTakerAssetAMount = Web3Wrapper.toUnitAmount(minTotalTakerAssetAmount, sellTokenDecimals);
+        const minPrice =
+            buyAmount === undefined
+                ? minUnitMakerAssetAmount.dividedBy(minUnitTakerAssetAMount).decimalPlaces(sellTokenDecimals)
+                : minUnitTakerAssetAMount.dividedBy(minUnitMakerAssetAmount).decimalPlaces(buyTokenDecimals);
 
         const apiSwapQuote: GetSwapQuoteResponse = {
             price,
+            minPrice,
             to,
             data: affiliatedData,
             value,
-            gas,
+            gas: suggestedGasEstimate,
             from,
             gasPrice,
             protocolFee,
@@ -180,8 +197,8 @@ export class SwapService {
                         amounts,
                         {
                             ...ASSET_SWAPPER_MARKET_ORDERS_OPTS,
-                            slippagePercentage: 0,
                             bridgeSlippage: 0,
+                            maxFallbackSlippage: 0,
                             numSamples: 3,
                         },
                     );

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -101,8 +101,8 @@ export class SwapService {
             protocolFeeInWeiAmount: protocolFee,
         } = attributedSwapQuote.bestCaseQuoteInfo;
         const {
-            makerAssetAmount: worstMakerAssetAmount,
-            totalTakerAssetAmount: worstTotalTakerAssetAmount,
+            makerAssetAmount: guaranteedMakerAssetAmount,
+            totalTakerAssetAmount: guaranteedTotalTakerAssetAmount,
             gas,
         } = attributedSwapQuote.worstCaseQuoteInfo;
         const { orders, gasPrice, sourceBreakdown } = attributedSwapQuote;
@@ -148,17 +148,24 @@ export class SwapService {
             buyAmount === undefined
                 ? unitMakerAssetAmount.dividedBy(unitTakerAssetAMount).decimalPlaces(sellTokenDecimals)
                 : unitTakerAssetAMount.dividedBy(unitMakerAssetAmount).decimalPlaces(buyTokenDecimals);
-        // Min price before revert occurs
-        const minUnitMakerAssetAmount = Web3Wrapper.toUnitAmount(worstMakerAssetAmount, buyTokenDecimals);
-        const minUnitTakerAssetAMount = Web3Wrapper.toUnitAmount(worstTotalTakerAssetAmount, sellTokenDecimals);
-        const minPrice =
+        // Guaranteed price before revert occurs
+        const guaranteedUnitMakerAssetAmount = Web3Wrapper.toUnitAmount(guaranteedMakerAssetAmount, buyTokenDecimals);
+        const guaranteedUnitTakerAssetAMount = Web3Wrapper.toUnitAmount(
+            guaranteedTotalTakerAssetAmount,
+            sellTokenDecimals,
+        );
+        const guaranteedPrice =
             buyAmount === undefined
-                ? minUnitMakerAssetAmount.dividedBy(minUnitTakerAssetAMount).decimalPlaces(sellTokenDecimals)
-                : minUnitTakerAssetAMount.dividedBy(minUnitMakerAssetAmount).decimalPlaces(buyTokenDecimals);
+                ? guaranteedUnitMakerAssetAmount
+                      .dividedBy(guaranteedUnitTakerAssetAMount)
+                      .decimalPlaces(sellTokenDecimals)
+                : guaranteedUnitTakerAssetAMount
+                      .dividedBy(guaranteedUnitMakerAssetAmount)
+                      .decimalPlaces(buyTokenDecimals);
 
         const apiSwapQuote: GetSwapQuoteResponse = {
             price,
-            minPrice,
+            guaranteedPrice,
             to,
             data: affiliatedData,
             value,

--- a/src/types.ts
+++ b/src/types.ts
@@ -309,6 +309,7 @@ export interface TokenMetadata {
 
 export interface GetSwapQuoteResponse {
     price: BigNumber;
+    minPrice: BigNumber;
     to: string;
     data: string;
     gasPrice: BigNumber;

--- a/src/types.ts
+++ b/src/types.ts
@@ -309,7 +309,7 @@ export interface TokenMetadata {
 
 export interface GetSwapQuoteResponse {
     price: BigNumber;
-    minPrice: BigNumber;
+    guaranteedPrice: BigNumber;
     to: string;
     data: string;
     gasPrice: BigNumber;

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,24 +42,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-58b6c25d5":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-aaa62beca":
   version "4.4.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/c5fe08a1a6df83d6818d5fb8455f45ceed8fdb1a"
-  dependencies:
-    "@0x/assert" "^3.0.7"
-    "@0x/contract-addresses" "^4.9.0"
-    "@0x/contract-wrappers" "^13.6.3"
-    "@0x/json-schemas" "^5.0.7"
-    "@0x/order-utils" "^10.2.4"
-    "@0x/orderbook" "^2.2.5"
-    "@0x/utils" "^5.4.1"
-    "@0x/web3-wrapper" "^7.0.7"
-    heartbeats "^5.0.1"
-    lodash "^4.17.11"
-
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-plp-58b6c25d5":
-  version "4.4.0-plp"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/380db71d0e828f93a1bde8513ed2d3e43fb1c0a0"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/9b4505d1df8bb50f999c330610cb21a28e8f532f"
   dependencies:
     "@0x/assert" "^3.0.7"
     "@0x/contract-addresses" "^4.9.0"
@@ -142,9 +127,8 @@
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@0x/contract-artifacts/-/contract-artifacts-3.2.0.tgz#a013ab50862f6c4d16fbbaa2bfc2299c630379d8"
 
-"@0x/contract-wrappers@0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-58b6c25d5", "@0x/contract-wrappers@0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-e3f3bb670", "@0x/contract-wrappers@^13.3.0", "@0x/contract-wrappers@^13.4.0", "@0x/contract-wrappers@^13.6.3":
+"@0x/contract-wrappers@0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-e3f3bb670", "@0x/contract-wrappers@^13.3.0", "@0x/contract-wrappers@^13.4.0", "@0x/contract-wrappers@^13.6.3":
   version "13.6.3"
-  uid eda9bb7e81dc9dc7e63f23e6332858e322786235
   resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/eda9bb7e81dc9dc7e63f23e6332858e322786235"
   dependencies:
     "@0x/assert" "^3.0.7"


### PR DESCRIPTION
* Adds fallback path when 0x Native orders are used in the optimal path.
* Adds `guaranteedPrice` in the response now that we're potentially falling back with a path that has additional slippage. It will fill at this price (or better) or revert.
* Bumps the gas schedule to be more accurate with reality of filling via a bridge.
* Bumps default slippage to 3% during these volatile times.
* `gas` is now always returned as our faux estimate or a real estimate (whatever is largest)

# Comparison
### dev vs prod 
Dev has 3%, 1.5% bridgeSlippage, maxFallbackSlippage
Production has 1% slippage and no fallback

![image](https://user-images.githubusercontent.com/27389/76598912-97185f00-654f-11ea-9b94-9a698d2469bf.png)

You can observe the fallback path and increase in slippage to 3% has a significant effect in these volatile times.

### dev vs staging (with fallback)
Dev has 3%, 1.5% bridgeSlippage, maxFallbackSlippage
Staging has 1.5%, 1.5%

![image](https://user-images.githubusercontent.com/27389/76598848-6df7ce80-654f-11ea-9fd8-f3280b0285ca.png)

You can observe the fallback path but a tight slippage isn't suitable in these volatile times. We don't often find a fallback path within 1.5% slippage range.