### PR TITLE
Handle 0x-api-key header

### DIFF
--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -83,6 +83,7 @@ export class SwapHandlers {
             gasPrice,
             excludedSources,
             affiliateAddress,
+            apiKey: req.header('0x-api-key'),
         };
 
         try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -372,6 +372,7 @@ export interface CalculateSwapQuoteParams {
     gasPrice?: BigNumber;
     excludedSources?: ERC20BridgeSource[];
     affiliateAddress?: string;
+    apiKey?: string;
 }
 
 export interface GetSwapQuoteResponseLiquiditySource {


### PR DESCRIPTION
I've introduced API Keys as part of #162 .  @fabioberger asked me to put the API Key handling into its own PR so he can build on top of it for meta-transactions.

Amazingly, these 2 lines are the only thing that aren't RFQ-T-specific.