### PR TITLE
feat: RFQ-T follow-ups

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "clean:ts": "shx rm -rf lib",
         "clean:docker": "shx rm -rf 0x_mesh/db",
         "build": "tsc -p tsconfig.json",
-        "test": "ETHEREUM_RPC_URL=http://localhost:8545 CHAIN_ID=1337 RFQT_API_KEY_WHITELIST='koolApiKey1,koolApikey2' RFQT_MAKER_ENDPOINTS='https://mock-rfqt1.club' META_TXN_RELAY_ADDRESS=0x9eFCa436873b55a0d6AEa260f92DE50150360dca META_TXN_RELAY_PRIVATE_KEY=82b9c3b8d45f608badd8fda250a0d95088381540e850734519b659e1e1ac3e71 mocha --require source-map-support/register --require make-promises-safe lib/test/**/*_test.js --timeout 200000 --exit",
+        "test": "ETHEREUM_RPC_URL=http://localhost:8545 CHAIN_ID=1337 RFQT_API_KEY_WHITELIST='koolApiKey1,koolApikey2' RFQT_MAKER_ASSET_OFFERINGS='{\"https://mock-rfqt1.club\": [[\"0x871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c\",\"0x0b1ba0af832d7c05fd64161e0db78e85978e8082\"]]}' META_TXN_RELAY_ADDRESS=0x9eFCa436873b55a0d6AEa260f92DE50150360dca META_TXN_RELAY_PRIVATE_KEY=82b9c3b8d45f608badd8fda250a0d95088381540e850734519b659e1e1ac3e71 mocha --require source-map-support/register --require make-promises-safe lib/test/**/*_test.js --timeout 200000 --exit",
         "dev": "nodemon -r dotenv/config src/index.ts | pino-pretty",
         "dev:service:http": "nodemon -r dotenv/config src/runners/http_service_runner.ts | pino-pretty",
         "dev:service:sra_http": "nodemon -r dotenv/config src/runners/http_sra_service_runner.ts | pino-pretty",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-49e4ade66",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-ff1811ef9",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-49e4ade66",
         "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-49e4ade66",

--- a/src/config.ts
+++ b/src/config.ts
@@ -333,6 +333,10 @@ function assertEnvVarType(name: string, value: any, expectedType: EnvVarType): a
                         `second token address for asset pair ${i} for maker endpoint ${makerEndpoint}`,
                         assetPair[1],
                     );
+                    assert.assert(
+                        assetPair[0] !== assetPair[1],
+                        `asset pair array ${i} for maker endpoint ${makerEndpoint} has identical assets`,
+                    );
                 });
             }
             return offerings;

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ import {
     DEFAULT_LOCAL_POSTGRES_URI,
     DEFAULT_LOGGER_INCLUDE_TIMESTAMP,
     DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE,
+    DEFAULT_RFQT_SKIP_BUY_REQUESTS,
     NULL_ADDRESS,
     NULL_BYTES,
 } from './constants';
@@ -161,6 +162,11 @@ export const RFQT_MAKER_ASSET_OFFERINGS: RfqtMakerAssetOfferings = _.isEmpty(pro
           process.env.RFQT_MAKER_ASSET_OFFERINGS,
           EnvVarType.RfqtMakerAssetOfferings,
       );
+
+// tslint:disable-next-line:boolean-naming
+export const RFQT_SKIP_BUY_REQUESTS: boolean = _.isEmpty(process.env.RFQT_SKIP_BUY_REQUESTS)
+    ? DEFAULT_RFQT_SKIP_BUY_REQUESTS
+    : assertEnvVarType('RFQT_SKIP_BUY_REQUESTS', process.env.RFQT_SKIP_BUY_REQUESTS, EnvVarType.Boolean);
 
 // Whitelisted 0x API keys that can use the meta-txn /submit endpoint
 export const WHITELISTED_API_KEYS_META_TXN_SUBMIT: string[] =

