### PR TITLE
fix: validation gas limit

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,7 @@ export const DEFAULT_LOGGER_INCLUDE_TIMESTAMP = true;
 export const ONE_SECOND_MS = 1000;
 export const ONE_MINUTE_MS = ONE_SECOND_MS * 60;
 export const TEN_MINUTES_MS = ONE_MINUTE_MS * 10;
+export const DEFAULT_VALIDATION_GAS_LIMIT = 10e6;
 
 // The number of orders to post to Mesh at one time
 export const MESH_ORDERS_BATCH_SIZE = 200;

--- a/src/services/meta_transaction_service.ts
+++ b/src/services/meta_transaction_service.ts
@@ -21,6 +21,7 @@ import {
     RFQT_SKIP_BUY_REQUESTS,
 } from '../config';
 import {
+    DEFAULT_VALIDATION_GAS_LIMIT,
     ONE_GWEI,
     ONE_MINUTE_MS,
     ONE_SECOND_MS,
@@ -265,6 +266,7 @@ export class MetaTransactionService {
                 from: PUBLIC_ADDRESS_FOR_ETH_CALLS,
                 gasPrice,
                 value: protocolFee,
+                gas: DEFAULT_VALIDATION_GAS_LIMIT,
             });
         } catch (err) {
             // we reach into the underlying revert and throw it instead of
@@ -296,7 +298,6 @@ export class MetaTransactionService {
         protocolFee: BigNumber,
     ): Promise<PartialTxParams> {
         const gasPrice = zeroExTransaction.gasPrice;
-        // TODO(dekz): our pattern is to eth_call and estimateGas in parallel and return the result of eth_call validations
         const gas = await this._contractWrappers.exchange
             .executeTransaction(zeroExTransaction, signature)
             .estimateGasAsync({

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -86,7 +86,16 @@ export class SwapService {
     }
 
     public async calculateSwapQuoteAsync(params: CalculateSwapQuoteParams): Promise<GetSwapQuoteResponse> {
-        const { buyAmount, buyTokenAddress, sellTokenAddress, isETHSell, from, affiliateAddress } = params;
+        const {
+            buyAmount,
+            buyTokenAddress,
+            sellTokenAddress,
+            isETHSell,
+            from,
+            affiliateAddress,
+            // tslint:disable-next-line:boolean-naming
+            skipValidation,
+        } = params;
         const swapQuote = await this._getMarketBuyOrSellQuoteAsync(params);
 
         const attributedSwapQuote = serviceUtils.attributeSwapQuoteOrders(swapQuote);
@@ -115,9 +124,7 @@ export class SwapService {
         );
 
         let conservativeBestCaseGasEstimate = new BigNumber(worstCaseGas).plus(gasTokenGasCost);
-        // Temporarily disable validation
-        // if (!skipValidation && from) {
-        if (false) {
+        if (!skipValidation && from) {
             // Force a revert error if the takerAddress does not have enough ETH.
             const txDataValue = isETHSell
                 ? BigNumber.min(value, await this._web3Wrapper.getBalanceInWeiAsync(from))

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -24,6 +24,7 @@ import {
     RFQT_SKIP_BUY_REQUESTS,
 } from '../config';
 import {
+    DEFAULT_VALIDATION_GAS_LIMIT,
     GAS_LIMIT_BUFFER_MULTIPLIER,
     GST2_WALLET_ADDRESSES,
     ONE,
@@ -142,7 +143,10 @@ export class SwapService {
         // Add a buffer to get the worst case gas estimate
         const worstCaseGasEstimate = conservativeBestCaseGasEstimate.times(GAS_LIMIT_BUFFER_MULTIPLIER).integerValue();
         // Cap the refund at 50% our best estimate
-        const estimatedGasTokenRefund = BigNumber.min(conservativeBestCaseGasEstimate.div(2), gasTokenRefund);
+        const estimatedGasTokenRefund = BigNumber.min(
+            conservativeBestCaseGasEstimate.div(2),
+            gasTokenRefund,
+        ).decimalPlaces(0);
         const { price, guaranteedPrice } = await this._getSwapQuotePriceAsync(
             buyAmount,
             buyTokenAddress,
@@ -282,12 +286,8 @@ export class SwapService {
     }
 
     private async _estimateGasOrThrowRevertErrorAsync(txData: Partial<TxData>): Promise<BigNumber> {
-        // Perform this concurrently
-        // if the call fails the gas estimation will also fail, we can throw a more helpful
-        // error message than gas estimation failure
-        const estimateGasPromise = this._web3Wrapper.estimateGasAsync(txData).catch(_e => 0);
-        await this._throwIfCallIsRevertErrorAsync(txData);
-        const gas = await estimateGasPromise;
+        const gas = await this._web3Wrapper.estimateGasAsync(txData).catch(_e => DEFAULT_VALIDATION_GAS_LIMIT);
+        await this._throwIfCallIsRevertErrorAsync({ ...txData, gas });
         return new BigNumber(gas);
     }
 
@@ -298,9 +298,20 @@ export class SwapService {
             callResult = await this._web3Wrapper.callAsync(txData);
         } catch (e) {
             // RPCSubprovider can throw if .error exists on the response payload
-            // This `error` response occurs from Parity nodes (incl Alchemy) but not on INFURA (geth)
-            revertError = decodeThrownErrorAsRevertError(e);
-            throw revertError;
+            // This `error` response occurs from Parity nodes (incl Alchemy) and Geth nodes >= 1.9.14
+            // Geth 1.9.15
+            if (e.message && /execution reverted/.test(e.message) && e.data) {
+                try {
+                    revertError = RevertError.decode(e.data, false);
+                } catch (e) {
+                    // No revert error
+                }
+            } else {
+                revertError = decodeThrownErrorAsRevertError(e);
+            }
+            if (revertError) {
+                throw revertError;
+            }
         }
         try {
             revertError = RevertError.decode(callResult, false);

--- a/test/rfqt_test.ts
+++ b/test/rfqt_test.ts
@@ -285,7 +285,7 @@ describe(SUITE_NAME, () => {
                     },
                 );
             });
-            it.skip('should fail validation when taker can not actually fill', async () => {
+            it('should fail validation when taker can not actually fill', async () => {
                 const wethContract = new WETH9Contract(contractAddresses.etherToken, provider);
                 await wethContract
                     .approve(contractAddresses.erc20Proxy, new BigNumber(0))

--- a/test/swap_test.ts
+++ b/test/swap_test.ts
@@ -217,7 +217,7 @@ describe(SUITE_NAME, () => {
                 },
             );
         });
-        it.skip('should throw a validation error if takerAddress cannot complete the quote', async () => {
+        it('should throw a validation error if takerAddress cannot complete the quote', async () => {
             // The taker does not have an allowance
             await quoteAndExpectAsync(
                 {


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

Geth shipped a breaking change which did the following.

1.  Removed the "bug" which allowed the caller to have `value` irrespective of their ETH balance
2. Set the gas limit to MaxUint64 if not supplied

These two combination results in an insufficient funds as not even Vitalik has enough funds for 50 gwei @ MaxUint64 gas limit.

As a result we either need to drop (or lower) gas price to 1 wei, resulting in the user requiring 18 ETH for validation. We want to validate the gas price and protocol fee, so we cannot drop the gas price entirely. So this is out.

So we need to either fix the gas limit to something reasonable in the case we're performing a validation (eth call with ?? gas). Or we perform the Estimate gas first then the `eth_call`, unable to parallelize.

In `/swap/v0/quote` we have opted to remove the parallelization and first perform the estimate then the call. 

In MetaTxn we have opted to fix the gas limit to 10e6 as we do not yet have a signer. The reason we wanted to perform them in parallel is for speed and to reveal the `eth_call` error, not the gas estimation error.



