### PR TITLE
fix: validate slippagePercentage <= 1

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -124,6 +124,9 @@ export enum ValidationErrorCodes {
     TokenNotSupported = 1009,
 }
 
+export enum ValidationErrorReasons {
+    PercentageOutOfRange = 'MUST_BE_LESS_THAN_OR_EQUAL_TO_ONE',
+}
 export abstract class AlertError {
     public abstract message: string;
     public shouldAlert: boolean = true;


### PR DESCRIPTION
If slippage percentage is > 1 (100%), throw an informative validation error.

The confusion over orders of magnitude (0.02 instead of 2 to mean "2%") has tripped us up a couple of times already.