### PR TITLE
fix: unify the response data from /swap/v0/price and /meta_transaction/v0/price

### DIFF
--- a/src/handlers/meta_transaction_handlers.ts
+++ b/src/handlers/meta_transaction_handlers.ts
@@ -23,7 +23,7 @@ import { logger } from '../logger';
 import { isAPIError, isRevertError } from '../middleware/error_handling';
 import { schemas } from '../schemas/schemas';
 import { MetaTransactionService } from '../services/meta_transaction_service';
-import { GetTransactionRequestParams, ZeroExTransactionWithoutDomain } from '../types';
+import { GetMetaTransactionPriceResponse, GetTransactionRequestParams, ZeroExTransactionWithoutDomain } from '../types';
 import { parseUtils } from '../utils/parse_utils';
 import { schemaUtils } from '../utils/schema_utils';
 import { findTokenAddressOrThrowApiError } from '../utils/token_metadata_utils';
@@ -147,12 +147,13 @@ export class MetaTransactionHandlers {
                 },
                 'price',
             );
-            const metaTransactionPriceResponse = {
+            const metaTransactionPriceResponse: GetMetaTransactionPriceResponse = {
                 price: metaTransactionPrice.price,
                 buyAmount: metaTransactionPrice.buyAmount,
                 sellAmount: metaTransactionPrice.sellAmount,
                 sellTokenAddress,
                 buyTokenAddress,
+                sources: metaTransactionPrice.sources,
             };
             res.status(HttpStatus.OK).send(metaTransactionPriceResponse);
         } catch (e) {

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -19,7 +19,7 @@ import { SwapService } from '../services/swap_service';
 import { TokenMetadatasForChains } from '../token_metadatas_for_networks';
 import {
     CalculateSwapQuoteParams,
-    GetSwapQuotePriceResponse,
+    GetSwapPriceResponse,
     GetSwapQuoteRequestParams,
     GetSwapQuoteResponse,
 } from '../types';
@@ -100,7 +100,7 @@ export class SwapHandlers {
             },
         });
 
