### PR TITLE
feat: Improve RFQ-T logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # [1.3.0](https://github.com/0xProject/0x-api/compare/v1.2.0...v1.3.0) (2020-05-11)
 
-
 ### Features
 
-* Remove Kyber exclusion ([#211](https://github.com/0xProject/0x-api/issues/211)) ([aa600ab](https://github.com/0xProject/0x-api/commit/aa600abd74bb963303720d8a3cdf3b5f5044ae4f))
-* RFQ-T follow-ups ([#201](https://github.com/0xProject/0x-api/issues/201)) ([a55f22e](https://github.com/0xProject/0x-api/commit/a55f22ee866f0ce8a8e5164829bc511838019a47)), closes [/github.com/0xProject/0x-api/pull/201#discussion_r417775612](https://github.com//github.com/0xProject/0x-api/pull/201/issues/discussion_r417775612)
+-   Remove Kyber exclusion ([#211](https://github.com/0xProject/0x-api/issues/211)) ([aa600ab](https://github.com/0xProject/0x-api/commit/aa600abd74bb963303720d8a3cdf3b5f5044ae4f))
+-   RFQ-T follow-ups ([#201](https://github.com/0xProject/0x-api/issues/201)) ([a55f22e](https://github.com/0xProject/0x-api/commit/a55f22ee866f0ce8a8e5164829bc511838019a47)), closes [/github.com/0xProject/0x-api/pull/201#discussion_r417775612](https://github.com//github.com/0xProject/0x-api/pull/201/issues/discussion_r417775612)
 
 # [1.2.0](https://github.com/0xProject/0x-api/compare/v1.1.0...v1.2.0) (2020-05-04)
 

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-ff1811ef9",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-d9e13d6b9",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-fb0311e67",
         "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-fb0311e67",

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -37,9 +37,22 @@ export class SwapHandlers {
         this._swapService = swapService;
     }
     public async getSwapQuoteAsync(req: express.Request, res: express.Response): Promise<void> {
-        res.status(HttpStatus.OK).send(
-            await this._calculateSwapQuoteAsync(parseGetSwapQuoteRequestParams(req, 'quote')),
-        );
+        const params = parseGetSwapQuoteRequestParams(req, 'quote');
+        const quote = await this._calculateSwapQuoteAsync(params);
+        if (params.rfqt !== undefined) {
+            logger.info({
+                firmQuoteServed: {
+                    taker: params.takerAddress,
+                    apiKey: params.apiKey,
+                    buyToken: params.buyToken,
+                    sellToken: params.sellToken,
+                    buyAmount: params.buyAmount,
+                    sellAmount: params.sellAmount,
+                    makers: quote.orders.map(order => order.makerAddress),
+                },
+            });
+        }
+        res.status(HttpStatus.OK).send(quote);
     }
     // tslint:disable-next-line:prefer-function-over-method
     public async getSwapTokensAsync(_req: express.Request, res: express.Response): Promise<void> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,9 +32,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-ff1811ef9":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-d9e13d6b9":
   version "4.4.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/64535d1f229d124c2d57102f6a9d28a9e94cc820"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/8bf3e651d724a72912dee78cc1978a674b82b93c"
   dependencies:
     "@0x/assert" "^3.0.7"
     "@0x/contract-addresses" "^4.9.0"


### PR DESCRIPTION
# Description

Updates logging to support the operational monitoring of RFQ-T usage.

Re-pins to [an updated `asset-swapper`](https://github.com/0xProject/0x-monorepo/pull/2581) with similar changes.

<!--- Describe your changes in detail -->

# Testing Instructions

View new logging in output of existing (mocha) tests.  Below are some examples from the latest CI run of this PR.  For each text log entry I've included a nice visual rendering to go with it.

---

`{"level":"info","time":1589240068300,"pid":5145,"hostname":"e6c519a5c290","firmQuoteServed":{"taker":"0x6ecbe1db9ef729cbe972c83fb886247691fb6beb","apiKey":"koolApiKey1","buyToken":"ZRX","sellToken":"WETH","sellAmount":"100000000000000000","makers":["0x5409ED021D9299bf6814279A6A1411A7e866A631"]},"v":1}`
![image](https://user-images.githubusercontent.com/7883777/81622456-0b8c4480-93bf-11ea-8d49-f905ae7c5183.png)

---

`{"level":"info","time":1589240069170,"pid":5145,"hostname":"e6c519a5c290","indicativeQuoteServed":{"taker":"0x6ecbe1db9ef729cbe972c83fb886247691fb6beb","apiKey":"koolApiKey1","buyToken":"ZRX","sellToken":"WETH","sellAmount":"100000000000000000","makers":["0x0000000000000000000000000000000000000000"]},"v":1}`
![image](https://user-images.githubusercontent.com/7883777/81622492-2068d800-93bf-11ea-8639-5bf166cc95fa.png)

---

And for completion here's the rendering of the logs in that [asset swapper PR](https://github.com/0xProject/0x-monorepo/pull/2581):

---

`{"level":"info","time":1589240066372,"pid":5145,"hostname":"e6c519a5c290","rfqtMakerInteraction":{"url":"https://mock-rfqt1.club","quoteType":"firm","requestParams":{"takerAddress":"0x6ecbe1db9ef729cbe972c83fb886247691fb6beb","buyToken":"0x871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c","sellToken":"0x0b1ba0af832d7c05fd64161e0db78e85978e8082","sellAmount":"100000000000000000"},"response":{"statusCode":200,"latencyMs":4}},"v":1}`
![image](https://user-images.githubusercontent.com/7883777/81622535-35456b80-93bf-11ea-9284-179642099453.png)

---