### PR TITLE
feat: Graceful Shutdowns

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -50,7 +50,7 @@ export const HTTP_PORT = _.isEmpty(process.env.HTTP_PORT)
     ? 3000
     : assertEnvVarType('HTTP_PORT', process.env.HTTP_PORT, EnvVarType.Port);
 
-// Network port for the healthcheck service at /healthz, if no provided, it uses the HTTP_PORT value.
+// Network port for the healthcheck service at /healthz, if not provided, it uses the HTTP_PORT value.
 export const HEALTHCHECK_HTTP_PORT = _.isEmpty(process.env.HEALTHCHECK_HTTP_PORT)
     ? HTTP_PORT
     : assertEnvVarType('HEALTHCHECK_HTTP_PORT', process.env.HEALTHCHECK_HTTP_PORT, EnvVarType.Port);

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,6 +50,11 @@ export const HTTP_PORT = _.isEmpty(process.env.HTTP_PORT)
     ? 3000
     : assertEnvVarType('HTTP_PORT', process.env.HTTP_PORT, EnvVarType.Port);
 
+// Network port for the healthcheck service at /healthz, if no provided, it uses the HTTP_PORT value.
+export const HEALTHCHECK_HTTP_PORT = _.isEmpty(process.env.HEALTHCHECK_HTTP_PORT)
+    ? HTTP_PORT
+    : assertEnvVarType('HEALTHCHECK_HTTP_PORT', process.env.HEALTHCHECK_HTTP_PORT, EnvVarType.Port);
+
 // Number of milliseconds of inactivity the servers waits for additional
 // incoming data aftere it finished writing last response before a socket will
 // be destroyed.
@@ -297,6 +302,7 @@ export const ASSET_SWAPPER_MARKET_ORDERS_OPTS: Partial<SwapQuoteRequestOpts> = {
 
 export const defaultHttpServiceConfig: HttpServiceConfig = {
     httpPort: HTTP_PORT,
+    healthcheckHttpPort: HEALTHCHECK_HTTP_PORT,
     ethereumRpcUrl: ETHEREUM_RPC_URL,
     httpKeepAliveTimeout: HTTP_KEEP_ALIVE_TIMEOUT,
     httpHeadersTimeout: HTTP_HEADERS_TIMEOUT,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,6 +49,7 @@ export const SWAP_PATH = '/swap/v0';
 export const META_TRANSACTION_PATH = '/meta_transaction/v0';
 export const METRICS_PATH = '/metrics';
 export const API_KEY_HEADER = '0x-api-key';
+export const HEALTHCHECK_PATH = '/healthz';
 
 // Docs
 export const SWAP_DOCS_URL = 'https://0x.org/docs/api#swap';

--- a/src/handlers/healthcheck_handlers.ts
+++ b/src/handlers/healthcheck_handlers.ts
@@ -1,0 +1,15 @@
+import * as express from 'express';
+
+import { HealthcheckService } from '../services/healthcheck_service';
+
+export class HealthcheckHandlers {
+    private readonly _healthcheckService: HealthcheckService;
+
+    constructor(healthcheckService: HealthcheckService) {
+        this._healthcheckService = healthcheckService;
+    }
+
+    public serveHealthcheck(_req: express.Request, res: express.Response): void {
+        res.send(this._healthcheckService.getHealth());
+    }
+}

--- a/src/handlers/healthcheck_handlers.ts
+++ b/src/handlers/healthcheck_handlers.ts
@@ -1,4 +1,5 @@
 import * as express from 'express';
+import * as HttpStatus from 'http-status-codes';
 
 import { HealthcheckService } from '../services/healthcheck_service';
 
@@ -10,6 +11,11 @@ export class HealthcheckHandlers {
     }
 
     public serveHealthcheck(_req: express.Request, res: express.Response): void {
-        res.send(this._healthcheckService.getHealth());
+        const isHealthy = this._healthcheckService.isHealthy();
+        if (isHealthy) {
+            res.status(HttpStatus.OK).send({ isHealthy });
+        } else {
+            res.status(HttpStatus.SERVICE_UNAVAILABLE).send({ isHealthy });
+        }
     }
 }

--- a/src/routers/healthcheck_router.ts
+++ b/src/routers/healthcheck_router.ts
@@ -1,0 +1,14 @@
+import * as express from 'express';
+
+import { HealthcheckHandlers } from '../handlers/healthcheck_handlers';
+import { HealthcheckService } from '../services/healthcheck_service';
+
+export const createHealthcheckRouter = (healthcheckService: HealthcheckService): express.Router => {
+    const router = express.Router();
+    const handlers = new HealthcheckHandlers(healthcheckService);
+    /**
+     * GET healthcheck endpoint returns the health of the http server.
+     */
+    router.get('/', handlers.serveHealthcheck.bind(handlers));
+    return router;
+};

--- a/src/runners/http_meta_transaction_service_runner.ts
+++ b/src/runners/http_meta_transaction_service_runner.ts
@@ -57,6 +57,5 @@ async function runHttpServiceAsync(
     }
     app.use(errorHandler);
     server.listen(config.httpPort);
-    logger.info(`server listening on ${config.httpPort}`);
     return server;
 }

