### PR TITLE
fix: Changes latency to be capped at 600ms, added some extra typing

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -283,6 +283,8 @@ const feeSchedule: { [key in ERC20BridgeSource]: BigNumber } = Object.assign(
     })),
 );
 
+export const RFQT_REQUEST_MAX_RESPONSE_MS = 600;
+
 export const ASSET_SWAPPER_MARKET_ORDERS_OPTS: Partial<SwapQuoteRequestOpts> = {
     excludedSources: EXCLUDED_SOURCES,
     bridgeSlippage: DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE,

--- a/src/services/meta_transaction_service.ts
+++ b/src/services/meta_transaction_service.ts
@@ -1,5 +1,5 @@
 import { Orderbook, SwapQuoter, SwapQuoterOpts } from '@0x/asset-swapper';
-import { OrderPrunerPermittedFeeTypes } from '@0x/asset-swapper/lib/src/types';
+import { OrderPrunerPermittedFeeTypes, SwapQuoteRequestOpts } from '@0x/asset-swapper/lib/src/types';
 import { ContractWrappers } from '@0x/contract-wrappers';
 import { DevUtilsContract } from '@0x/contracts-dev-utils';
 import { generatePseudoRandomSalt, SupportedProvider, ZeroExTransaction } from '@0x/order-utils';
@@ -113,9 +113,8 @@ export class MetaTransactionService {
                 takerAddress,
             };
         }
-        const assetSwapperOpts = {
+        const assetSwapperOpts: Partial<SwapQuoteRequestOpts> = {
             ...ASSET_SWAPPER_MARKET_ORDERS_OPTS,
-            slippagePercentage,
             bridgeSlippage: slippagePercentage,
             excludedSources, // TODO(dave4506): overrides the excluded sources selected by chainId
             rfqt: _rfqt,

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -1,12 +1,13 @@
 import {
     ExtensionContractType,
     Orderbook,
+    RfqtRequestOpts,
     SwapQuote,
     SwapQuoteConsumer,
     SwapQuoter,
     SwapQuoterOpts,
 } from '@0x/asset-swapper';
-import { OrderPrunerPermittedFeeTypes } from '@0x/asset-swapper/lib/src/types';
+import { OrderPrunerPermittedFeeTypes, SwapQuoteRequestOpts } from '@0x/asset-swapper/lib/src/types';
 import { getContractAddressesForChainOrThrow } from '@0x/contract-addresses';
 import { ERC20TokenContract, WETH9Contract } from '@0x/contract-wrappers';
 import { assetDataUtils, SupportedProvider } from '@0x/order-utils';
@@ -21,6 +22,7 @@ import {
     LIQUIDITY_POOL_REGISTRY_ADDRESS,
     RFQT_API_KEY_WHITELIST,
     RFQT_MAKER_ASSET_OFFERINGS,
+    RFQT_REQUEST_MAX_RESPONSE_MS,
     RFQT_SKIP_BUY_REQUESTS,
 } from '../config';
 import {
@@ -338,7 +340,7 @@ export class SwapService {
             rfqt,
             // tslint:disable-next-line:boolean-naming
         } = params;
-        let _rfqt;
+        let _rfqt: RfqtRequestOpts | undefined;
         if (apiKey !== undefined && (isETHSell || from !== undefined)) {
             _rfqt = {
                 ...rfqt,
@@ -348,11 +350,11 @@ export class SwapService {
                 // forwarder contract. If it's not, then we want to request quotes with the taker set to the
                 // API's takerAddress query parameter, which in this context is known as `from`.
                 takerAddress: isETHSell ? this._forwarderAddress : from || '',
+                makerEndpointMaxResponseTimeMs: RFQT_REQUEST_MAX_RESPONSE_MS,
             };
         }
-        const assetSwapperOpts = {
+        const assetSwapperOpts: Partial<SwapQuoteRequestOpts> = {
             ...ASSET_SWAPPER_MARKET_ORDERS_OPTS,
-            slippagePercentage,
             bridgeSlippage: slippagePercentage,
             gasPrice: providedGasPrice,
             excludedSources, // TODO(dave4506): overrides the excluded sources selected by chainId

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,10 @@
-import { ERC20BridgeSource, MarketBuySwapQuote, MarketSellSwapQuote, SupportedProvider } from '@0x/asset-swapper';
+import {
+    ERC20BridgeSource,
+    MarketBuySwapQuote,
+    MarketSellSwapQuote,
+    RfqtRequestOpts,
+    SupportedProvider,
+} from '@0x/asset-swapper';
 import { AcceptedOrderInfo, RejectedOrderInfo } from '@0x/mesh-rpc-client';
 import {
     APIOrder,
@@ -511,11 +517,7 @@ export interface CalculateSwapQuoteParams {
     excludedSources?: ERC20BridgeSource[];
     affiliateAddress?: string;
     apiKey?: string;
-    rfqt?: {
-        intentOnFilling?: boolean;
-        isIndicative?: boolean;
-        skipBuyRequests?: boolean;
-    };
+    rfqt?: Partial<RfqtRequestOpts>;
     skipValidation: boolean;
 }
 


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

We noticed that RFQT latency on `api.0x.org` can be too high at times and may cause downstream latency to our customers, so we are going to cap HTTP RFQT timeouts to 600ms.  This PR sets the `makerEndpointMaxResponseTimeMs` parameter that can be optionally specified in `RfqtRequestOpts`, and that defaults to 1 second. We are intentionally enforcing this parameter to be `600`.

⚠️ We noticed that 0x API passes to Asset Swapper some parameters that do not exist anymore. More precisely:

- `skipBuyRequests` is an old relic of when our RFQT bot only supported sell requests. skipBuyRequests is not used at all by AssetSwapper, since it’s not present in [RfqtRequestOpts](https://github.com/0xProject/0x-monorepo/blob/85ca926fd012d9233c01a0a2a58e8709d5dabe32/packages/asset-swapper/src/types.ts#L202).
- `slippagePercentage` was removed [here](https://github.com/0xProject/0x-monorepo/pull/2513) and passing this parameter to SwapQuoter will have no effect at all.

Can I get a sign off from @dekz and/or @dorothy-zbornak that the removal of these 2 parameters does not cause any issue downstream? and that these parameters are simply technical debt? 

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

Once I have a first approval that my PR does not introduce new issues, I will try it in staging

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Get a sign-off from @dekz and/or @dorothy-zbornak re. removal of the 2 parameters
-   [x] Test in staging
-   [ ] Merge and deploy to Prod
