### PR TITLE
Handle WETH and ETH unwrapping/wrapping  with swap quote

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ export const ZRX_DECIMALS = 18;
 export const DEFAULT_PAGE = 1;
 export const DEFAULT_PER_PAGE = 20;
 export const ZERO = new BigNumber(0);
+export const ONE = new BigNumber(1);
 export const MAX_TOKEN_SUPPLY_POSSIBLE = new BigNumber(2).pow(256);
 export const DEFAULT_LOCAL_POSTGRES_URI = 'postgresql://api:api@localhost/api';
 export const DEFAULT_LOGGER_INCLUDE_TIMESTAMP = true;
@@ -25,10 +26,12 @@ export const GAS_LIMIT_BUFFER_PERCENTAGE = 0.2; // Add 20% to the estimated gas 
 export const DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE = 0.03; // 3% Slippage
 export const DEFAULT_FALLBACK_SLIPPAGE_PERCENTAGE = 0.015; // 1.5% Slippage in a fallback route
 export const ETH_SYMBOL = 'ETH';
+export const WETH_SYMBOL = 'WETH';
 export const ADDRESS_HEX_LENGTH = 42;
 export const DEFAULT_TOKEN_DECIMALS = 18;
 export const FIRST_PAGE = 1;
 export const PERCENTAGE_SIG_DIGITS = 4;
+export const PROTOCOL_FEE_UTILS_POLLING_INTERVAL_IN_MS = 6000;
 
 // API namespaces
 export const SRA_PATH = '/sra/v3';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,6 +32,8 @@ export const DEFAULT_TOKEN_DECIMALS = 18;
 export const FIRST_PAGE = 1;
 export const PERCENTAGE_SIG_DIGITS = 4;
 export const PROTOCOL_FEE_UTILS_POLLING_INTERVAL_IN_MS = 6000;
+export const UNWRAP_QUOTE_GAS = new BigNumber(40000);
+export const WRAP_QUOTE_GAS = new BigNumber(30000);
 
 // API namespaces
 export const SRA_PATH = '/sra/v3';

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -110,4 +110,5 @@ export enum ValidationErrorCodes {
     UnsupportedOption = 1006,
     InvalidOrder = 1007,
     InternalError = 1008,
+    TokenNotSupported = 1009,
 }

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -42,7 +42,7 @@ export class SwapHandlers {
                 {
                     field: 'buyToken',
                     code: ValidationErrorCodes.TokenNotSupported,
-                    reason: 'Buying ETH is unsupported (set to \'WETH\' to received wrapped Ether)',
+                    reason: "Buying ETH is unsupported (set to 'WETH' to received wrapped Ether)",
                 },
             ]);
         }

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -37,6 +37,15 @@ export class SwapHandlers {
             excludedSources,
             affiliateAddress,
         } = parseGetSwapQuoteRequestParams(req);
+        if (isETHSymbol(buyToken)) {
+            throw new ValidationError([
+                {
+                    field: 'buyToken',
+                    code: ValidationErrorCodes.TokenNotSupported,
+                    reason: 'Buying ETH is unsupported (set to \'WETH\' to received wrapped Ether)',
+                },
+            ]);
+        }
         const isETHSell = isETHSymbol(sellToken);
         const sellTokenAddress = findTokenAddressOrThrowApiError(sellToken, 'sellToken', CHAIN_ID);
         const buyTokenAddress = findTokenAddressOrThrowApiError(buyToken, 'buyToken', CHAIN_ID);

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -11,7 +11,7 @@ import { isAPIError, isRevertError } from '../middleware/error_handling';
 import { schemas } from '../schemas/schemas';
 import { SwapService } from '../services/swap_service';
 import { TokenMetadatasForChains } from '../token_metadatas_for_networks';
-import { ChainId, GetSwapQuoteRequestParams, GetSwapQuoteResponse, CalculateSwapQuoteParams } from '../types';
+import { CalculateSwapQuoteParams, ChainId, GetSwapQuoteRequestParams, GetSwapQuoteResponse } from '../types';
 import { schemaUtils } from '../utils/schema_utils';
 import { findTokenAddress, getTokenMetadataIfExists, isETHSymbol, isWETHSymbol } from '../utils/token_metadata_utils';
 

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -11,12 +11,8 @@ import {
     SwapQuoter,
     SwapQuoterOpts,
 } from '@0x/asset-swapper';
-import {
-    WETH9Contract,
-} from '@0x/contract-wrappers';
-import {
-    getContractAddressesForChainOrThrow,
-} from '@0x/contract-addresses';
+import { getContractAddressesForChainOrThrow } from '@0x/contract-addresses';
+import { WETH9Contract } from '@0x/contract-wrappers';
 import { assetDataUtils, SupportedProvider } from '@0x/order-utils';
 import { AbiEncoder, BigNumber, decodeThrownErrorAsRevertError, RevertError } from '@0x/utils';
 import { TxData, Web3Wrapper } from '@0x/web3-wrapper';