-        const response: GetSwapQuotePriceResponse = {
+        const response: GetSwapPriceResponse = {
             price,
             value,
             gasPrice,

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -17,7 +17,12 @@ import { isAPIError, isRevertError } from '../middleware/error_handling';
 import { schemas } from '../schemas/schemas';
 import { SwapService } from '../services/swap_service';
 import { TokenMetadatasForChains } from '../token_metadatas_for_networks';
-import { CalculateSwapQuoteParams, GetSwapQuoteRequestParams, GetSwapQuoteResponse } from '../types';
+import {
+    CalculateSwapQuoteParams,
+    GetSwapQuotePriceResponse,
+    GetSwapQuoteRequestParams,
+    GetSwapQuoteResponse,
+} from '../types';
 import { parseUtils } from '../utils/parse_utils';
 import { schemaUtils } from '../utils/schema_utils';
 import {
@@ -70,7 +75,19 @@ export class SwapHandlers {
         const params = parseGetSwapQuoteRequestParams(req, 'price');
         params.skipValidation = true;
         const quote = await this._calculateSwapQuoteAsync(params);
-        const { price, value, gasPrice, gas, protocolFee, buyAmount, sellAmount, sources, orders } = quote;
+        const {
+            price,
+            value,
+            gasPrice,
+            gas,
+            protocolFee,
+            buyAmount,
+            sellAmount,
+            sources,
+            orders,
+            buyTokenAddress,
+            sellTokenAddress,
+        } = quote;
         logger.info({
             indicativeQuoteServed: {
                 taker: params.takerAddress,
@@ -82,7 +99,20 @@ export class SwapHandlers {
                 makers: orders.map(o => o.makerAddress),
             },
         });
-        res.status(HttpStatus.OK).send({ price, value, gasPrice, gas, protocolFee, buyAmount, sellAmount, sources });
+
+        const response: GetSwapQuotePriceResponse = {
+            price,
+            value,
+            gasPrice,
+            gas,
+            protocolFee,
+            buyTokenAddress,
+            buyAmount,
+            sellTokenAddress,
+            sellAmount,
+            sources,
+        };
+        res.status(HttpStatus.OK).send(response);
     }
     // tslint:disable-next-line:prefer-function-over-method
     public async getTokenPricesAsync(req: express.Request, res: express.Response): Promise<void> {

--- a/src/services/meta_transaction_service.ts
+++ b/src/services/meta_transaction_service.ts
@@ -138,8 +138,8 @@ export class MetaTransactionService {
 
         const response: CalculateMetaTransactionPriceResponse = {
             takerAddress,
-            sellAmount,
-            buyAmount,
+            buyAmount: makerAssetAmount,
+            sellAmount: totalTakerAssetAmount,
             price,
             swapQuote,
             sources: serviceUtils.convertSourceBreakdownToArray(swapQuote.sourceBreakdown),

--- a/src/types.ts
+++ b/src/types.ts
@@ -369,6 +369,22 @@ export interface Price {
     price: BigNumber;
 }
 
+interface BasePriceResponse {
+    price: BigNumber;
+    buyAmount: BigNumber;
+    sellAmount: BigNumber;
+    sellTokenAddress: string;
+    buyTokenAddress: string;
+    sources: GetSwapQuoteResponseLiquiditySource[];
+}
+
+export interface GetSwapQuotePriceResponse extends BasePriceResponse {
+    value: BigNumber;
+    gasPrice: BigNumber;
+    gas: BigNumber;
+    protocolFee: BigNumber;
+}
+
 export type GetTokenPricesResponse = Price[];
 
 export interface GetMetaTransactionQuoteResponse {
@@ -381,11 +397,7 @@ export interface GetMetaTransactionQuoteResponse {
     sources: GetSwapQuoteResponseLiquiditySource[];
 }
 
-export interface GetMetaTransactionPriceResponse {
-    price: BigNumber;
-    buyAmount: BigNumber;
-    sellAmount: BigNumber;
-}
+export interface GetMetaTransactionPriceResponse extends BasePriceResponse {}
 
 // takerAddress, sellAmount, buyAmount, swapQuote, price
 export interface CalculateMetaTransactionPriceResponse {

--- a/src/types.ts
+++ b/src/types.ts
@@ -378,7 +378,7 @@ interface BasePriceResponse {
     sources: GetSwapQuoteResponseLiquiditySource[];
 }
 
-export interface GetSwapQuotePriceResponse extends BasePriceResponse {
+export interface GetSwapPriceResponse extends BasePriceResponse {
     value: BigNumber;
     gasPrice: BigNumber;
     gas: BigNumber;

--- a/test/meta_transaction_test.ts
+++ b/test/meta_transaction_test.ts
@@ -213,6 +213,8 @@ describe(SUITE_NAME, () => {
 
         context('success tests', () => {
             let meshUtils: MeshTestUtils;
+            const price = '1';
+            const sellAmount = calculateSellAmount(buyAmount, price);
 
             beforeEach(async () => {
                 await blockchainLifecycle.startAsync();
@@ -240,8 +242,9 @@ describe(SUITE_NAME, () => {
                 expect(response.type).to.be.eq('application/json');
                 expect(response.status).to.be.eq(HttpStatus.OK);
                 expect(response.body).to.be.deep.eq({
-                    price: '1',
+                    price,
                     buyAmount,
+                    sellAmount,
                     sellTokenAddress,
                     buyTokenAddress,
                     sources: liquiditySources0xOnly,
@@ -262,8 +265,9 @@ describe(SUITE_NAME, () => {
                 expect(response.type).to.be.eq('application/json');
                 expect(response.status).to.be.eq(HttpStatus.OK);
                 expect(response.body).to.be.deep.eq({
-                    price: '1',
+                    price,
                     buyAmount,
+                    sellAmount,
                     sellTokenAddress,
                     buyTokenAddress,
                     sources: liquiditySources0xOnly,
@@ -273,7 +277,9 @@ describe(SUITE_NAME, () => {
             it('should show the price of the combination of the two orders in Mesh', async () => {
                 const validationResults = await meshUtils.addOrdersWithPricesAsync([1, 2]);
                 expect(validationResults.rejected.length, 'mesh should not reject any orders').to.be.eq(0);
+                const largeOrderPrice = '1.5';
                 const largeBuyAmount = DEFAULT_MAKER_ASSET_AMOUNT.times(2).toString();
+                const largeSellAmount = calculateSellAmount(largeBuyAmount, largeOrderPrice);
                 const route = constructRoute({
                     baseRoute: `${META_TRANSACTION_PATH}/price`,
                     queryParams: {
@@ -286,8 +292,9 @@ describe(SUITE_NAME, () => {
                 expect(response.type).to.be.eq('application/json');
                 expect(response.status).to.be.eq(HttpStatus.OK);
                 expect(response.body).to.be.deep.eq({
-                    price: '1.5',
+                    price: largeOrderPrice,
                     buyAmount: largeBuyAmount,
+                    sellAmount: largeSellAmount,
                     sellTokenAddress,
                     buyTokenAddress,
                     sources: liquiditySources0xOnly,
@@ -540,6 +547,7 @@ describe(SUITE_NAME, () => {
                     expect(response.body).to.be.deep.eq({
                         price,
                         buyAmount,
+                        sellAmount,
                         sellTokenAddress,
                         buyTokenAddress,
                         sources: liquiditySources0xOnly,

--- a/test/meta_transaction_test.ts
+++ b/test/meta_transaction_test.ts
@@ -17,6 +17,7 @@ import { GetMetaTransactionQuoteResponse } from '../src/types';
 import { setupApiAsync, setupMeshAsync, teardownApiAsync, teardownMeshAsync } from './utils/deployment';
 import { constructRoute, httpGetAsync, httpPostAsync } from './utils/http_utils';
 import { DEFAULT_MAKER_ASSET_AMOUNT, MeshTestUtils } from './utils/mesh_test_utils';
+import { liquiditySources0xOnly } from './utils/mocks';
 
 const SUITE_NAME = 'meta transactions tests';
 
@@ -243,6 +244,7 @@ describe(SUITE_NAME, () => {
                     buyAmount,
                     sellTokenAddress,
                     buyTokenAddress,
+                    sources: liquiditySources0xOnly,
                 });
             });
 
@@ -264,6 +266,7 @@ describe(SUITE_NAME, () => {
                     buyAmount,
                     sellTokenAddress,
                     buyTokenAddress,
+                    sources: liquiditySources0xOnly,
                 });
             });
 
@@ -287,6 +290,7 @@ describe(SUITE_NAME, () => {
                     buyAmount: largeBuyAmount,
                     sellTokenAddress,
                     buyTokenAddress,
+                    sources: liquiditySources0xOnly,
                 });
             });
         });
@@ -366,18 +370,7 @@ describe(SUITE_NAME, () => {
             buyAmount: testCase.expectedBuyAmount,
             sellAmount: calculateSellAmount(testCase.expectedBuyAmount, testCase.expectedPrice),
             // NOTE(jalextowle): 0x is the only source that is currently being tested.
-            sources: [
-                { name: '0x', proportion: '1' },
-                { name: 'Uniswap', proportion: '0' },
-                { name: 'Eth2Dai', proportion: '0' },
-                { name: 'Kyber', proportion: '0' },
-                { name: 'Curve_USDC_DAI', proportion: '0' },
-                { name: 'Curve_USDC_DAI_USDT', proportion: '0' },
-                { name: 'Curve_USDC_DAI_USDT_TUSD', proportion: '0' },
-                { name: 'Curve_USDC_DAI_USDT_BUSD', proportion: '0' },
-                { name: 'Curve_USDC_DAI_USDT_SUSD', proportion: '0' },
-                { name: 'LiquidityProvider', proportion: '0' },
-            ],
+            sources: liquiditySources0xOnly,
         });
     }
 
@@ -549,6 +542,7 @@ describe(SUITE_NAME, () => {
                         buyAmount,
                         sellTokenAddress,
                         buyTokenAddress,
+                        sources: liquiditySources0xOnly,
                     });
                 });
 
@@ -659,6 +653,7 @@ describe(SUITE_NAME, () => {
                         buyAmount: largeBuyAmount,
                         sellTokenAddress,
                         buyTokenAddress,
+                        sources: liquiditySources0xOnly,
                     });
                 });
 

--- a/test/utils/mocks.ts
+++ b/test/utils/mocks.ts
@@ -26,3 +26,16 @@ export const rfqtIndicativeQuoteResponse = {
     takerAssetData: '0xf47261b00000000000000000000000000b1ba0af832d7c05fd64161e0db78e85978e8082',
     expirationTimeSeconds: '1903620548', // in the year 2030
 };
+
+export const liquiditySources0xOnly = [
+    { name: '0x', proportion: '1' },
+    { name: 'Uniswap', proportion: '0' },
+    { name: 'Eth2Dai', proportion: '0' },
+    { name: 'Kyber', proportion: '0' },
+    { name: 'Curve_USDC_DAI', proportion: '0' },
+    { name: 'Curve_USDC_DAI_USDT', proportion: '0' },
+    { name: 'Curve_USDC_DAI_USDT_TUSD', proportion: '0' },
+    { name: 'Curve_USDC_DAI_USDT_BUSD', proportion: '0' },
+    { name: 'Curve_USDC_DAI_USDT_SUSD', proportion: '0' },
+    { name: 'LiquidityProvider', proportion: '0' },
+];


### PR DESCRIPTION
# Description
This fixes #227.

When integrating with the `/price` endpoints I noticed that the data returned back is very sparse compared to the quote endpoint. I also noticed that two endpoints return different data, so I tried to unify to the point it makes sense.

For us, it would be very helpful to be able to derive the pair from the response data so we don't have to keep track of that locally in the global state.

# Testing Instructions
**TODO:**
- [x] Test through on staging once the format is settled

# Checklist
-   [X] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:** 0xProject/website#298
-   [X] Prefix PR title with `[WIP]` if necessary.
-   [X] Add tests to cover changes as needed.