### PR TITLE
fix: made the estimated starting block for the next epoch more accurate

### DIFF
--- a/src/queries/staking_queries.ts
+++ b/src/queries/staking_queries.ts
@@ -69,7 +69,8 @@ export const nextEpochQuery = `
     )
     SELECT
         ce.epoch_id + 1 AS epoch_id
-        , ce.starting_block_number + cp.epoch_duration_in_seconds::NUMERIC / 15::NUMERIC AS starting_block_number
+        -- approximate starting block number based on a 13-second block time
+        , (ce.starting_block_number + (cp.epoch_duration_in_seconds::NUMERIC / 13::NUMERIC))::BIGINT AS starting_block_number
         , ce.starting_block_timestamp + ((cp.epoch_duration_in_seconds)::VARCHAR || ' seconds')::INTERVAL AS starting_block_timestamp
         , zd.zrx_deposited
         , zs.zrx_staked


### PR DESCRIPTION
<!---
Fixed the block number for the start of the next epoch.
-->

# Description

Edited the staking query for next epoch to return a better approximate value.

# Testing Instructions

Tested on hashalytics.