@@ -259,7 +255,10 @@ export class SwapService {
             .filter(p => p) as GetTokenPricesResponse;
         return prices;
     }
-    private async _getSwapQuoteForWethAsync(params: CalculateSwapQuoteParams, isUnwrap: boolean): Promise<GetSwapQuoteResponse> {
+    private async _getSwapQuoteForWethAsync(
+        params: CalculateSwapQuoteParams,
+        isUnwrap: boolean,
+    ): Promise<GetSwapQuoteResponse> {
         const {
             from,
             buyTokenAddress,
@@ -273,10 +272,13 @@ export class SwapService {
         if (amount === undefined) {
             throw new Error('sellAmount or buyAmount required');
         }
-        const data = (isUnwrap ? this._wethContract.withdraw(amount) : this._wethContract.deposit()).getABIEncodedTransactionData();
+        const data = (isUnwrap
+            ? this._wethContract.withdraw(amount)
+            : this._wethContract.deposit()
+        ).getABIEncodedTransactionData();
         const value = isUnwrap ? ZERO : amount;
         const affiliatedData = this._attributeCallData(data, affiliateAddress);
-        const gasPrice = providedGasPrice || await this._protocolFeeUtils.getGasPriceEstimationOrThrowAsync();
+        const gasPrice = providedGasPrice || (await this._protocolFeeUtils.getGasPriceEstimationOrThrowAsync());
         const gasEstimate = await this._estimateGasOrThrowRevertErrorAsync({
             to: this._wethContract.address,
             data: affiliatedData,

--- a/src/utils/token_metadata_utils.ts
+++ b/src/utils/token_metadata_utils.ts
@@ -1,4 +1,4 @@
-import { ADDRESS_HEX_LENGTH, ETH_SYMBOL } from '../constants';
+import { ADDRESS_HEX_LENGTH, ETH_SYMBOL, WETH_SYMBOL } from '../constants';
 import { TokenMetadataAndChainAddresses, TokenMetadatasForChains } from '../token_metadatas_for_networks';
 import { ChainId, TokenMetadata } from '../types';
 
@@ -35,6 +35,15 @@ export function getTokenMetadataIfExists(tokenAddressOrSymbol: string, chainId: 
  */
 export function isETHSymbol(tokenSymbol: string): boolean {
     return tokenSymbol.toLowerCase() === ETH_SYMBOL.toLowerCase();
+}
+
+/**
+ *  Returns true if this symbol represents WETH
+ *
+ * @param tokenSymbol the symbol of the token
+ */
+export function isWETHSymbol(tokenSymbol: string): boolean {
+    return tokenSymbol.toLowerCase() === WETH_SYMBOL.toLowerCase();
 }
 
 /**

--- a/src/utils/token_metadata_utils.ts
+++ b/src/utils/token_metadata_utils.ts
@@ -42,8 +42,13 @@ export function isETHSymbol(tokenSymbol: string): boolean {
  *
  * @param tokenSymbol the symbol of the token
  */
-export function isWETHSymbol(tokenSymbol: string): boolean {
-    return tokenSymbol.toLowerCase() === WETH_SYMBOL.toLowerCase();
+export function isWETHSymbolOrAddress(tokenAddressOrSymbol: string, chainId: number): boolean {
+    // force downcast to TokenMetadata the optional
+    const wethAddress = ((getTokenMetadataIfExists(WETH_SYMBOL, chainId) as any) as TokenMetadata).tokenAddress;
+    return (
+        tokenAddressOrSymbol.toLowerCase() === WETH_SYMBOL.toLowerCase() ||
+        tokenAddressOrSymbol.toLowerCase() === wethAddress
+    );
 }
 
 /**


### PR DESCRIPTION
### Changes

#### Unwrapping and Wrapping
You can now unwrap and wrap between ETH and WETH by requesting a quote:
- `sellToken=WETH` and `buyToken=ETH` for unwrapping
- `sellToken=ETH` and `buyToken=WETH` for wrapping

Providing either `sellAmount` and `buyAmount`  will give the same behavior because the "rate" between ETH<>WETH is always 1:1.

I have opted out of making the changes to support unwrapping and wrapping in asset-swapper because it seems out of scope and requires larger changes to AS that seem rather costly for such a feature.
- AS relies on token addresses and asset data to identify assets; with that we would need to introduce some ability to identity `ETH` between `WETH` to `SwapQuoter`'s interface. This would require a large change to AS.
- Behind the scenes, SwapQuoter will need to do quite a bit of work to skip the SOR logic. 
- With the eventual addition of exchange contract proxy pattern that allow for better UX around wrapping/unwrapping; seems to be the case this design will be a stop gap solution that that of a long term solution.

#### Throwing on `buyToken=ETH` 
0x API `/swap` considers `buyToken=ETH` as quotes where `buyToken=WETH`. Instead of the unexpected error, 0x API will throw a 400 error to reflect that 0x API doesn't support receiving ETH as a buyToken. (Only WETH). In the future with changes to the forwarder contract, buying ETH may be supported.