### PR TITLE
Make /asset_pairs more efficien

### DIFF
--- a/src/services/orderbook_service.ts
+++ b/src/services/orderbook_service.ts
@@ -34,7 +34,6 @@ export class OrderBookService {
         const signedOrderEntities = (await this._connection.manager.find(SignedOrderEntity)) as Array<
             Required<SignedOrderEntity>
         >;
-
         const assetPairsItems: AssetPairsItem[] = signedOrderEntities
             .map(orderUtils.deserializeOrder)
             .map(orderUtils.signedOrderToAssetPair);
@@ -52,7 +51,10 @@ export class OrderBookService {
                 assetPair.assetDataA.assetData === assetData || assetPair.assetDataB.assetData === assetData;
             nonPaginatedFilteredAssetPairs = assetPairsItems.filter(containsAssetData);
         }
-        const uniqueNonPaginatedFilteredAssetPairs = _.uniqWith(nonPaginatedFilteredAssetPairs, _.isEqual.bind(_));
+        const uniqueNonPaginatedFilteredAssetPairs = _.uniqBy(
+            nonPaginatedFilteredAssetPairs,
+            assetPair => `${assetPair.assetDataA.assetData}/${assetPair.assetDataB.assetData}`,
+        );
         const paginatedFilteredAssetPairs = paginationUtils.paginate(
             uniqueNonPaginatedFilteredAssetPairs,
             page,


### PR DESCRIPTION
```
diff --git a/src/services/orderbook_service.ts b/src/services/orderbook_service.ts
index 5dbc46b..355b486 100644
--- a/src/services/orderbook_service.ts
+++ b/src/services/orderbook_service.ts
@@ -31,10 +31,12 @@ export class OrderBookService {
         assetDataA?: string,
         assetDataB?: string,
     ): Promise<PaginatedCollection<AssetPairsItem>> {
+        console.time('order_fetch');
         const signedOrderEntities = (await this._connection.manager.find(SignedOrderEntity)) as Array<
             Required<SignedOrderEntity>
         >;
-
+        console.timeEnd('order_fetch');
+        console.time('filtering');
         const assetPairsItems: AssetPairsItem[] = signedOrderEntities
             .map(orderUtils.deserializeOrder)
             .map(orderUtils.signedOrderToAssetPair);
@@ -52,12 +54,17 @@ export class OrderBookService {
                 assetPair.assetDataA.assetData === assetData || assetPair.assetDataB.assetData === assetData;
             nonPaginatedFilteredAssetPairs = assetPairsItems.filter(containsAssetData);
         }
+        console.timeEnd('filtering');
+        console.time('unique');
         const uniqueNonPaginatedFilteredAssetPairs = _.uniqWith(nonPaginatedFilteredAssetPairs, _.isEqual.bind(_));
+        console.timeEnd('unique');
+        console.time('pagination');
         const paginatedFilteredAssetPairs = paginationUtils.paginate(
             uniqueNonPaginatedFilteredAssetPairs,
             page,
             perPage,
         );
+        console.timeEnd('pagination');
         return paginatedFilteredAssetPairs;
     }
     // tslint:disable-next-line:prefer-function-over-method
```

### Before
```
order_fetch: 391.892ms
filtering: 901.273ms
unique: 38924.817ms
pagination: 0.500ms
```
### After
```
unique: 37.155ms
```
