### PR TITLE
fix: Log 0x api key

### DIFF
--- a/src/middleware/request_logger.ts
+++ b/src/middleware/request_logger.ts
@@ -25,6 +25,7 @@ export function requestLogger(): core.RequestHandler {
                     url: req.originalUrl.split('?')[0],
                     method: req.method,
                     headers: {
+                        '0x-api-key': req.headers['0x-api-key'],
                         'user-agent': req.headers['user-agent'],
                         host: req.headers.host,
                         referer: req.headers.referer,


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/210914/80547379-e2a29300-896c-11ea-9606-b0eafc6ad634.png)


We feel comfortable having this API key in our logs, and it's very useful to have in Kibana.