### PR TITLE
fix: Clip Native Order penalty

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-6063854d0",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-b34edcbf8",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-a458e81f8",
         "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-a458e81f8",

--- a/test/app_test.ts
+++ b/test/app_test.ts
@@ -472,11 +472,15 @@ describe(SUITE_NAME, () => {
                                         proportion: '0',
                                     },
                                     {
-                                        name: 'LiquidityProvider',
+                                        name: 'Curve_USDC_DAI_USDT_BUSD',
                                         proportion: '0',
                                     },
                                     {
-                                        name: 'Curve_USDC_DAI_USDT_BUSD',
+                                        name: 'Curve_USDC_DAI_USDT_SUSD',
+                                        proportion: '0',
+                                    },
+                                    {
+                                        name: 'LiquidityProvider',
                                         proportion: '0',
                                     },
                                 ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,9 +32,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-6063854d0":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-b34edcbf8":
   version "4.4.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/d2cd5459eaa84d0633b4be92d9ae792c1eabbecc"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/cafb0266b3c31762d944802018d404484f1105ba"
   dependencies:
     "@0x/assert" "^3.0.7"
     "@0x/contract-addresses" "^4.9.0"


### PR DESCRIPTION
https://github.com/0xProject/0x-monorepo/pull/2565

Native Orders which are perfectly sized to the target amount should not be penalised more than a larger order.