### PR TITLE
feat: support renamed parameters in RFQT maker endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-b8cc164af",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-73c779c13",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-f14b6f2ba",
         "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-f14b6f2ba",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-187dd2fdc",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-b8cc164af",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-f14b6f2ba",
         "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-f14b6f2ba",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-dde0c7611",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-716293502",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-f14b6f2ba",
         "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-f14b6f2ba",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-716293502",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-187dd2fdc",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-f14b6f2ba",
         "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-f14b6f2ba",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-f14b6f2ba",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-dde0c7611",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.9.0-f14b6f2ba",
         "@0x/contract-wrappers": "0xProject/gitpkg-registry#0x-contract-wrappers-v13.6.3-f14b6f2ba",

--- a/test/rfqt_test.ts
+++ b/test/rfqt_test.ts
@@ -77,10 +77,10 @@ describe(SUITE_NAME, () => {
             responseCode: 200,
             requestApiKey: 'koolApiKey1',
             requestParams: {
-                sellToken: contractAddresses.etherToken,
-                buyToken: contractAddresses.zrxToken,
-                sellAmount: DEFAULT_SELL_AMOUNT.toString(),
-                buyAmount: undefined,
+                sellTokenAddress: contractAddresses.etherToken,
+                buyTokenAddress: contractAddresses.zrxToken,
+                sellAmountBaseUnits: DEFAULT_SELL_AMOUNT,
+                buyAmountBaseUnits: undefined,
                 takerAddress,
             },
         };
@@ -118,7 +118,7 @@ describe(SUITE_NAME, () => {
                     [
                         {
                             ...DEFAULT_RFQT_RESPONSE_DATA,
-                            responseData: ganacheZrxWethOrder1,
+                            responseData: { signedOrder: ganacheZrxWethOrder1 },
                         },
                     ],
                     async () => {
@@ -236,7 +236,7 @@ describe(SUITE_NAME, () => {
                     [
                         {
                             ...DEFAULT_RFQT_RESPONSE_DATA,
-                            responseData: ganacheZrxWethOrder1,
+                            responseData: { signedOrder: ganacheZrxWethOrder1 },
                         },
                     ],
                     async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,14 +22,13 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-b8cc164af":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-73c779c13":
   version "4.4.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/c0ab0c9bc847894cee77c48d5a3eabb8a42dcf68"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/b48045a98140f5a93c2fab2c691979e35a9b0dbc"
   dependencies:
     "@0x/assert" "^3.0.7"
     "@0x/contract-addresses" "^4.9.0"
     "@0x/contract-wrappers" "^13.6.3"
-    "@0x/contracts-zero-ex" "^0.1.0"
     "@0x/json-schemas" "^5.0.7"
     "@0x/order-utils" "^10.2.4"
     "@0x/orderbook" "^2.2.5"
@@ -277,7 +276,7 @@
     bn.js "^4.11.8"
     ethereum-types "^3.1.0"
 
-"@0x/contracts-zero-ex@0xProject/gitpkg-registry#0x-contracts-zero-ex-v0.1.0-f14b6f2ba", "@0x/contracts-zero-ex@^0.1.0":
+"@0x/contracts-zero-ex@0xProject/gitpkg-registry#0x-contracts-zero-ex-v0.1.0-f14b6f2ba":
   version "0.1.0"
   resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/963254db067233cdc0a7f7d377ae73b59fdcdd70"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,9 +22,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-187dd2fdc":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-b8cc164af":
   version "4.4.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/7af5bd471f7ccab39f0d1a3eb213e4b718525fa9"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/c0ab0c9bc847894cee77c48d5a3eabb8a42dcf68"
   dependencies:
     "@0x/assert" "^3.0.7"
     "@0x/contract-addresses" "^4.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,20 +22,23 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-f14b6f2ba":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-dde0c7611":
   version "4.4.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/bb8498654e8c753be460de7b026e0019ae08b8ea"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/53269f3eae3f277a09f4fbfb30c8cd9ce4ab091f"
   dependencies:
     "@0x/assert" "^3.0.7"
     "@0x/contract-addresses" "^4.9.0"
     "@0x/contract-wrappers" "^13.6.3"
+    "@0x/contracts-zero-ex" "^0.1.0"
     "@0x/json-schemas" "^5.0.7"
     "@0x/order-utils" "^10.2.4"
     "@0x/orderbook" "^2.2.5"
+    "@0x/quote-server" "^2.0.2"
     "@0x/utils" "^5.4.1"
     "@0x/web3-wrapper" "^7.0.7"
     axios "^0.19.2"
     axios-mock-adapter "^1.18.1"
+    ethereumjs-util "^5.1.1"
     heartbeats "^5.0.1"
     lodash "^4.17.11"
 
@@ -274,7 +277,7 @@
     bn.js "^4.11.8"
     ethereum-types "^3.1.0"
 
-"@0x/contracts-zero-ex@0xProject/gitpkg-registry#0x-contracts-zero-ex-v0.1.0-f14b6f2ba":
+"@0x/contracts-zero-ex@0xProject/gitpkg-registry#0x-contracts-zero-ex-v0.1.0-f14b6f2ba", "@0x/contracts-zero-ex@^0.1.0":
   version "0.1.0"
   resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/963254db067233cdc0a7f7d377ae73b59fdcdd70"
   dependencies:
@@ -402,6 +405,19 @@
     "@0x/mesh-rpc-client" "^7.0.4-beta-0xv3"
     "@0x/order-utils" "^10.2.4"
     "@0x/utils" "^5.4.1"
+
+"@0x/quote-server@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@0x/quote-server/-/quote-server-2.0.2.tgz#60d0665c1cad378c9abb89b5491bdc55b4c8412c"
+  integrity sha512-ScK8lHj2AN0RaEjSYplnxsABGy30j6bATG3GjmGMWOx5Bmj2X6UGHpD2ZJ0UH+oJqyDHyZ31vgpMbCSlBLFlzQ==
+  dependencies:
+    "@0x/json-schemas" "^5.0.7"
+    "@0x/order-utils" "^10.2.4"
+    "@0x/utils" "^5.4.1"
+    "@types/express" "^4.17.3"
+    express "^4.17.1"
+    express-async-handler "^1.1.4"
+    http-status-codes "^1.4.0"
 
 "@0x/sol-compiler@^4.0.8":
   version "4.0.8"
@@ -878,9 +894,10 @@
     "@types/node" "*"
     "@types/range-parser" "*"
 
-"@types/express@*", "@types/express@^4.17.1":
+"@types/express@*", "@types/express@^4.17.1", "@types/express@^4.17.3":
   version "4.17.6"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.6.tgz#6bce49e49570507b86ea1b07b806f04697fac45e"
+  integrity sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==
   dependencies:
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "*"
@@ -4346,9 +4363,10 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-http-status-codes@^1.3.2:
+http-status-codes@^1.3.2, http-status-codes@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/http-status-codes/-/http-status-codes-1.4.0.tgz#6e4c15d16ff3a9e2df03b89f3a55e1aae05fb477"
+  integrity sha512-JrT3ua+WgH8zBD3HEJYbeEgnuQaAnUeRRko/YojPAJjGmIfGD3KPU/asLdsLwKjfxOmQe5nXMQ0pt/7MyapVbQ==
 
 human-signals@^1.1.1:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,9 +22,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-dde0c7611":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-716293502":
   version "4.4.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/53269f3eae3f277a09f4fbfb30c8cd9ce4ab091f"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/23b00ed7a7ea8ac55c9815f99998b73ed5528e9a"
   dependencies:
     "@0x/assert" "^3.0.7"
     "@0x/contract-addresses" "^4.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,9 +22,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-716293502":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.4.0-187dd2fdc":
   version "4.4.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/23b00ed7a7ea8ac55c9815f99998b73ed5528e9a"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/7af5bd471f7ccab39f0d1a3eb213e4b718525fa9"
   dependencies:
     "@0x/assert" "^3.0.7"
     "@0x/contract-addresses" "^4.9.0"


### PR DESCRIPTION
Uses a new asset-swapper, which has support for the [maker endpoint's renamed taker request parameters](https://github.com/0xProject/quote-server/pull/5).

-   [x] Re-pin asset-swapper to a monorepo `development` commit rather than a PR branch commit, once https://github.com/0xProject/0x-monorepo/pull/2582 has been merged.