### PR TITLE
feat: added rewards per ZRX to pools endpoint

### DIFF
--- a/src/queries/staking_queries.ts
+++ b/src/queries/staking_queries.ts
@@ -238,7 +238,9 @@ export const poolsAvgRewardsQuery = `
                 , AVG((members_reward / 1e18) / esps.member_zrx_delegated) AS avg_member_reward_eth_per_zrx
             FROM events.rewards_paid_events rpe
             JOIN staking.current_epoch ce ON rpe.epoch_id > (ce.epoch_id - 4)
-            JOIN staking.epoch_start_pool_status esps ON esps.epoch_id = rpe.epoch_id AND esps.pool_id = rpe.pool_id
+            -- subtract one from the reward epoch ID, since reward events are stamped with the epoch
+            -- after the epoch for which they are paid out
+            JOIN staking.epoch_start_pool_status esps ON esps.epoch_id = (rpe.epoch_id - 1) AND esps.pool_id = rpe.pool_id
             GROUP BY 1
         )
         SELECT
@@ -262,7 +264,9 @@ export const poolAvgRewardsQuery = `
                 , AVG((members_reward / 1e18) / esps.member_zrx_delegated) AS avg_member_reward_eth_per_zrx
             FROM events.rewards_paid_events rpe
             JOIN staking.current_epoch ce ON rpe.epoch_id > (ce.epoch_id - 4)
-            JOIN staking.epoch_start_pool_status esps ON esps.epoch_id = rpe.epoch_id AND esps.pool_id = rpe.pool_id
+            -- subtract one from the reward epoch ID, since reward events are stamped with the epoch
+            -- after the epoch for which they are paid out
+            JOIN staking.epoch_start_pool_status esps ON esps.epoch_id = (rpe.epoch_id - 1) AND esps.pool_id = rpe.pool_id
             WHERE
                 rpe.pool_id = $1
             GROUP BY 1

--- a/src/queries/staking_queries.ts
+++ b/src/queries/staking_queries.ts
@@ -231,17 +231,22 @@ export const poolsAvgRewardsQuery = `
     WITH
         avg_rewards AS (
             SELECT
-                pool_id
+                rpe.pool_id
                 , AVG(members_reward) / 1e18 AS avg_member_reward_in_eth
                 , AVG(operator_reward + members_reward) / 1e18 AS avg_total_reward_in_eth
+                , AVG(esps.member_zrx_delegated) AS avg_member_stake
+                , AVG((members_reward / 1e18) / esps.member_zrx_delegated) AS avg_member_reward_eth_per_zrx
             FROM events.rewards_paid_events rpe
             JOIN staking.current_epoch ce ON rpe.epoch_id > (ce.epoch_id - 4)
+            JOIN staking.epoch_start_pool_status esps ON esps.epoch_id = rpe.epoch_id AND esps.pool_id = rpe.pool_id
             GROUP BY 1
         )
         SELECT
             p.pool_id
             , COALESCE(r.avg_member_reward_in_eth, 0) AS avg_member_reward_in_eth
             , COALESCE(r.avg_total_reward_in_eth, 0) AS avg_total_reward_in_eth
+            , COALESCE(r.avg_member_stake, 0) AS avg_member_stake
+            , COALESCE(r.avg_member_reward_eth_per_zrx, 0) AS avg_member_reward_eth_per_zrx
         FROM events.staking_pool_created_events p
         LEFT JOIN avg_rewards r ON r.pool_id = p.pool_id;
 `;
@@ -250,11 +255,14 @@ export const poolAvgRewardsQuery = `
     WITH
         avg_rewards AS (
             SELECT
-                pool_id
+                rpe.pool_id
                 , AVG(members_reward) / 1e18 AS avg_member_reward_in_eth
                 , AVG(operator_reward + members_reward) / 1e18 AS avg_total_reward_in_eth
+                , AVG(esps.member_zrx_delegated) AS avg_member_stake
+                , AVG((members_reward / 1e18) / esps.member_zrx_delegated) AS avg_member_reward_eth_per_zrx
             FROM events.rewards_paid_events rpe
             JOIN staking.current_epoch ce ON rpe.epoch_id > (ce.epoch_id - 4)
+            JOIN staking.epoch_start_pool_status esps ON esps.epoch_id = rpe.epoch_id AND esps.pool_id = rpe.pool_id
             WHERE
                 rpe.pool_id = $1
             GROUP BY 1
@@ -263,6 +271,8 @@ export const poolAvgRewardsQuery = `
             p.pool_id
             , COALESCE(r.avg_member_reward_in_eth, 0) AS avg_member_reward_in_eth
             , COALESCE(r.avg_total_reward_in_eth, 0) AS avg_total_reward_in_eth
