### PR TITLE
fix(metatx): don't return hexadecimal values in partial tx

### DIFF
--- a/src/services/meta_transaction_service.ts
+++ b/src/services/meta_transaction_service.ts
@@ -13,7 +13,6 @@ import {
 import { PartialTxParams } from '@0x/subproviders';
 import { ExchangeProxyMetaTransaction, Order, SignedOrder } from '@0x/types';
 import { BigNumber, RevertError } from '@0x/utils';
-import { utils as web3WrapperUtils } from '@0x/web3-wrapper/lib/src/utils';
 import { Connection, Repository } from 'typeorm';
 
 import {
@@ -242,9 +241,9 @@ export class MetaTransactionService {
 
         const ethereumTxnParams: PartialTxParams = {
             data: executeTxnCalldata,
-            gas: web3WrapperUtils.encodeAmountAsHexString(gas),
-            gasPrice: web3WrapperUtils.encodeAmountAsHexString(gasPrice),
-            value: web3WrapperUtils.encodeAmountAsHexString(protocolFee),
+            gas: gas.toString(),
+            gasPrice: gasPrice.toString(),
+            value: protocolFee.toString(),
             to: callTarget,
             chainId: CHAIN_ID,
             // NOTE we arent returning nonce and from fields back to the user


### PR DESCRIPTION
# Description
This fixes #124. If the hex values are intentional feel free to close this PR. I just found it a bit odd that this endpoint returns these values as hex whereas other endpoints return them as decimals.

# Testing Instructions
- [x] Tested on staging

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:** 0xProject/website#303
