### PR TITLE
Fix expired order filter, better error logging

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -55,7 +55,7 @@ export async function getDefaultAppDependenciesAsync(
     try {
         swapService = createSwapServiceFromOrderBookService(orderBookService, provider);
     } catch (err) {
-        logger.error(err);
+        logger.error(err.stack);
     }
 
     const websocketOpts = { path: SRA_PATH };

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ if (require.main === module) {
         const provider = providerUtils.createWeb3Provider(config.ETHEREUM_RPC_URL);
         const dependencies = await getDefaultAppDependenciesAsync(provider, config);
         await getAppAsync(dependencies, config);
-    })().catch(err => logger.error(err));
+    })().catch(err => logger.error(err.stack));
 }
 process.on('uncaughtException', err => {
     logger.error(err);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -20,7 +20,7 @@ export function alertOnExpiredOrders(expired: APIOrder[], details?: string): voi
     if (
         expired.find((order, i) => {
             idx = i;
-            return order.order.expirationTimeSeconds.gt(maxExpirationTimeSeconds);
+            return order.order.expirationTimeSeconds.toNumber() > maxExpirationTimeSeconds;
         })
     ) {
         const error = new ExpiredOrderError(expired[idx].order, MAX_ORDER_EXPIRATION_BUFFER_SECONDS, details);

--- a/src/runners/http_service_runner.ts
+++ b/src/runners/http_service_runner.ts
@@ -35,7 +35,7 @@ if (require.main === module) {
         const provider = providerUtils.createWeb3Provider(defaultConfig.ETHEREUM_RPC_URL);
         const dependencies = await getDefaultAppDependenciesAsync(provider, defaultConfig);
         await runHttpServiceAsync(dependencies, defaultConfig);
-    })().catch(error => logger.error(error));
+    })().catch(error => logger.error(error.stack));
 }
 
 /**

--- a/src/runners/http_sra_service_runner.ts
+++ b/src/runners/http_sra_service_runner.ts
@@ -37,7 +37,7 @@ if (require.main === module) {
         const provider = providerUtils.createWeb3Provider(defaultConfig.ETHEREUM_RPC_URL);
         const dependencies = await getDefaultAppDependenciesAsync(provider, defaultConfig);
         await runHttpServiceAsync(dependencies, defaultConfig);
-    })().catch(error => logger.error(error));
+    })().catch(error => logger.error(error.stack));
 }
 
 async function runHttpServiceAsync(

--- a/src/runners/http_staking_service_runner.ts
+++ b/src/runners/http_staking_service_runner.ts
@@ -36,7 +36,7 @@ if (require.main === module) {
         const provider = providerUtils.createWeb3Provider(defaultConfig.ETHEREUM_RPC_URL);
         const dependencies = await getDefaultAppDependenciesAsync(provider, defaultConfig);
         await runHttpServiceAsync(dependencies, defaultConfig);
-    })().catch(error => logger.error(error));
+    })().catch(error => logger.error(error.stack));
 }
 
 async function runHttpServiceAsync(

--- a/src/runners/http_swap_service_runner.ts
+++ b/src/runners/http_swap_service_runner.ts
@@ -36,7 +36,7 @@ if (require.main === module) {
         const provider = providerUtils.createWeb3Provider(defaultConfig.ETHEREUM_RPC_URL);
         const dependencies = await getDefaultAppDependenciesAsync(provider, defaultConfig);
         await runHttpServiceAsync(dependencies, defaultConfig);
-    })().catch(error => logger.error(error));
+    })().catch(error => logger.error(error.stack));
 }
 
 async function runHttpServiceAsync(

--- a/src/runners/order_watcher_service_runner.ts
+++ b/src/runners/order_watcher_service_runner.ts
@@ -27,7 +27,7 @@ if (require.main === module) {
             );
             process.exit(1);
         }
-    })().catch(error => logger.error(error));
+    })().catch(error => logger.error(error.stack));
 }
 process.on('uncaughtException', err => {
     logger.error(err);

--- a/src/utils/mesh_utils.ts
+++ b/src/utils/mesh_utils.ts
@@ -12,6 +12,8 @@ import { ValidationErrorCodes } from '../errors';
 import { logger } from '../logger';
 import { AddedRemovedUpdate, APIOrderWithMetaData } from '../types';
 
+import { orderUtils } from './order_utils';
+
 export const meshUtils = {
     orderInfosToApiOrders: (
         orderEvent: Array<OrderEvent | AcceptedOrderInfo | RejectedOrderInfo | OrderInfo>,
@@ -25,7 +27,7 @@ export const meshUtils = {
             ? (orderEvent as OrderEvent).fillableTakerAssetAmount
             : ZERO;
         return {
-            order: orderEvent.signedOrder,
+            order: orderUtils.deserializeOrder(orderEvent.signedOrder as any), // tslint:disable-line:no-unnecessary-type-assertion
             metaData: {
                 orderHash: orderEvent.orderHash,
                 remainingFillableTakerAssetAmount,

--- a/src/utils/mesh_utils.ts
+++ b/src/utils/mesh_utils.ts
@@ -27,6 +27,7 @@ export const meshUtils = {
             ? (orderEvent as OrderEvent).fillableTakerAssetAmount
             : ZERO;
         return {
+            // orderEvent.signedOrder comes from mesh with string fields, needs to be serialized into SignedOrder
             order: orderUtils.deserializeOrder(orderEvent.signedOrder as any), // tslint:disable-line:no-unnecessary-type-assertion
             metaData: {
                 orderHash: orderEvent.orderHash,

--- a/src/utils/order_utils.ts
+++ b/src/utils/order_utils.ts
@@ -113,7 +113,7 @@ export const orderUtils = {
         expirationBufferSeconds: number = SRA_ORDER_EXPIRATION_BUFFER_SECONDS,
     ): boolean => {
         const dateNowSeconds = Date.now() / ONE_SECOND_MS;
-        return apiOrder.order.expirationTimeSeconds.gt(dateNowSeconds + expirationBufferSeconds);
+        return apiOrder.order.expirationTimeSeconds.toNumber() > dateNowSeconds + expirationBufferSeconds;
     },
     groupByFreshness: <T extends APIOrder>(
         apiOrders: T[],


### PR DESCRIPTION
`BigNumber` fields in `SignedOrder` were not being cast and instead were being passed around as `number` primitives, leading to failures when calling `.gt()`. This PR calls `>` instead of `.gt()`. 

Also start logging `error.stack` instead of `error` everywhere. Logging `error` shows up as `Error [[Object object]]` whereas `error.stack` is informative.

successful deploy and OrderWatcherService sync logs here: https://kibana.mesh.0x.org/goto/05c2f0125ec0772142300e7d7cc3f69d