--- a/src/runners/http_meta_transaction_service_runner.ts
+++ b/src/runners/http_meta_transaction_service_runner.ts
@@ -1,5 +1,3 @@
-import * as bodyParser from 'body-parser';
-import * as cors from 'cors';
 import * as express from 'express';
 // tslint:disable-next-line:no-implicit-dependencies
 import * as core from 'express-serve-static-core';
@@ -11,10 +9,11 @@ import { META_TRANSACTION_PATH } from '../constants';
 import { rootHandler } from '../handlers/root_handler';
 import { logger } from '../logger';
 import { errorHandler } from '../middleware/error_handling';
-import { requestLogger } from '../middleware/request_logger';
 import { createMetaTransactionRouter } from '../routers/meta_transaction_router';
 import { HttpServiceConfig } from '../types';
 import { providerUtils } from '../utils/provider_utils';
+
+import { createDefaultServer } from './utils';
 
 /**
  * This module can be used to run the Meta Transaction HTTP service standalone
@@ -45,14 +44,8 @@ async function runHttpServiceAsync(
     _app?: core.Express,
 ): Promise<Server> {
     const app = _app || express();
-    app.use(requestLogger());
-    app.use(cors());
-    app.use(bodyParser.json());
+    const server = createDefaultServer(dependencies, config, app);
     app.get('/', rootHandler);
-    const server = app.listen(config.httpPort, () => {
-        logger.info(`API (HTTP) listening on port ${config.httpPort}!`);
-    });
-
     if (dependencies.metaTransactionService) {
         app.use(
             META_TRANSACTION_PATH,
@@ -63,5 +56,7 @@ async function runHttpServiceAsync(
         process.exit(1);
     }
     app.use(errorHandler);
+    server.listen(config.httpPort);
+    logger.info(`server listening on ${config.httpPort}`);
     return server;
 }

--- a/src/runners/http_service_runner.ts
+++ b/src/runners/http_service_runner.ts
@@ -125,7 +125,6 @@ export async function runHttpServiceAsync(
         process.exit(1);
     }
     server.listen(config.httpPort);
-    logger.info(`server listening on ${config.httpPort}`);
     return {
         server,
         wsService,

--- a/src/runners/http_service_runner.ts
+++ b/src/runners/http_service_runner.ts
@@ -1,5 +1,3 @@
-import bodyParser = require('body-parser');
-import * as cors from 'cors';
 import * as express from 'express';
 // tslint:disable-next-line:no-implicit-dependencies
 import * as core from 'express-serve-static-core';
@@ -12,7 +10,6 @@ import { rootHandler } from '../handlers/root_handler';
 import { logger } from '../logger';
 import { addressNormalizer } from '../middleware/address_normalizer';
 import { errorHandler } from '../middleware/error_handling';
-import { requestLogger } from '../middleware/request_logger';
 import { createMetaTransactionRouter } from '../routers/meta_transaction_router';
 import { createMetricsRouter } from '../routers/metrics_router';
 import { createSRARouter } from '../routers/sra_router';
@@ -21,6 +18,8 @@ import { createSwapRouter } from '../routers/swap_router';
 import { WebsocketService } from '../services/websocket_service';
 import { HttpServiceConfig } from '../types';
 import { providerUtils } from '../utils/provider_utils';
+
+import { createDefaultServer } from './utils';
 
 /**
  * http_service_runner hosts endpoints for staking, sra, swap and meta-txns (minus the /submit endpoint)
@@ -63,19 +62,12 @@ export async function runHttpServiceAsync(
     _app?: core.Express,
 ): Promise<HttpServices> {
     const app = _app || express();
-    app.use(requestLogger());
-    app.use(cors());
-    app.use(bodyParser.json());
+    const server = createDefaultServer(dependencies, config, app);
 
     app.get('/', rootHandler);
-    const server = app.listen(config.httpPort, () => {
-        logger.info(`API (HTTP) listening on port ${config.httpPort}!`);
-    });
     server.on('error', err => {
         logger.error(err);
     });
-    server.keepAliveTimeout = config.httpKeepAliveTimeout;
-    server.headersTimeout = config.httpHeadersTimeout;
 
     // transform all values of `req.query.[xx]Address` to lowercase
     app.use(addressNormalizer);
@@ -132,7 +124,8 @@ export async function runHttpServiceAsync(
         logger.error(`Could not establish mesh connection, exiting`);
         process.exit(1);
     }
-
+    server.listen(config.httpPort);
+    logger.info(`server listening on ${config.httpPort}`);
     return {
         server,
         wsService,

--- a/src/runners/http_sra_service_runner.ts
+++ b/src/runners/http_sra_service_runner.ts
@@ -63,6 +63,5 @@ async function runHttpServiceAsync(
     }
 
     server.listen(config.httpPort);
-    logger.info(`server listening on ${config.httpPort}`);
     return server;
 }

--- a/src/runners/http_sra_service_runner.ts
+++ b/src/runners/http_sra_service_runner.ts
@@ -1,9 +1,6 @@
 /**
  * This module can be used to run the SRA HTTP service standalone
  */