--- a/src/config.ts
+++ b/src/config.ts
@@ -150,8 +150,9 @@ export const LIQUIDITY_POOL_REGISTRY_ADDRESS: string | undefined = _.isEmpty(
           EnvVarType.ETHAddressHex,
       );
 
-export const RFQT_API_KEY_WHITELIST: string[] =
-    process.env.RFQT_API_KEY_WHITELIST === undefined ? [] : process.env.RFQT_API_KEY_WHITELIST.split(',');
+export const RFQT_API_KEY_WHITELIST: string[] = _.isEmpty(process.env.RFQT_API_KEY_WHITELIST)
+    ? []
+    : assertEnvVarType('RFQT_API_KEY_WHITELIST', process.env.RFQT_API_KEY_WHITELIST, EnvVarType.StringList);
 
 export const RFQT_MAKER_ASSET_OFFERINGS: RfqtMakerAssetOfferings = _.isEmpty(process.env.RFQT_MAKER_ASSET_OFFERINGS)
     ? {}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,6 +36,7 @@ export const PROTOCOL_FEE_UTILS_POLLING_INTERVAL_IN_MS = 6000;
 export const UNWRAP_QUOTE_GAS = new BigNumber(60000);
 export const WRAP_QUOTE_GAS = new BigNumber(40000);
 export const ONE_GWEI = new BigNumber(1000000000);
+export const DEFAULT_RFQT_SKIP_BUY_REQUESTS = true;
 
 // API namespaces
 export const SRA_PATH = '/sra/v3';

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -51,7 +51,18 @@ export class SwapHandlers {
         const params = parseGetSwapQuoteRequestParams(req, 'price');
         params.skipValidation = true;
         const quote = await this._calculateSwapQuoteAsync(params);
-        const { price, value, gasPrice, gas, protocolFee, buyAmount, sellAmount, sources } = quote;
+        const { price, value, gasPrice, gas, protocolFee, buyAmount, sellAmount, sources, orders } = quote;
+        logger.info({
+            indicativeQuoteServed: {
+                taker: params.takerAddress,
+                apiKey: params.apiKey,
+                buyToken: params.buyToken,
+                sellToken: params.sellToken,
+                buyAmount: params.buyAmount,
+                sellAmount: params.sellAmount,
+                makers: orders.map(o => o.makerAddress),
+            },
+        });
         res.status(HttpStatus.OK).send({ price, value, gasPrice, gas, protocolFee, buyAmount, sellAmount, sources });
     }
     // tslint:disable-next-line:prefer-function-over-method

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -20,6 +20,7 @@ import {
     LIQUIDITY_POOL_REGISTRY_ADDRESS,
     RFQT_API_KEY_WHITELIST,
     RFQT_MAKER_ASSET_OFFERINGS,
+    RFQT_SKIP_BUY_REQUESTS,
 } from '../config';
 import {
     GAS_LIMIT_BUFFER_PERCENTAGE,
@@ -53,6 +54,7 @@ export class SwapService {
             rfqt: {
                 takerApiKeyWhitelist: RFQT_API_KEY_WHITELIST,
                 makerAssetOfferings: RFQT_MAKER_ASSET_OFFERINGS,
+                skipBuyRequests: RFQT_SKIP_BUY_REQUESTS,
                 warningLogger: logger.warn.bind(logger),
                 infoLogger: logger.info.bind(logger),
             },

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -19,7 +19,7 @@ import {
     CHAIN_ID,
     LIQUIDITY_POOL_REGISTRY_ADDRESS,
     RFQT_API_KEY_WHITELIST,
-    RFQT_MAKER_ENDPOINTS,
+    RFQT_MAKER_ASSET_OFFERINGS,
 } from '../config';
 import {
     GAS_LIMIT_BUFFER_PERCENTAGE,
@@ -52,7 +52,7 @@ export class SwapService {
             liquidityProviderRegistryAddress: LIQUIDITY_POOL_REGISTRY_ADDRESS,
             rfqt: {
                 takerApiKeyWhitelist: RFQT_API_KEY_WHITELIST,
-                makerEndpoints: RFQT_MAKER_ENDPOINTS,
+                makerAssetOfferings: RFQT_MAKER_ASSET_OFFERINGS,
                 warningLogger: logger.warn.bind(logger),
                 infoLogger: logger.info.bind(logger),
             },

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -54,6 +54,7 @@ export class SwapService {
                 takerApiKeyWhitelist: RFQT_API_KEY_WHITELIST,
                 makerEndpoints: RFQT_MAKER_ENDPOINTS,
                 warningLogger: logger.warn.bind(logger),
+                infoLogger: logger.info.bind(logger),
             },
             permittedOrderFeeTypes: new Set([OrderPrunerPermittedFeeTypes.NoFees]),
         };

--- a/src/types.ts
+++ b/src/types.ts
@@ -435,6 +435,7 @@ export interface CalculateSwapQuoteParams {
     rfqt?: {
         intentOnFilling?: boolean;
         isIndicative?: boolean;
+        skipBuyRequests?: boolean;
     };
     skipValidation: boolean;
 }

--- a/test/utils/deployment.ts
+++ b/test/utils/deployment.ts
@@ -206,6 +206,6 @@ async function waitForDependencyStartupAsync(logStream: ChildProcessWithoutNullS
         });
         setTimeout(() => {
             reject(new Error('Timed out waiting for dependency logs'));
-        }, 180000); // tslint:disable-line:custom-no-magic-numbers
+        }, 300000); // tslint:disable-line:custom-no-magic-numbers
     });
 }

