### PR TITLE
fix: Prune Taker fees in Maker asset

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
         "prettier_target": "{.,test/**,src/**}/*.{ts,tsx,json,md}"
     },
     "resolutions": {
-        "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-a458e81f8",
-        "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-a458e81f8"
+        "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-49e4ade66",
+        "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-49e4ade66"
     },
     "devDependencies": {
         "@0x/dev-utils": "^3.1.1",
@@ -69,10 +69,10 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-b34edcbf8",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-49e4ade66",
         "@0x/connect": "^6.0.4",
-        "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-a458e81f8",
-        "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-a458e81f8",
+        "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-49e4ade66",
+        "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-49e4ade66",
         "@0x/contracts-dev-utils": "0xProject/gitpkg-registry#0x-contracts-dev-utils-v1.3.3-110e1afa8",
         "@0x/json-schemas": "^5.0.4",
         "@0x/mesh-rpc-client": "^9.2.1",

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -55,10 +55,7 @@ export class SwapService {
                 makerEndpoints: RFQT_MAKER_ENDPOINTS,
                 warningLogger: logger.warn.bind(logger),
             },
-            permittedOrderFeeTypes: new Set([
-                OrderPrunerPermittedFeeTypes.NoFees,
-                OrderPrunerPermittedFeeTypes.TakerDenominatedTakerFee,
-            ]),
+            permittedOrderFeeTypes: new Set([OrderPrunerPermittedFeeTypes.NoFees]),
         };
         this._swapQuoter = new SwapQuoter(this._provider, orderbook, swapQuoterOpts);
         this._swapQuoteConsumer = new SwapQuoteConsumer(this._provider, swapQuoterOpts);

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -6,6 +6,7 @@ import {
     SwapQuoter,
     SwapQuoterOpts,
 } from '@0x/asset-swapper';
+import { OrderPrunerPermittedFeeTypes } from '@0x/asset-swapper/lib/src/types';
 import { getContractAddressesForChainOrThrow } from '@0x/contract-addresses';
 import { WETH9Contract } from '@0x/contract-wrappers';
 import { assetDataUtils, SupportedProvider } from '@0x/order-utils';
@@ -54,6 +55,10 @@ export class SwapService {
                 makerEndpoints: RFQT_MAKER_ENDPOINTS,
                 warningLogger: logger.warn.bind(logger),
             },
+            permittedOrderFeeTypes: new Set([
+                OrderPrunerPermittedFeeTypes.NoFees,
+                OrderPrunerPermittedFeeTypes.TakerDenominatedTakerFee,
+            ]),
         };
         this._swapQuoter = new SwapQuoter(this._provider, orderbook, swapQuoterOpts);
         this._swapQuoteConsumer = new SwapQuoteConsumer(this._provider, swapQuoterOpts);

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,9 +32,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-b34edcbf8":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-49e4ade66":
   version "4.4.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/cafb0266b3c31762d944802018d404484f1105ba"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/1d7f8ae2e7ec8e11a1645ef5b4470999ed171a08"
   dependencies:
     "@0x/assert" "^3.0.7"
     "@0x/contract-addresses" "^4.9.0"
@@ -95,13 +95,13 @@
     uuid "^3.3.2"
     websocket "^1.0.26"
 
-"@0x/contract-addresses@0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-a458e81f8", "@0x/contract-addresses@^4.9.0":
+"@0x/contract-addresses@0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-49e4ade66", "@0x/contract-addresses@^4.9.0":
   version "4.9.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/968819537f0b3266e7c8d2de2ae810dca4b503eb"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/e1859ac60bb09e39822f427e7c5cbdd692d61715"
 
-"@0x/contract-wrappers@0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-a458e81f8", "@0x/contract-wrappers@^13.4.0", "@0x/contract-wrappers@^13.6.3":
+"@0x/contract-wrappers@0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-49e4ade66", "@0x/contract-wrappers@^13.4.0", "@0x/contract-wrappers@^13.6.3":
   version "13.6.3"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/a0e131fc683042811b1944e9ab94caaaada89e8b"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/233dd3d6abf75b00d2ff95f5de8cc75d135c9f47"
   dependencies:
     "@0x/assert" "^3.0.7"
     "@0x/base-contract" "^6.2.1"


### PR DESCRIPTION
Asset-swapper cannot currently determine that the taker (if provided) has the ability to pay the taker fee in the maker asset. This is guaranteed by the balance, but is not guaranteed by the allowance of the taker.

Also updates the Kovan ERC20BridgeSampler address. https://github.com/0xProject/0x-monorepo/pull/2570