### PR TITLE
[meta-txn] Remove nonce

### DIFF
--- a/src/handlers/signer_handlers.ts
+++ b/src/handlers/signer_handlers.ts
@@ -70,7 +70,6 @@ export class SignerHandlers {
                         gas: ethereumTxn.gas,
                         value: ethereumTxn.value,
                         to: ethereumTxn.to,
-                        nonce: ethereumTxn.nonce,
                     },
                 });
             }


### PR DESCRIPTION
We accidentally return the nonce with the unsigned Ethereum txn when we shouldn't.