### PR TITLE
fix: remove check for status from _waitUntilTxHashAsync procedure

### DIFF
--- a/src/services/meta_transaction_service.ts
+++ b/src/services/meta_transaction_service.ts
@@ -316,12 +316,7 @@ export class MetaTransactionService {
         return utils.runWithTimeout(async () => {
             while (true) {
                 const tx = await this._transactionEntityRepository.findOne(txEntity.refHash);
-                if (
-                    tx !== undefined &&
-                    tx.status === TransactionStates.Submitted &&
-                    tx.txHash !== undefined &&
-                    tx.signedTx !== undefined
-                ) {
+                if (tx !== undefined && tx.txHash !== undefined && tx.signedTx !== undefined) {
                     return { ethereumTransactionHash: tx.txHash, signedEthereumTransaction: tx.signedTx };
                 }
 


### PR DESCRIPTION
# Description

This PR removes the check for `status` inside of `_waitUntilTxHashAsync` to not run into a race condition where the status was updated to `Included` or `Mempool` quicker than the polling loop.

# Testing Instructions

Run `yarn integration-test` 