### PR TITLE
uint8 is decoded as number

### DIFF
--- a/src/utils/service_utils.ts
+++ b/src/utils/service_utils.ts
@@ -99,7 +99,7 @@ export const serviceUtils = {
             const encodedCallData = decimalsEncoder.encode(tokenAddress);
             try {
                 const result = await web3Wrapper.callAsync({ data: encodedCallData, to: tokenAddress });
-                decimals = decimalsEncoder.strictDecodeReturnValue<BigNumber>(result).toNumber();
+                decimals = decimalsEncoder.strictDecodeReturnValue<number>(result);
                 logger.info(`Unmapped token decimals ${tokenAddress} ${decimals}`);
             } catch (err) {
                 logger.warn(`Error fetching token decimals ${tokenAddress}`);


### PR DESCRIPTION
When `uint8` is used as an output it is decoded as `number` not `BigNumber`