+            , COALESCE(r.avg_member_stake, 0) AS avg_member_stake
+            , COALESCE(r.avg_member_reward_eth_per_zrx, 0) AS avg_member_reward_eth_per_zrx
         FROM events.staking_pool_created_events p
         LEFT JOIN avg_rewards r ON r.pool_id = p.pool_id
         WHERE

--- a/src/services/staking_data_service.ts
+++ b/src/services/staking_data_service.ts
@@ -176,6 +176,7 @@ export class StakingDataService {
             sevenDayProtocolFeesGeneratedInEth: pool7dProtocolFeesGenerated.sevenDayProtocolFeesGeneratedInEth,
             avgMemberRewardInEth: poolAvgReward.avgMemberRewardInEth,
             avgTotalRewardInEth: poolAvgReward.avgTotalRewardInEth,
+            avgMemberRewardEthPerZrx: poolAvgReward.avgMemberRewardEthPerZrx,
             currentEpochStats: currentEpochPoolStats,
             nextEpochStats: nextEpochPoolStats,
         };
@@ -211,6 +212,7 @@ export class StakingDataService {
                 poolProtocolFeesGeneratedMap[pool.poolId].sevenDayProtocolFeesGeneratedInEth,
             avgMemberRewardInEth: poolAvgRewardsMap[pool.poolId].avgMemberRewardInEth,
             avgTotalRewardInEth: poolAvgRewardsMap[pool.poolId].avgTotalRewardInEth,
+            avgMemberRewardEthPerZrx: poolAvgRewardsMap[pool.poolId].avgMemberRewardEthPerZrx,
             currentEpochStats: currentEpochPoolStatsMap[pool.poolId],
             nextEpochStats: nextEpochPoolStatsMap[pool.poolId],
         }));

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,6 +151,7 @@ export interface PoolWithStats extends Pool {
     sevenDayProtocolFeesGeneratedInEth: number;
     avgMemberRewardInEth: number;
     avgTotalRewardInEth: number;
+    avgMemberRewardEthPerZrx: number;
 }
 
 export interface PoolWithHistoricalStats extends PoolWithStats {
@@ -211,12 +212,15 @@ export interface RawPoolAvgRewards {
     pool_id: string;
     avg_member_reward_in_eth: string;
     avg_total_reward_in_eth: string;
+    avg_member_stake: string;
+    avg_member_reward_eth_per_zrx: string;
 }
 
 export interface PoolAvgRewards {
     poolId: string;
     avgMemberRewardInEth: number;
     avgTotalRewardInEth: number;
+    avgMemberRewardEthPerZrx: number;
 }
 
 export interface RawPoolTotalProtocolFeesGenerated {

--- a/src/utils/staking_utils.ts
+++ b/src/utils/staking_utils.ts
@@ -193,11 +193,17 @@ export const stakingUtils = {
         return rawPoolsProtocolFeesGenerated.map(stakingUtils.getPoolProtocolFeesGeneratedFromRaw);
     },
     getPoolAvgRewardsFromRaw: (rawPoolAvgRewards: RawPoolAvgRewards): PoolAvgRewards => {
-        const { pool_id, avg_member_reward_in_eth, avg_total_reward_in_eth } = rawPoolAvgRewards;
+        const {
+            pool_id,
+            avg_member_reward_in_eth,
+            avg_total_reward_in_eth,
+            avg_member_reward_eth_per_zrx,
+        } = rawPoolAvgRewards;
         return {
             poolId: pool_id,
             avgMemberRewardInEth: Number(avg_member_reward_in_eth || 0),
             avgTotalRewardInEth: Number(avg_total_reward_in_eth || 0),
+            avgMemberRewardEthPerZrx: Number(avg_member_reward_eth_per_zrx || 0),
         };
     },
     getPoolsAvgRewardsFromRaw: (rawPoolsAvgRewards: RawPoolAvgRewards[]): PoolAvgRewards[] => {


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

Added a new field to the `pools` and `pools/<id>` endpoint called `avgMemberRewardEthPerZrx`. It provides the average member reward over the last 3 epochs divided by the average member stake. 

# Testing Instructions

Testing:
- [x] Tested locally on analytics database
