### PR TITLE
Removed totalProtocolFeesGeneratedInEth

### DIFF
--- a/src/queries/staking_queries.ts
+++ b/src/queries/staking_queries.ts
@@ -5,14 +5,6 @@ export const currentEpochQuery = `
         FROM staking.epoch_start_pool_status esps
         JOIN staking.current_epoch ce ON ce.epoch_id = esps.epoch_id
     )
-    , protocol_fees AS (
-        SELECT
-            SUM(protocol_fee_paid) / 1e18::NUMERIC AS protocol_fees_generated_in_eth
-        FROM events.fill_events fe
-        JOIN staking.current_epoch ce
-            ON fe.block_number > ce.starting_block_number
-            OR (fe.block_number = ce.starting_block_number AND fe.transaction_index > ce.starting_transaction_index)
-    )
     , zrx_deposited AS (
         SELECT
             SUM(scc.amount) AS zrx_deposited
@@ -25,11 +17,9 @@ export const currentEpochQuery = `
         ce.*
         , zd.zrx_deposited
         , zs.zrx_staked
-        , pf.protocol_fees_generated_in_eth
     FROM staking.current_epoch ce
     CROSS JOIN zrx_deposited zd
-    CROSS JOIN zrx_staked zs
-    CROSS JOIN protocol_fees pf;`;
+    CROSS JOIN zrx_staked zs;`;
 
 export const nextEpochQuery = `
     WITH

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,7 +67,6 @@ export interface RawEpoch {
     ending_block_timestamp?: null;
     zrx_deposited?: string;
     zrx_staked?: string;
-    protocol_fees_generated_in_eth?: string;
 }
 
 export interface TransactionDate {
@@ -82,7 +81,6 @@ export interface Epoch {
     epochEnd?: TransactionDate;
     zrxStaked: number;
     zrxDeposited: number;
-    protocolFeesGeneratedInEth: number;
 }
 
 export interface RawPool {

--- a/src/utils/staking_utils.ts
+++ b/src/utils/staking_utils.ts
@@ -40,7 +40,6 @@ export const stakingUtils = {
             ending_block_timestamp,
             zrx_deposited,
             zrx_staked,
-            protocol_fees_generated_in_eth,
         } = rawEpoch;
         let epochEnd: TransactionDate | undefined;
         if (ending_transaction_hash && ending_block_number) {
@@ -60,7 +59,6 @@ export const stakingUtils = {
             epochEnd,
             zrxDeposited: Number(zrx_deposited || 0),
             zrxStaked: Number(zrx_staked || 0),
-            protocolFeesGeneratedInEth: Number(protocol_fees_generated_in_eth || 0),
         };
     },
     getPoolFromRaw: (rawPool: RawPool): Pool => {


### PR DESCRIPTION
Removed total protocol fees from current epoch query to improve performance.

Query runtime on Hashalytics:
~180ms -> ~150ms

Testing:
- [x] Tested Query
- [x] Tested Locally
- [x] Tested in Staging