### PR TITLE
feat: Unique quote ID

### DIFF
--- a/src/utils/number_utils.ts
+++ b/src/utils/number_utils.ts
@@ -5,15 +5,15 @@ export const numberUtils = {
         const max = Math.floor(maximumSpecified);
         return Math.floor(Math.random() * (max - min + 1)) + min; // The maximum is inclusive and the minimum is inclusive
     },
-    // creates a random number of desired length by stringing together
-    // random integers from 1-9, guaranteeing the
-    // the .toString().length of the return value to equal to numberLength parameter
-    randomNumberOfLength: (numberLength: number): number => {
+    // creates a random hex number of desired length by stringing together
+    // random integers from 1-15, guaranteeing the
+    // result is a hex number of the given length
+    randomHexNumberOfLength: (numberLength: number): string => {
         let res = '';
         for (let i = 0; i < numberLength; i++) {
             // tslint:disable-next-line:custom-no-magic-numbers
-            res = `${res}${numberUtils.randomNumberInclusive(1, 9)}`;
+            res = `${res}${numberUtils.randomNumberInclusive(1, 15).toString(16)}`;
         }
-        return parseInt(res, 10);
+        return res;
     },
 };

--- a/src/utils/number_utils.ts
+++ b/src/utils/number_utils.ts
@@ -1,0 +1,19 @@
+export const numberUtils = {
+    // from MDN https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
+    randomNumberInclusive: (minimumSpecified: number, maximumSpecified: number): number => {
+        const min = Math.ceil(minimumSpecified);
+        const max = Math.floor(maximumSpecified);
+        return Math.floor(Math.random() * (max - min + 1)) + min; // The maximum is inclusive and the minimum is inclusive
+    },
+    // creates a random number of desired length by stringing together
+    // random integers from 1-9, guaranteeing the
+    // the .toString().length of the return value to equal to numberLength parameter
+    randomNumberOfLength: (numberLength: number): number => {
+        let res = '';
+        for (let i = 0; i < numberLength; i++) {
+            // tslint:disable-next-line:custom-no-magic-numbers
+            res = `${res}${numberUtils.randomNumberInclusive(1, 9)}`;
+        }
+        return parseInt(res, 10);
+    },
+};

--- a/src/utils/service_utils.ts
+++ b/src/utils/service_utils.ts
@@ -29,6 +29,8 @@ import { GasTokenRefundInfo, GetSwapQuoteResponseLiquiditySource } from '../type
 import { orderUtils } from '../utils/order_utils';
 import { findTokenDecimalsIfExists } from '../utils/token_metadata_utils';
 
+import { numberUtils } from './number_utils';
+
 export const serviceUtils = {
     attributeSwapQuoteOrders(
         swapQuote: MarketSellSwapQuote | MarketBuySwapQuote,
@@ -63,14 +65,20 @@ export const serviceUtils = {
             name: 'ZeroExAPIAffiliate',
             inputs: [
                 { name: 'affiliate', type: 'address' },
-                { name: 'timestamp', type: 'uint256' },
+                { name: 'uniqueIdentifier', type: 'uint256' },
             ],
             payable: false,
             stateMutability: 'view',
             type: 'function',
         });
-        const timestamp = new BigNumber(Date.now() / ONE_SECOND_MS).integerValue();
-        const encodedAffiliateData = affiliateCallDataEncoder.encode([affiliateAddressOrDefault, timestamp]);
+
+        // Generate unique identiifer
+        const timestampInSeconds = new BigNumber(Date.now() / ONE_SECOND_MS).integerValue();
+        const randomNumber = numberUtils.randomNumberOfLength(10);
+        const uniqueIdentifier = `${randomNumber}${timestampInSeconds}`;
+
+        // Encode additional call data and return
+        const encodedAffiliateData = affiliateCallDataEncoder.encode([affiliateAddressOrDefault, uniqueIdentifier]);
         const affiliatedData = `${data}${encodedAffiliateData.slice(2)}`;
         return affiliatedData;
     },

--- a/src/utils/service_utils.ts
+++ b/src/utils/service_utils.ts
@@ -65,7 +65,7 @@ export const serviceUtils = {
             name: 'ZeroExAPIAffiliate',
             inputs: [
                 { name: 'affiliate', type: 'address' },
-                { name: 'uniqueIdentifier', type: 'uint256' },
+                { name: 'timestamp', type: 'uint256' },
             ],
             payable: false,
             stateMutability: 'view',

--- a/src/utils/service_utils.ts
+++ b/src/utils/service_utils.ts
@@ -75,7 +75,7 @@ export const serviceUtils = {
         // Generate unique identiifer
         const timestampInSeconds = new BigNumber(Date.now() / ONE_SECOND_MS).integerValue();
         const randomNumber = numberUtils.randomNumberOfLength(10);
-        const uniqueIdentifier = `${randomNumber}${timestampInSeconds}`;
+        const uniqueIdentifier = new BigNumber(`${randomNumber}${timestampInSeconds}`);
 
         // Encode additional call data and return
         const encodedAffiliateData = affiliateCallDataEncoder.encode([affiliateAddressOrDefault, uniqueIdentifier]);

--- a/src/utils/service_utils.ts
+++ b/src/utils/service_utils.ts
@@ -73,9 +73,11 @@ export const serviceUtils = {
         });
 
         // Generate unique identiifer
+        const HEX_DIGITS = 16;
         const timestampInSeconds = new BigNumber(Date.now() / ONE_SECOND_MS).integerValue();
-        const randomNumber = numberUtils.randomNumberOfLength(10);
-        const uniqueIdentifier = new BigNumber(`${randomNumber}${timestampInSeconds}`);
+        const hexTimestamp = timestampInSeconds.toString(HEX_DIGITS);
+        const randomNumber = numberUtils.randomHexNumberOfLength(10);
+        const uniqueIdentifier = new BigNumber(`${randomNumber}${hexTimestamp}`, HEX_DIGITS);
 
         // Encode additional call data and return
         const encodedAffiliateData = affiliateCallDataEncoder.encode([affiliateAddressOrDefault, uniqueIdentifier]);


### PR DESCRIPTION
# Description

Hijacks the timestamp calldata to be treated as unique id: `[10 random numbers][timestamp in seconds]`

This will allow us to more easily attribute data in our data pipeline, and communicate unique ids for quotes to RFQT market makers

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
