### PR TITLE
Extended buyAmount sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
         "prettier_target": "{.,test/**,src/**}/*.{ts,tsx,json,md}"
     },
     "resolutions": {
-        "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-110e1afa8",
-        "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-0e196a59d"
+        "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-a458e81f8",
+        "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-a458e81f8"
     },
     "devDependencies": {
         "@0x/dev-utils": "^3.1.1",
@@ -66,10 +66,10 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-110e1afa8",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-a458e81f8",
         "@0x/connect": "^6.0.4",
-        "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-110e1afa8",
-        "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-0e196a59d",
+        "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-a458e81f8",
+        "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-a458e81f8",
         "@0x/json-schemas": "^5.0.4",
         "@0x/mesh-rpc-client": "^9.2.1",
         "@0x/order-utils": "^10.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,9 +32,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-110e1afa8":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-a458e81f8":
   version "4.4.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/210a8bc61dda466b8f364d621d45a33fb1416360"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/d0225b6a18705e14ed5efa1a65670a3b7cefe556"
   dependencies:
     "@0x/assert" "^3.0.7"
     "@0x/contract-addresses" "^4.9.0"
@@ -95,13 +95,13 @@
     uuid "^3.3.2"
     websocket "^1.0.26"
 
-"@0x/contract-addresses@0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-110e1afa8", "@0x/contract-addresses@^4.9.0":
+"@0x/contract-addresses@0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-a458e81f8", "@0x/contract-addresses@^4.9.0":
   version "4.9.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/93578492c2db18a5fb88709156fe50aa00b086aa"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/968819537f0b3266e7c8d2de2ae810dca4b503eb"
 
-"@0x/contract-wrappers@0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-0e196a59d", "@0x/contract-wrappers@^13.4.0", "@0x/contract-wrappers@^13.6.3":
+"@0x/contract-wrappers@0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-a458e81f8", "@0x/contract-wrappers@^13.4.0", "@0x/contract-wrappers@^13.6.3":
   version "13.6.3"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/8bc7a7ffe50b0c4c345d49aa979af9a6f8738b4c"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/a0e131fc683042811b1944e9ab94caaaada89e8b"
   dependencies:
     "@0x/assert" "^3.0.7"
     "@0x/base-contract" "^6.2.1"
@@ -180,7 +180,6 @@
 "@0x/mesh-rpc-client@^9.2.1":
   version "9.2.1"
   resolved "https://registry.yarnpkg.com/@0x/mesh-rpc-client/-/mesh-rpc-client-9.2.1.tgz#52540e2492e8c3a5c54127532e80f7ffb622fbea"
-  integrity sha512-VuAt8J1RpY4s2nCyfLIpPLTTLiYX0Wg0R7b+OT0B1p4JahrEcbfklHAyJM8YOT78wIllWeeTWDZ7/PL9EYPpTA==
   dependencies:
     "@0x/assert" "^3.0.6"
     "@0x/types" "^3.1.2"
@@ -1049,7 +1048,6 @@ aws4@^1.8.0:
 axios-mock-adapter@^1.18.1:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.18.1.tgz#a2ba2638ef513d954793f96bde3e26bd4a1b7940"
-  integrity sha512-kFBZsG1Ma5yxjRGHq5KuuL55mPb7WzFULhypquEhzPg8SH5CXICb+qwC2CCA5u+GQVpiqGPwKSRkd3mBCs6gdw==
   dependencies:
     fast-deep-equal "^3.1.1"
     is-buffer "^2.0.3"
@@ -4185,7 +4183,6 @@ is-buffer@^1.1.5:
 is-buffer@^2.0.3, is-buffer@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
-  integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
 is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.1.5:
   version "1.1.5"
@@ -4887,7 +4884,6 @@ make-iterator@^1.0.0:
 make-promises-safe@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/make-promises-safe/-/make-promises-safe-5.1.0.tgz#dd9d311f555bcaa144f12e225b3d37785f0aa8f2"
-  integrity sha512-AfdZ49rtyhQR/6cqVKGoH7y4ql7XkS5HJI1lZm0/5N6CQosy1eYbBJ/qbhkKHzo17UH7M918Bysf6XB9f3kS1g==
 
 map-cache@^0.2.0, map-cache@^0.2.2:
   version "0.2.2"
@@ -6229,7 +6225,6 @@ ret@~0.1.10:
 retry-axios@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/retry-axios/-/retry-axios-2.1.2.tgz#78a8041bc34047a205aa4098af23f943ec58abd2"
-  integrity sha512-MVNOizOgcM+dXK/kJCMnHPCGjp2Z0o3Ngznh7SfJkIVrqemHmDcgUEAbEHs3RyR3lbJtSyamq9k3gmgGSaow1g==
 
 rimraf@^2.6.3:
   version "2.7.1"


### PR DESCRIPTION
Adds additional sources when `buyAmount` is used as an API parameter. Previously Kyber and Curve were not used. 

Now Curve has support for exact sampling of buy amounts. For Kyber we approximate with a 5bps tolerance.