### PR TITLE
Add zeros for sources

### DIFF
--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -238,7 +238,10 @@ export class SwapService {
     private _convertSourceBreakdownToArray(
         sourceBreakdown: SwapQuoteOrdersBreakdown,
     ): GetSwapQuoteResponseLiquiditySource[] {
-        const defaultSourceBreakdown: SwapQuoteOrdersBreakdown = Object.assign({}, ...Object.values(ERC20BridgeSource).map(s => ({ [s]: ZERO })));
+        const defaultSourceBreakdown: SwapQuoteOrdersBreakdown = Object.assign(
+            {},
+            ...Object.values(ERC20BridgeSource).map(s => ({ [s]: ZERO })),
+        );
 
         const breakdown: GetSwapQuoteResponseLiquiditySource[] = [];
         return Object.entries({ ...defaultSourceBreakdown, ...sourceBreakdown }).reduce(

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -27,6 +27,7 @@ import {
     ONE_SECOND_MS,
     PERCENTAGE_SIG_DIGITS,
     QUOTE_ORDER_EXPIRATION_BUFFER_MS,
+    ZERO,
 } from '../constants';
 import { logger } from '../logger';
 import { TokenMetadatasForChains } from '../token_metadatas_for_networks';
@@ -237,8 +238,18 @@ export class SwapService {
     private _convertSourceBreakdownToArray(
         sourceBreakdown: SwapQuoteOrdersBreakdown,
     ): GetSwapQuoteResponseLiquiditySource[] {
+        const defaultSourceBreakdown: SwapQuoteOrdersBreakdown = Object.keys(ERC20BridgeSource).reduce(
+            (acc: SwapQuoteOrdersBreakdown, k: any): SwapQuoteOrdersBreakdown => {
+                return {
+                    ...acc,
+                    [k]: ZERO,
+                };
+            },
+            {},
+        );
+
         const breakdown: GetSwapQuoteResponseLiquiditySource[] = [];
-        return Object.entries(sourceBreakdown).reduce(
+        return Object.entries({ ...defaultSourceBreakdown, ...sourceBreakdown }).reduce(
             (acc: GetSwapQuoteResponseLiquiditySource[], [source, percentage]) => {
                 return [
                     ...acc,

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -238,15 +238,7 @@ export class SwapService {
     private _convertSourceBreakdownToArray(
         sourceBreakdown: SwapQuoteOrdersBreakdown,
     ): GetSwapQuoteResponseLiquiditySource[] {
-        const defaultSourceBreakdown: SwapQuoteOrdersBreakdown = Object.keys(ERC20BridgeSource).reduce(
-            (acc: SwapQuoteOrdersBreakdown, k: any): SwapQuoteOrdersBreakdown => {
-                return {
-                    ...acc,
-                    [k]: ZERO,
-                };
-            },
-            {},
-        );
+        const defaultSourceBreakdown: SwapQuoteOrdersBreakdown = Object.assign({}, ...Object.values(ERC20BridgeSource).map(s => ({ [s]: ZERO })));
 
         const breakdown: GetSwapQuoteResponseLiquiditySource[] = [];
         return Object.entries({ ...defaultSourceBreakdown, ...sourceBreakdown }).reduce(
@@ -262,6 +254,7 @@ export class SwapService {
             breakdown,
         );
     }
+
     private async _estimateGasOrThrowRevertErrorAsync(txData: Partial<TxData>): Promise<BigNumber> {
         // Perform this concurrently
         // if the call fails the gas estimation will also fail, we can throw a more helpful


### PR DESCRIPTION
If a liquidity source is not utilized in swap quote, `sources` will return the liquidity provider with `proportion` set to zero. This will allow for easier understanding of the potential breakdown of liquidity when requesting a quote. 

Docs update: https://github.com/0xProject/website/pull/274