### PR TITLE
feat: Added pool breakdown of operator vs member stake, added option to add…

### DIFF
--- a/src/handlers/staking_handlers.ts
+++ b/src/handlers/staking_handlers.ts
@@ -46,7 +46,7 @@ export class StakingHandlers {
             if (!(_req.query.withFees === 'true' || _req.query.withFees === 'false')) {
                 res.status(HttpStatus.BAD_REQUEST).send(`Invalid value for withFees`);
             }
-            isWithFees = (_req.query.withFees === 'true');
+            isWithFees = _req.query.withFees === 'true';
         } else {
             isWithFees = false;
         }
@@ -63,8 +63,8 @@ export class StakingHandlers {
             };
         } else {
             const [currentEpoch, nextEpoch] = await Promise.all([
-            this._stakingDataService.getCurrentEpochAsync(),
-            this._stakingDataService.getNextEpochAsync(),
+                this._stakingDataService.getCurrentEpochAsync(),
+                this._stakingDataService.getNextEpochAsync(),
             ]);
             response = {
                 currentEpoch,

--- a/src/handlers/staking_handlers.ts
+++ b/src/handlers/staking_handlers.ts
@@ -1,6 +1,7 @@
 import * as express from 'express';
 import * as HttpStatus from 'http-status-codes';
 
+import { schemas } from '../schemas/schemas';
 import { StakingDataService } from '../services/staking_data_service';
 import {
     StakingDelegatorResponse,
@@ -10,6 +11,7 @@ import {
     StakingPoolsResponse,
     StakingStatsResponse,
 } from '../types';
+import { schemaUtils } from '../utils/schema_utils';
 
 export class StakingHandlers {
     private readonly _stakingDataService: StakingDataService;
@@ -39,17 +41,10 @@ export class StakingHandlers {
 
         res.status(HttpStatus.OK).send(response);
     }
-    public async getStakingEpochsAsync(_req: express.Request, res: express.Response): Promise<void> {
+    public async getStakingEpochsAsync(req: express.Request, res: express.Response): Promise<void> {
         // optional query string to include fees
-        let isWithFees: boolean;
-        if (_req.query.withFees) {
-            if (!(_req.query.withFees === 'true' || _req.query.withFees === 'false')) {
-                res.status(HttpStatus.BAD_REQUEST).send(`Invalid value for withFees`);
-            }
-            isWithFees = _req.query.withFees === 'true';
-        } else {
-            isWithFees = false;
-        }
+        schemaUtils.validateSchema(req.query, schemas.stakingEpochRequestSchema as any);
+        const isWithFees = req.query.withFees ? req.query.withFees === 'true' : false;
 
         let response: StakingEpochsResponse | StakingEpochsWithFeesResponse;
         if (isWithFees) {

--- a/src/schemas/schemas.ts
+++ b/src/schemas/schemas.ts
@@ -1,6 +1,7 @@
 import * as metaTransactionFillRequestSchema from './meta_transaction_fill_request_schema.json';
 import * as metaTransactionQuoteRequestSchema from './meta_transaction_quote_request_schema.json';
 import * as sraPostOrderRequestSchema from './sra_post_order_request_schema.json';
+import * as stakingEpochRequestSchema from './staking_epoch_request_schema.json';
 import * as swapQuoteRequestSchema from './swap_quote_request_schema.json';
 
 export const schemas = {
@@ -8,4 +9,5 @@ export const schemas = {
     sraPostOrderRequestSchema,
     metaTransactionFillRequestSchema,
     metaTransactionQuoteRequestSchema,
+    stakingEpochRequestSchema,
 };

--- a/src/schemas/staking_epoch_request_schema.json
+++ b/src/schemas/staking_epoch_request_schema.json
@@ -1,0 +1,11 @@
+{
+    "id": "/StakingEpochRequestSchema",
+    "properties": {
+        "withFees": {
+            "type": "string",
+            "enum": ["true", "false"]
+        }
+    },
+    "required": [],
+    "type": "object"
+}

--- a/src/services/staking_data_service.ts
+++ b/src/services/staking_data_service.ts
@@ -44,7 +44,9 @@ export class StakingDataService {
     }
 
     public async getCurrentEpochWithFeesAsync(): Promise<EpochWithFees> {
-        const rawEpochWithFees: RawEpochWithFees | undefined = _.head(await this._connection.query(queries.currentEpochWithFeesQuery));
+        const rawEpochWithFees: RawEpochWithFees | undefined = _.head(
+            await this._connection.query(queries.currentEpochWithFeesQuery),
+        );
         if (!rawEpochWithFees) {
             throw new Error('Could not find the current epoch.');
         }

--- a/src/services/staking_data_service.ts
+++ b/src/services/staking_data_service.ts
@@ -10,6 +10,7 @@ import {
     DelegatorEvent,
     Epoch,
     EpochDelegatorStats,
+    EpochWithFees,
     Pool,
     PoolEpochRewards,
     PoolWithStats,
@@ -19,6 +20,7 @@ import {
     RawDelegatorEvent,
     RawDelegatorStaked,
     RawEpoch,
+    RawEpochWithFees,
     RawPool,
     RawPoolEpochRewards,
     RawPoolTotalProtocolFeesGenerated,
@@ -41,12 +43,30 @@ export class StakingDataService {
         return epoch;
     }
 
+    public async getCurrentEpochWithFeesAsync(): Promise<EpochWithFees> {
+        const rawEpochWithFees: RawEpochWithFees | undefined = _.head(await this._connection.query(queries.currentEpochWithFeesQuery));
+        if (!rawEpochWithFees) {
+            throw new Error('Could not find the current epoch.');
+        }
+        const epoch = stakingUtils.getEpochWithFeesFromRaw(rawEpochWithFees);
+        return epoch;
+    }
+
     public async getNextEpochAsync(): Promise<Epoch> {
         const rawEpoch: RawEpoch | undefined = _.head(await this._connection.query(queries.nextEpochQuery));
         if (!rawEpoch) {
-            throw new Error('Could not find the next current epoch.');
+            throw new Error('Could not find the next epoch.');
         }
         const epoch = stakingUtils.getEpochFromRaw(rawEpoch);
+        return epoch;
+    }
+
+    public async getNextEpochWithFeesAsync(): Promise<EpochWithFees> {
+        const rawEpoch: RawEpochWithFees | undefined = _.head(await this._connection.query(queries.nextEpochQuery));
+        if (!rawEpoch) {
+            throw new Error('Could not find the next epoch.');
+        }
+        const epoch = stakingUtils.getEpochWithFeesFromRaw(rawEpoch);
         return epoch;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,12 @@ export interface RawEpoch {
     zrx_staked?: string;
 }
 
+// Separating out the response with fees
+// As this is a significantly heavier query (it has to sum over fills)
+export interface RawEpochWithFees extends RawEpoch {
+    protocol_fees_generated_in_eth: string;
+}
+
 export interface TransactionDate {
     blockNumber: number;
     txHash: string;
@@ -87,6 +93,10 @@ export interface Epoch {
     epochEnd?: TransactionDate;
     zrxStaked: number;
     zrxDeposited: number;
+}
+
+export interface EpochWithFees extends Epoch {
+    protocolFeesGeneratedInEth: number;
 }
 
 export interface RawPool {
@@ -153,6 +163,8 @@ export interface RawEpochPoolStats {
     maker_addresses: string[];
     operator_share?: string;
     zrx_staked?: string;
+    operator_zrx_staked?: string;
+    member_zrx_staked?: string;
     total_staked?: string;
     share_of_stake?: string;
     total_protocol_fees_generated_in_eth?: string;
@@ -165,6 +177,8 @@ export interface RawEpochPoolStats {
 export interface EpochPoolStats {
     poolId: string;
     zrxStaked: number;
+    operatorZrxStaked: number;
+    memberZrxStaked: number;
     shareOfStake: number;
     operatorShare?: number;
     makerAddresses: string[];
@@ -290,6 +304,10 @@ export interface StakingDelegatorResponse {
 export interface StakingEpochsResponse {
     currentEpoch: Epoch;
     nextEpoch: Epoch;
+}
+export interface StakingEpochsWithFeesResponse {
+    currentEpoch: EpochWithFees;
+    nextEpoch: EpochWithFees;
 }
 export interface StakingStatsResponse {
     allTime: AllTimeStakingStats;

--- a/src/utils/staking_utils.ts
+++ b/src/utils/staking_utils.ts
@@ -7,6 +7,7 @@ import {
     DelegatorEvent,
     Epoch,
     EpochPoolStats,
+    EpochWithFees,
     Pool,
     PoolAvgRewards,
     PoolEpochDelegatorStats,
@@ -20,6 +21,7 @@ import {
     RawDelegatorStaked,
     RawEpoch,
     RawEpochPoolStats,
+    RawEpochWithFees,
     RawPool,
     RawPoolAvgRewards,
     RawPoolEpochRewards,
@@ -61,6 +63,40 @@ export const stakingUtils = {
             zrxStaked: Number(zrx_staked || 0),
         };
     },
+    getEpochWithFeesFromRaw: (rawEpochWithFees: RawEpochWithFees): EpochWithFees => {
+        const {
+            epoch_id,
+            starting_transaction_hash,
+            starting_block_number,
+            starting_block_timestamp,
+            ending_transaction_hash,
+            ending_block_number,
+            ending_block_timestamp,
+            zrx_deposited,
+            zrx_staked,
+            protocol_fees_generated_in_eth,
+        } = rawEpochWithFees;
+        let epochEnd: TransactionDate | undefined;
+        if (ending_transaction_hash && ending_block_number) {
+            epochEnd = {
+                blockNumber: parseInt(ending_block_number, 10),
+                txHash: ending_transaction_hash,
+                timestamp: ending_block_timestamp || undefined,
+            };
+        }
+        return {
+            epochId: parseInt(epoch_id, 10),
+            epochStart: {
+                blockNumber: parseInt(starting_block_number, 10),
+                txHash: starting_transaction_hash,
+                timestamp: starting_block_timestamp || undefined,
+            },
+            epochEnd,
+            zrxDeposited: Number(zrx_deposited || 0),
+            zrxStaked: Number(zrx_staked || 0),
+            protocolFeesGeneratedInEth: Number(protocol_fees_generated_in_eth || 0),
+        };
+    },
     getPoolFromRaw: (rawPool: RawPool): Pool => {
         const {
             pool_id,
@@ -100,6 +136,8 @@ export const stakingUtils = {
             maker_addresses,
             operator_share,
             zrx_staked,
+            operator_zrx_staked,
+            member_zrx_staked,
             share_of_stake,
             total_protocol_fees_generated_in_eth,
             share_of_fees,
@@ -110,6 +148,8 @@ export const stakingUtils = {
         return {
             poolId: pool_id,
             zrxStaked: Number(zrx_staked || 0),
+            operatorZrxStaked: Number(operator_zrx_staked || 0),
+            memberZrxStaked: Number(member_zrx_staked || 0),
             shareOfStake: Number(share_of_stake),
             operatorShare: _.isNil(operator_share) ? undefined : Number(operator_share),
             approximateStakeRatio: approximate_stake_ratio ? Number(approximate_stake_ratio) : 0,


### PR DESCRIPTION
… fees to epoch

Changes:
- Added an option to add fees to the epoch endpoint. Fees make the amount of data queried much larger, but they are useful for estimating rewards for an epoch.
- Added a breakdown of stake for the /pools endpoint between members and operator.

Testing:
- [x] Tested locally on Hashalytics

Dependencies:
https://github.com/0xProject/0x-event-pipeline/pull/24