### PR TITLE
Fix excluded sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ These are services that handle HTTP requests and responses.
 | Name                                                | Path       | Run Command                       | Requires [0x Mesh](https://github.com/0xProject/0x-mesh)? | Requires Ethereum JSON RPC Provider? | Requires Relational Database? |
 | --------------------------------------------------- | ---------- | --------------------------------- | --------------------------------------------------------- | ------------------------------------ | ----------------------------- |
 | All HTTP Services                                   | `/*`       | `yarn start:service:http`         | Yes                                                       | Yes                                  | Yes                           |
-| [Swap](https://0x.org/docs/api#swap)                | `/swap`    | `yarn start:service:swap_http` | Yes                                                       | Yes                                  | Yes                           |
+| [Swap](https://0x.org/docs/api#swap)                | `/swap`    | `yarn start:service:swap_http`    | Yes                                                       | Yes                                  | Yes                           |
 | [Standard Relayer API](https://0x.org/docs/api#sra) | `/sra`     | `yarn start:service:sra_http`     | Yes                                                       | No                                   | Yes                           |
 | Staking (Not Public)                                | `/staking` | `yarn start:service:staking_http` | No                                                        | No                                   | Yes                           |
 

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -146,9 +146,13 @@ const findTokenAddressOrThrowApiError = (address: string, field: string, chainId
 };
 
 const parseStringArrForERC20BridgeSources = (excludedSources: string[]): ERC20BridgeSource[] => {
+    // Need to compare value of the enum instead of the key, as values are used by asset-swapper
+    // CurveUsdcDaiUsdt = 'Curve_USDC_DAI_USDT' is excludedSources=Curve_USDC_DAI_USDT
     return excludedSources
         .map(source => (source === '0x' ? 'Native' : source))
-        .filter((source: string) => source in ERC20BridgeSource) as ERC20BridgeSource[];
+        .filter((source: string) =>
+            Object.keys(ERC20BridgeSource).find((k: any) => ERC20BridgeSource[k] === source),
+        ) as ERC20BridgeSource[];
 };
 
 const parseGetSwapQuoteRequestParams = (req: express.Request): GetSwapQuoteRequestParams => {


### PR DESCRIPTION
Needs to find the value of `CurveUsdcDaiUsdt` i.e `Curve_USDC_DAI_USDT` as that is what is used internally in asset-swapper and returned via the API. 


`excludedSources=CurveUsdcDaiUsdt` was returning `['CurveUsdcDaiUsdt']` and `excludedSources=Curve_USDC_DAI_USDT` was returning `[]`. `Native/0x` and `Kyber` etc are fine as they don't have different key/values.