### PR TITLE
Make axios retryable only when desired

### DIFF
--- a/src/utils/axios_utils.ts
+++ b/src/utils/axios_utils.ts
@@ -3,9 +3,6 @@ import * as rax from 'retry-axios';
 
 import { logger } from '../logger';
 
-// Attach retry-axios to the global instance
-rax.attach();
-
 const DEFAULT_RETRY_CONFIG: rax.RetryConfig = {
     // Retry 3 times
     retry: 3,
@@ -21,12 +18,16 @@ const DEFAULT_RETRY_CONFIG: rax.RetryConfig = {
     },
 };
 
-export const axios = (config: AxiosRequestConfig): AxiosPromise => {
-    return Axios({
+const retryableAxiosInstance = Axios.create();
+export const retryableAxios = (config: AxiosRequestConfig): AxiosPromise => {
+    return retryableAxiosInstance({
         ...config,
         raxConfig: {
+            instance: retryableAxiosInstance,
             ...DEFAULT_RETRY_CONFIG,
             ...config.raxConfig,
         },
     });
 };
+// Attach retry-axios to the global instance
+rax.attach(retryableAxiosInstance);

--- a/src/utils/axios_utils.ts
+++ b/src/utils/axios_utils.ts
@@ -29,5 +29,5 @@ export const retryableAxios = (config: AxiosRequestConfig): AxiosPromise => {
         },
     });
 };
-// Attach retry-axios to the global instance
+// Attach retry-axios only to our specific instance
 rax.attach(retryableAxiosInstance);

--- a/src/utils/mesh_client.ts
+++ b/src/utils/mesh_client.ts
@@ -13,7 +13,7 @@ import * as _ from 'lodash';
 import { MESH_ORDERS_BATCH_HTTP_BYTE_LENGTH, MESH_ORDERS_BATCH_SIZE } from '../constants';
 import { logger } from '../logger';
 
-import { axios } from './axios_utils';
+import { retryableAxios } from './axios_utils';
 import { utils } from './utils';
 
 export class MeshClient extends WSClient {
@@ -43,7 +43,7 @@ export class MeshClient extends WSClient {
                 try {
                     const startTime = Date.now();
                     // send the request
-                    const response = await axios({
+                    const response = await retryableAxios({
                         method: 'post',
                         url: this.httpURI,
                         data,


### PR DESCRIPTION
Change retry-axios to only apply to an explicit instance, instead of being on the global Axios object.

This fixes the code so RFQT requests are not retried