### PR TITLE
fix: Re-pin asset-swapper to latest monorepo commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-511cd90c4",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-98a99d96a",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-fb0311e67",
         "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-fb0311e67",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-d9e13d6b9",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-511cd90c4",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-fb0311e67",
         "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-fb0311e67",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,9 +22,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-511cd90c4":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-98a99d96a":
   version "4.4.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/749dde847d72578be3e0d2bf03e6ee105d7556b8"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/8bf61afc0605d11bd13d09681e82d89b91b87d12"
   dependencies:
     "@0x/assert" "^3.0.7"
     "@0x/contract-addresses" "^4.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,9 +22,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-d9e13d6b9":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-511cd90c4":
   version "4.4.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/8bf3e651d724a72912dee78cc1978a674b82b93c"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/749dde847d72578be3e0d2bf03e6ee105d7556b8"
   dependencies:
     "@0x/assert" "^3.0.7"
     "@0x/contract-addresses" "^4.9.0"


### PR DESCRIPTION
To pick up a small fix for logging RFQ-T maker endpoint response error codes. 

This is the monorepo commit being pinned to: https://github.com/0xProject/0x-monorepo/commit/98a99d96aab15623188661568785b5354e66172a

At the time of this writing (9am PT, May 28) that's the latest monorepo commit.

This change has been verified on staging.  However, I did not verify the actual case being corrected (the error response code handling from the maker endpoint), because it was not readily apparent to me how to simulate that.  But what I _did_ test was that existing functionality is holding together okay.  To do that I requested a few RFQ-T quotes, and also ran the Assertible smoke tests.