### PR TITLE
feat: return ethereum transaction status in the response from metatxn status

### DIFF
--- a/src/handlers/meta_transaction_handlers.ts
+++ b/src/handlers/meta_transaction_handlers.ts
@@ -359,5 +359,6 @@ const marshallTransactionEntity = (tx: TransactionEntity): any => {
         updatedAt: tx.updatedAt,
         blockNumber: tx.blockNumber,
         expectedMinedInSec: tx.expectedMinedInSec,
+        ethereumTxStatus: tx.txStatus,
     };
 };

--- a/src/handlers/meta_transaction_handlers.ts
+++ b/src/handlers/meta_transaction_handlers.ts
@@ -22,7 +22,12 @@ import { logger } from '../logger';
 import { isAPIError, isRevertError } from '../middleware/error_handling';
 import { schemas } from '../schemas/schemas';
 import { MetaTransactionService } from '../services/meta_transaction_service';
-import { GetMetaTransactionPriceResponse, GetTransactionRequestParams, ZeroExTransactionWithoutDomain } from '../types';
+import {
+    GetMetaTransactionPriceResponse,
+    GetMetaTransactionStatusResponse,
+    GetTransactionRequestParams,
+    ZeroExTransactionWithoutDomain,
+} from '../types';
 import { parseUtils } from '../utils/parse_utils';
 import { schemaUtils } from '../utils/schema_utils';
 import { findTokenAddressOrThrowApiError } from '../utils/token_metadata_utils';
@@ -350,7 +355,7 @@ const parsePostTransactionRequestBody = (req: any): PostTransactionRequestBody =
     };
 };
 
-const marshallTransactionEntity = (tx: TransactionEntity): any => {
+const marshallTransactionEntity = (tx: TransactionEntity): GetMetaTransactionStatusResponse => {
     return {
         refHash: tx.refHash,
         hash: tx.txHash,

--- a/src/types.ts
+++ b/src/types.ts
@@ -417,6 +417,17 @@ export interface GetMetaTransactionQuoteResponse {
 
 export interface GetMetaTransactionPriceResponse extends BasePriceResponse {}
 
+export interface GetMetaTransactionStatusResponse {
+    refHash: string;
+    hash?: string;
+    status: string;
+    gasPrice?: BigNumber;
+    updatedAt?: Date;
+    blockNumber?: number;
+    expectedMinedInSec?: number;
+    ethereumTxStatus?: number;
+}
+
 // takerAddress, sellAmount, buyAmount, swapQuote, price
 export interface CalculateMetaTransactionPriceResponse {
     price: BigNumber;


### PR DESCRIPTION
# Description

Add ethereum transaction status to the response of `/status/:refHash`