-
-import bodyParser = require('body-parser');
-import * as cors from 'cors';
 import * as express from 'express';
 // tslint:disable-next-line:no-implicit-dependencies
 import * as core from 'express-serve-static-core';
@@ -16,11 +13,12 @@ import { rootHandler } from '../handlers/root_handler';
 import { logger } from '../logger';
 import { addressNormalizer } from '../middleware/address_normalizer';
 import { errorHandler } from '../middleware/error_handling';
-import { requestLogger } from '../middleware/request_logger';
 import { createSRARouter } from '../routers/sra_router';
 import { WebsocketService } from '../services/websocket_service';
 import { HttpServiceConfig } from '../types';
 import { providerUtils } from '../utils/provider_utils';
+
+import { createDefaultServer } from './utils';
 
 process.on('uncaughtException', err => {
     logger.error(err);
@@ -47,18 +45,11 @@ async function runHttpServiceAsync(
     _app?: core.Express,
 ): Promise<Server> {
     const app = _app || express();
-    app.use(requestLogger());
-    app.use(cors());
-    app.use(bodyParser.json());
-    app.get('/', rootHandler);
-    const server = app.listen(config.httpPort, () => {
-        logger.info(`API (HTTP) listening on port ${config.httpPort}!`);
-    });
-    server.keepAliveTimeout = config.httpKeepAliveTimeout;
-    server.headersTimeout = config.httpHeadersTimeout;
-
-    // SRA http service
     app.use(addressNormalizer);
+    const server = createDefaultServer(dependencies, config, app);
+
+    app.get('/', rootHandler);
+    // SRA http service
     app.use(SRA_PATH, createSRARouter(dependencies.orderBookService));
     app.use(errorHandler);
 
@@ -71,5 +62,7 @@ async function runHttpServiceAsync(
         process.exit(1);
     }
 
+    server.listen(config.httpPort);
+    logger.info(`server listening on ${config.httpPort}`);
     return server;
 }

--- a/src/runners/http_staking_service_runner.ts
+++ b/src/runners/http_staking_service_runner.ts
@@ -1,9 +1,6 @@
 /**
  * This module can be used to run the Staking HTTP service standalone
  */
-
-import bodyParser = require('body-parser');
-import * as cors from 'cors';
 import * as express from 'express';
 // tslint:disable-next-line:no-implicit-dependencies
 import * as core from 'express-serve-static-core';
@@ -16,10 +13,11 @@ import { rootHandler } from '../handlers/root_handler';
 import { logger } from '../logger';
 import { addressNormalizer } from '../middleware/address_normalizer';
 import { errorHandler } from '../middleware/error_handling';
-import { requestLogger } from '../middleware/request_logger';
 import { createStakingRouter } from '../routers/staking_router';
 import { HttpServiceConfig } from '../types';
 import { providerUtils } from '../utils/provider_utils';
+
+import { createDefaultServer } from './utils';
 
 process.on('uncaughtException', err => {
     logger.error(err);
@@ -46,19 +44,15 @@ async function runHttpServiceAsync(
     _app?: core.Express,
 ): Promise<Server> {
     const app = _app || express();
-    app.use(requestLogger());
-    app.use(cors());
-    app.use(bodyParser.json());
     app.use(addressNormalizer);
-    app.get('/', rootHandler);
-    const server = app.listen(config.httpPort, () => {
-        logger.info(`API (HTTP) listening on port ${config.httpPort}!`);
-    });
-    server.keepAliveTimeout = config.httpKeepAliveTimeout;
-    server.headersTimeout = config.httpHeadersTimeout;
+    const server = createDefaultServer(dependencies, config, app);
 
+    app.get('/', rootHandler);
     // staking http service
     app.use(STAKING_PATH, createStakingRouter(dependencies.stakingDataService));
     app.use(errorHandler);
+
+    server.listen(config.httpPort);
+    logger.info(`server listening on ${config.httpPort}`);
     return server;
 }

--- a/src/runners/http_staking_service_runner.ts
+++ b/src/runners/http_staking_service_runner.ts
@@ -53,6 +53,5 @@ async function runHttpServiceAsync(
     app.use(errorHandler);
 
     server.listen(config.httpPort);
-    logger.info(`server listening on ${config.httpPort}`);
     return server;
 }

--- a/src/runners/http_swap_service_runner.ts
+++ b/src/runners/http_swap_service_runner.ts
@@ -2,8 +2,6 @@
  * This module can be used to run the Swap HTTP service standalone
  */
 
-import bodyParser = require('body-parser');
-import * as cors from 'cors';
 import * as express from 'express';
 // tslint:disable-next-line:no-implicit-dependencies
 import * as core from 'express-serve-static-core';
@@ -16,10 +14,11 @@ import { rootHandler } from '../handlers/root_handler';
 import { logger } from '../logger';
 import { addressNormalizer } from '../middleware/address_normalizer';
 import { errorHandler } from '../middleware/error_handling';
-import { requestLogger } from '../middleware/request_logger';
 import { createSwapRouter } from '../routers/swap_router';
 import { HttpServiceConfig } from '../types';
 import { providerUtils } from '../utils/provider_utils';
+
+import { createDefaultServer } from './utils';
 
 process.on('uncaughtException', err => {
     logger.error(err);
@@ -46,16 +45,10 @@ async function runHttpServiceAsync(
     _app?: core.Express,
 ): Promise<Server> {
     const app = _app || express();
-    app.use(requestLogger());
-    app.use(cors());
-    app.use(bodyParser.json());
     app.use(addressNormalizer);
+    const server = createDefaultServer(dependencies, config, app);
+
     app.get('/', rootHandler);
-    const server = app.listen(config.httpPort, () => {
-        logger.info(`API (HTTP) listening on port ${config.httpPort}!`);
-    });
-    server.keepAliveTimeout = config.httpKeepAliveTimeout;
-    server.headersTimeout = config.httpHeadersTimeout;
 
     if (dependencies.swapService) {
         app.use(SWAP_PATH, createSwapRouter(dependencies.swapService));
@@ -64,5 +57,8 @@ async function runHttpServiceAsync(
         process.exit(1);
     }
     app.use(errorHandler);
+
+    server.listen(config.httpPort);
+    logger.info(`server listening on ${config.httpPort}`);
     return server;
 }

--- a/src/runners/http_swap_service_runner.ts
+++ b/src/runners/http_swap_service_runner.ts
@@ -59,6 +59,5 @@ async function runHttpServiceAsync(
     app.use(errorHandler);
 
     server.listen(config.httpPort);
-    logger.info(`server listening on ${config.httpPort}`);
     return server;
 }

--- a/src/runners/utils.ts
+++ b/src/runners/utils.ts
@@ -43,14 +43,14 @@ export function createDefaultServer(
         logger.info(`received: ${sig}, shutting down server`);
         healthcheckService.setHealth(false);
         server.close(async err => {
-            if (!server.listening) {
-                process.exit(0);
+            if (dependencies.meshClient) {
+                dependencies.meshClient.destroy();
             }
             if (dependencies.connection) {
                 await dependencies.connection.close();
             }
-            if (dependencies.meshClient) {
-                dependencies.meshClient.destroy();
+            if (!server.listening) {
+                process.exit(0);
             }
             if (err) {
                 logger.error(`server closed with an error: ${err}, exiting`);

--- a/src/runners/utils.ts
+++ b/src/runners/utils.ts
@@ -36,12 +36,12 @@ export function createDefaultServer(
     const shutdownFunc = (sig: string) => {
         logger.info(`received: ${sig}, shutting down server`);
         healthcheckService.setHealth(false);
-        server.close(err => {
+        server.close(async err => {
             if (!server.listening) {
                 process.exit(0);
             }
             if (dependencies.connection) {
-                dependencies.connection.close();
+                await dependencies.connection.close();
             }
             if (dependencies.meshClient) {
                 dependencies.meshClient.destroy();

--- a/src/runners/utils.ts
+++ b/src/runners/utils.ts
@@ -29,11 +29,16 @@ export function createDefaultServer(
     const server = createServer(app);
     server.keepAliveTimeout = config.httpKeepAliveTimeout;
     server.headersTimeout = config.httpHeadersTimeout;
+    const healthcheckService = new HealthcheckService();
+
     server.on('close', () => {
         logger.info('http server shutdown');
     });
+    server.on('listening', () => {
+        logger.info(`server listening on ${config.httpPort}`);
+        healthcheckService.setHealth(true);
+    });
 
-    const healthcheckService = new HealthcheckService();
     const shutdownFunc = (sig: string) => {
         logger.info(`received: ${sig}, shutting down server`);
         healthcheckService.setHealth(false);
@@ -69,5 +74,6 @@ export function createDefaultServer(
     }
     process.on('SIGINT', shutdownFunc);
     process.on('SIGTERM', shutdownFunc);
+    process.on('SIGQUIT', shutdownFunc);
     return server;
 }

--- a/src/services/healthcheck_service.ts
+++ b/src/services/healthcheck_service.ts
@@ -1,7 +1,7 @@
 export class HealthcheckService {
     private _isHealthy: boolean;
     constructor() {
-        this._isHealthy = true;
+        this._isHealthy = false;
     }
 
     public setHealth(val: boolean): void {

--- a/src/services/healthcheck_service.ts
+++ b/src/services/healthcheck_service.ts
@@ -8,7 +8,7 @@ export class HealthcheckService {
         this._isHealthy = val;
     }
 
-    public getHealth(): boolean {
+    public isHealthy(): boolean {
         return this._isHealthy;
     }
 }

--- a/src/services/healthcheck_service.ts
+++ b/src/services/healthcheck_service.ts
@@ -1,0 +1,14 @@
+export class HealthcheckService {
+    private _isHealthy: boolean;
+    constructor() {
+        this._isHealthy = true;
+    }
+
+    public setHealth(val: boolean): void {
+        this._isHealthy = val;
+    }
+
+    public getHealth(): boolean {
+        return this._isHealthy;
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -592,6 +592,7 @@ export interface TransactionWatcherSignerServiceConfig {
 
 export interface HttpServiceConfig {
     httpPort: number;
+    healthcheckHttpPort: number;
     ethereumRpcUrl: string;
     httpKeepAliveTimeout: number;
     httpHeadersTimeout: number;

--- a/test/utils/deployment.ts
+++ b/test/utils/deployment.ts
@@ -229,7 +229,7 @@ async function waitForApiStartupAsync(logStream: ChildProcessWithoutNullStreams)
         logStream.stdout.on('data', (chunk: Buffer) => {
             const data = chunk.toString().split('\n');
             for (const datum of data) {
-                if (/API \(HTTP\) listening on port 3000!/.test(datum)) {
+                if (/server listening.*/.test(datum)) {
                     resolve();
                 }
             }


### PR DESCRIPTION
# Description

This PR adds a `createDefaultServer` function to be used across all HTTP runners which prepares a `http.Server` with:
- Header timeouts `server.keepAliveTimeout` &  `server.headersTimeout`
- Healthcheck service exposed at `/healthz`
- Graceful shutdown through [server.close](https://nodejs.org/api/http.html#http_server_close_callback)
- Adds common middleware: `requestLogger`, `cors`, `bodyParser`

# Testing Instructions
This PR has been tested on staging, however we can still unit test the graceful shutdown:
- [ ] Add unit test for graceful shutdowns

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [x] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
