### PR TITLE
feat: Support RFQT via Meta-txn Endpoints

### DIFF
--- a/src/handlers/meta_transaction_handlers.ts
+++ b/src/handlers/meta_transaction_handlers.ts
@@ -130,17 +130,20 @@ export class MetaTransactionHandlers {
         const sellTokenAddress = findTokenAddressOrThrowApiError(sellToken, 'sellToken', CHAIN_ID);
         const buyTokenAddress = findTokenAddressOrThrowApiError(buyToken, 'buyToken', CHAIN_ID);
         try {
-            const metaTransactionPrice = await this._metaTransactionService.calculateMetaTransactionPriceAsync({
-                takerAddress,
-                buyTokenAddress,
-                sellTokenAddress,
-                buyAmount,
-                sellAmount,
-                from: takerAddress,
-                slippagePercentage,
-                excludedSources,
-                apiKey,
-            }, 'price');
+            const metaTransactionPrice = await this._metaTransactionService.calculateMetaTransactionPriceAsync(
+                {
+                    takerAddress,
+                    buyTokenAddress,
+                    sellTokenAddress,
+                    buyAmount,
+                    sellAmount,
+                    from: takerAddress,
+                    slippagePercentage,
+                    excludedSources,
+                    apiKey,
+                },
+                'price',
+            );
             const metaTransactionPriceResponse = {
                 price: metaTransactionPrice.price,
                 buyAmount: metaTransactionPrice.buyAmount,

--- a/src/services/meta_transaction_service.ts
+++ b/src/services/meta_transaction_service.ts
@@ -37,6 +37,7 @@ export class MetaTransactionService {
     }
     public async calculateMetaTransactionPriceAsync(
         params: CalculateMetaTransactionQuoteParams,
+        endpoint: 'price' | 'quote',
     ): Promise<CalculateMetaTransactionPriceResponse> {
         const {
             takerAddress,
@@ -46,13 +47,24 @@ export class MetaTransactionService {
             sellTokenAddress,
             slippagePercentage,
             excludedSources,
+            apiKey,
         } = params;
 
+        let _rfqt;
+        if (apiKey !== undefined) {
+            _rfqt = {
+                intentOnFilling: endpoint === 'quote',
+                isIndicative: endpoint === 'price',
+                apiKey,
+                takerAddress,
+            };
+        }
         const assetSwapperOpts = {
             ...ASSET_SWAPPER_MARKET_ORDERS_OPTS,
             slippagePercentage,
             bridgeSlippage: slippagePercentage,
             excludedSources, // TODO(dave4506): overrides the excluded sources selected by chainId
+            rfqt: _rfqt,
         };
 
         let swapQuote;
@@ -107,6 +119,7 @@ export class MetaTransactionService {
     ): Promise<GetMetaTransactionQuoteResponse> {
         const { takerAddress, sellAmount, buyAmount, swapQuote, price } = await this.calculateMetaTransactionPriceAsync(
             params,
+            'quote',
         );
 
         const floatGasPrice = swapQuote.gasPrice;

--- a/src/types.ts
+++ b/src/types.ts
@@ -458,4 +458,5 @@ export interface CalculateMetaTransactionQuoteParams {
     from: string | undefined;
     slippagePercentage?: number;
     excludedSources?: ERC20BridgeSource[];
+    apiKey: string | undefined;
 }


### PR DESCRIPTION
This PR adds support for RFQT quotes via the meta-txn endpoints. More specifically it adds API Keys to meta-txn /price & /quote endpoints and pass RFQT opts into Asset-swapper in order for RFQT orders to surface.