--- a/test/utils/deployment.ts
+++ b/test/utils/deployment.ts
@@ -206,6 +206,6 @@ async function waitForDependencyStartupAsync(logStream: ChildProcessWithoutNullS
         });
         setTimeout(() => {
             reject(new Error('Timed out waiting for dependency logs'));
-        }, 60000); // tslint:disable-line:custom-no-magic-numbers
+        }, 100000); // tslint:disable-line:custom-no-magic-numbers
     });
 }

--- a/test/utils/deployment.ts
+++ b/test/utils/deployment.ts
@@ -206,6 +206,6 @@ async function waitForDependencyStartupAsync(logStream: ChildProcessWithoutNullS
         });
         setTimeout(() => {
             reject(new Error('Timed out waiting for dependency logs'));
-        }, 100000); // tslint:disable-line:custom-no-magic-numbers
+        }, 120000); // tslint:disable-line:custom-no-magic-numbers
     });
 }

--- a/test/utils/mocks.ts
+++ b/test/utils/mocks.ts
@@ -24,4 +24,5 @@ export const rfqtIndicativeQuoteResponse = {
     takerAssetAmount: '100000000000000000',
     makerAssetData: '0xf47261b0000000000000000000000000871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c',
     takerAssetData: '0xf47261b00000000000000000000000000b1ba0af832d7c05fd64161e0db78e85978e8082',
+    expirationTimeSeconds: '1903620548', // in the year 2030
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,9 +32,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-49e4ade66":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-ff1811ef9":
   version "4.4.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/1d7f8ae2e7ec8e11a1645ef5b4470999ed171a08"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/64535d1f229d124c2d57102f6a9d28a9e94cc820"
   dependencies:
     "@0x/assert" "^3.0.7"
     "@0x/contract-addresses" "^4.9.0"


### PR DESCRIPTION
Lots of tasks that needed doing after the initial implementation of RFQ-T. I recommend reviewing commit by commit.

Depends on https://github.com/0xProject/0x-monorepo/pull/2574

-   [x] Test on staging, exercising the new `RFQT_MAKER_ASSET_OFFERINGS` environment variable scheme.
-   [x] Re-pin asset-swapper to monorepo `development`-branch commit, after https://github.com/0xProject/0x-monorepo/pull/2574 merges. (Currently this is pinned to a commit in that PR's branch).