### PR TITLE
feat: Depth Chart API endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-9a16f5736",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-ae2a6fb68",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "^4.11.0",
         "@0x/contract-wrappers": "^13.7.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -330,7 +330,7 @@ export const ASSET_SWAPPER_MARKET_ORDERS_V0_OPTS: Partial<SwapQuoteRequestOpts> 
     feeSchedule: FEE_SCHEDULE_V0,
     gasSchedule: GAS_SCHEDULE_V0,
     shouldBatchBridgeOrders: true,
-    runLimit: 2 ** 13,
+    runLimit: 2 ** 8,
 };
 
 export const GAS_SCHEDULE_V1: FeeSchedule = {
@@ -356,7 +356,7 @@ export const ASSET_SWAPPER_MARKET_ORDERS_V1_OPTS: Partial<SwapQuoteRequestOpts> 
     feeSchedule: FEE_SCHEDULE_V1,
     gasSchedule: GAS_SCHEDULE_V1,
     shouldBatchBridgeOrders: false,
-    runLimit: 2 ** 13,
+    runLimit: 2 ** 8,
 };
 
 export const SAMPLER_OVERRIDES: SamplerOverrides | undefined = (() => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -89,3 +89,8 @@ export const GST2_WALLET_ADDRESSES = {
     [ChainId.Kovan]: NULL_ADDRESS,
     [ChainId.Ganache]: NULL_ADDRESS,
 };
+
+// Market Depth
+export const MARKET_DEPTH_MAX_SAMPLES = 50;
+export const MARKET_DEPTH_DEFAULT_DISTRIBUTION = 1.05;
+export const MARKET_DEPTH_END_PRICE_SLIPPAGE_PERC = 20;

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -4,7 +4,12 @@ import * as express from 'express';
 import * as HttpStatus from 'http-status-codes';
 
 import { CHAIN_ID } from '../config';
-import { DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE, SWAP_DOCS_URL } from '../constants';
+import {
+    DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE,
+    MARKET_DEPTH_DEFAULT_DISTRIBUTION,
+    MARKET_DEPTH_MAX_SAMPLES,
+    SWAP_DOCS_URL,
+} from '../constants';
 import {
     InternalServerError,
     RevertAPIError,
@@ -129,25 +134,21 @@ export class SwapHandlers {
     public async getMarketDepthAsync(req: express.Request, res: express.Response): Promise<void> {
         const makerToken = getTokenMetadataIfExists(req.query.buyToken as string, CHAIN_ID);
         const takerToken = getTokenMetadataIfExists(req.query.sellToken as string, CHAIN_ID);
-        try {
-            const response = await this._swapService.calculateMarketDepthAsync({
-                buyToken: makerToken,
-                sellToken: takerToken,
-                sellAmount: new BigNumber(req.query.sellAmount as string),
-                // tslint:disable-next-line:radix custom-no-magic-numbers
-                numSamples: req.query.numSamples ? parseInt(req.query.numSamples as string) : 100,
-                sampleDistributionBase: req.query.sampleDistributionBase
-                    ? parseFloat(req.query.sampleDistributionBase as string)
-                    : 1.05,
-                excludedSources: req.query.excludedSources === undefined
+        const response = await this._swapService.calculateMarketDepthAsync({
+            buyToken: makerToken,
+            sellToken: takerToken,
+            sellAmount: new BigNumber(req.query.sellAmount as string),
+            // tslint:disable-next-line:radix custom-no-magic-numbers
+            numSamples: req.query.numSamples ? parseInt(req.query.numSamples as string) : MARKET_DEPTH_MAX_SAMPLES,
+            sampleDistributionBase: req.query.sampleDistributionBase
+                ? parseFloat(req.query.sampleDistributionBase as string)
+                : MARKET_DEPTH_DEFAULT_DISTRIBUTION,
+            excludedSources:
+                req.query.excludedSources === undefined
                     ? []
                     : parseUtils.parseStringArrForERC20BridgeSources((req.query.excludedSources as string).split(',')),
-            });
-            res.status(HttpStatus.OK).send({ ...response, buyToken: makerToken, sellToken: takerToken });
-        } catch (e) {
-            console.log(e);
-            throw e;
-        }
+        });
+        res.status(HttpStatus.OK).send({ ...response, buyToken: makerToken, sellToken: takerToken });
     }
 
     private async _calculateSwapQuoteAsync(

--- a/src/routers/swap_router.ts
+++ b/src/routers/swap_router.ts
@@ -12,6 +12,7 @@ export function createSwapRouter(swapService: SwapService): express.Router {
     router.get('/v0', asyncHandler(SwapHandlers.rootAsync.bind(SwapHandlers)));
     router.get('/v0/prices', asyncHandler(handlers.getTokenPricesAsync.bind(handlers)));
     router.get('/v0/tokens', asyncHandler(handlers.getSwapTokensAsync.bind(handlers)));
+    router.get('/v0/depth', asyncHandler(handlers.getMarketDepthAsync.bind(handlers)));
 
     router.get('/v0/quote', asyncHandler(handlers.getSwapQuoteAsync.bind(handlers, SwapVersion.V0)));
     router.get('/v0/price', asyncHandler(handlers.getSwapPriceAsync.bind(handlers, SwapVersion.V0)));

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -276,8 +276,8 @@ export class SwapService {
     public async calculateMarketDepthAsync(
         params: CalaculateMarketDepthParams,
     ): Promise<{
-        asks: { dataByBucketPrice: BucketedPriceDepth[] };
-        bids: { dataByBucketPrice: BucketedPriceDepth[] };
+        asks: { depth: BucketedPriceDepth[] };
+        bids: { depth: BucketedPriceDepth[] };
     }> {
         const { buyToken, sellToken, sellAmount, numSamples, sampleDistributionBase, excludedSources } = params;
         const marketDepth = await this._swapQuoter.getBidAskLiquidityForMakerTakerAssetPairAsync(
@@ -318,10 +318,10 @@ export class SwapService {
         return {
             // We're buying buyToken and SELLING sellToken (DAI) (50k)
             // Price goes from HIGH to LOW
-            asks: { dataByBucketPrice: askDepth },
+            asks: { depth: askDepth },
             // We're BUYING sellToken (DAI) (50k) and selling buyToken
             // Price goes from LOW to HIGH
-            bids: { dataByBucketPrice: bidDepth },
+            bids: { depth: bidDepth },
         };
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -622,4 +622,11 @@ export interface CalaculateMarketDepthParams {
     sampleDistributionBase: number;
     excludedSources?: ERC20BridgeSource[];
 }
+
+export interface BucketedPriceDepth {
+    cumulative: BigNumber;
+    price: BigNumber;
+    bucket: number;
+    bucketTotal: BigNumber;
+}
 // tslint:disable-line:max-file-line-count

--- a/src/types.ts
+++ b/src/types.ts
@@ -613,4 +613,13 @@ export interface HttpServiceConfig {
     meshHttpUri?: string;
     metaTxnRateLimiters?: MetaTransactionRateLimitConfig;
 }
+
+export interface CalaculateMarketDepthParams {
+    buyToken: TokenMetadata;
+    sellToken: TokenMetadata;
+    sellAmount: BigNumber;
+    numSamples: number;
+    sampleDistributionBase: number;
+    excludedSources?: ERC20BridgeSource[];
+}
 // tslint:disable-line:max-file-line-count

--- a/src/utils/market_depth_utils.ts
+++ b/src/utils/market_depth_utils.ts
@@ -1,0 +1,158 @@
+import {
+    DexSample,
+    ERC20BridgeSource,
+    MarketDepthSide,
+    NativeFillData,
+} from '@0x/asset-swapper/lib/src/utils/market_operation_utils/types';
+import { MarketOperation } from '@0x/types';
+import { BigNumber } from '@0x/utils';
+import { Web3Wrapper } from '@0x/web3-wrapper';
+import _ = require('lodash');
+
+import { ZERO } from '../constants';
+import { TokenMetadata } from '../types';
+
+export const marketDepthUtils = {
+    getBucketPrices: (
+        startAmount: BigNumber,
+        endAmount: BigNumber,
+        numSamples: number,
+        sampleDistributionBase: number = 1,
+    ): BigNumber[] => {
+        const amount = endAmount.minus(startAmount);
+        const distribution = [...Array<BigNumber>(numSamples)].map((_v, i) =>
+            new BigNumber(sampleDistributionBase).pow(i),
+        );
+        const stepSizes = distribution.map(d => d.div(BigNumber.sum(...distribution)));
+        const amounts = stepSizes.map((_s, i) => {
+            return amount.times(BigNumber.sum(...[0, ...stepSizes.slice(0, i + 1)])).plus(startAmount);
+        });
+        return [startAmount, ...amounts, endAmount];
+    },
+    calculateUnitPrice: (
+        input: BigNumber,
+        output: BigNumber,
+        outputToken: TokenMetadata,
+        inputToken: TokenMetadata,
+    ): BigNumber => {
+        if (output && input && output.isGreaterThan(0)) {
+            return Web3Wrapper.toUnitAmount(output, outputToken.decimals).dividedBy(
+                Web3Wrapper.toUnitAmount(input, inputToken.decimals),
+            );
+        }
+        return ZERO;
+    },
+    getSampleAmountsFromDepthSide: (depthSide: MarketDepthSide): BigNumber[] => {
+        // Native is not a "sampled" output, here we convert it to be a accumulated sample output
+        const nativeIndexIfExists = depthSide.findIndex(s => s[0] && s[0].source === ERC20BridgeSource.Native);
+        // Find an on-chain source which has samples, if possible
+        const nonNativeIndexIfExists = depthSide.findIndex(s => s[0] && s[0].source !== ERC20BridgeSource.Native);
+        // If we don't have a on-chain samples, just use the native orders inputs for a super rough guide
+        const sampleAmounts =
+            nonNativeIndexIfExists !== -1
+                ? depthSide[nonNativeIndexIfExists].map(s => s.input)
+                : _.uniqBy<BigNumber>(
+                      depthSide[nativeIndexIfExists].map(s => s.input),
+                      a => a.toString(),
+                  );
+        return sampleAmounts;
+    },
+    sampleNativeOrders: (path: Array<DexSample<NativeFillData>>, targetInput: BigNumber): BigNumber => {
+        const sortedPath = path.sort((a, b) => a.output.dividedBy(a.input).comparedTo(b.output.dividedBy(b.input)));
+        let totalOutput = ZERO;
+        let totalInput = ZERO;
+        for (const fill of sortedPath) {
+            if (totalInput.gte(targetInput)) {
+                break;
+            }
+            const input = BigNumber.min(targetInput.minus(totalInput), fill.input);
+            const output = input.times(fill.output.dividedBy(fill.input)).integerValue();
+            totalOutput = totalOutput.plus(output);
+            totalInput = totalInput.plus(input);
+        }
+        if (totalInput.isLessThan(targetInput)) {
+            return ZERO;
+        }
+        return totalOutput;
+    },
+    normalizeMarketDepthToSampleOutput: (depthSide: MarketDepthSide, _operation: MarketOperation): MarketDepthSide => {
+        // Native is not a "sampled" output, here we convert it to be a accumulated sample output
+        const nativeIndexIfExists = depthSide.findIndex(
+            s => s[0] && s[0].source === ERC20BridgeSource.Native && s[0].output,
+        );
+        if (nativeIndexIfExists === -1) {
+            return depthSide.filter(s => s && s.length > 0);
+        }
+        // We should now have [1, 10, 100] sample amounts
+        const sampleAmounts = marketDepthUtils.getSampleAmountsFromDepthSide(depthSide);
+        const nativeSamples = sampleAmounts.map(a => ({
+            input: a,
+            output: marketDepthUtils.sampleNativeOrders(
+                depthSide[nativeIndexIfExists] as Array<DexSample<NativeFillData>>,
+                a,
+            ),
+            source: ERC20BridgeSource.Native,
+        }));
+        const normalizedDepth = [
+            ...depthSide.filter(s => s[0] && s[0].source !== ERC20BridgeSource.Native),
+            nativeSamples,
+        ].filter(s => s.length > 0);
+        return normalizedDepth;
+    },
+
+    calculateStartEndBucketPrice: (depthSide: MarketDepthSide, side: MarketOperation): [BigNumber, BigNumber] => {
+        const pricesByAmount = depthSide
+            .map(samples =>
+                samples
+                    .map(s => (!s.output.isZero() ? s.output.dividedBy(s.input) : ZERO))
+                    .filter(s => s.isGreaterThan(ZERO)),
+            )
+            .filter(samples => samples.length > 0);
+        let bestInBracket: BigNumber;
+        let worstBestInBracket: BigNumber;
+        if (side === MarketOperation.Sell) {
+            // Sell we want to sell for a higher price as possible
+            console.log(pricesByAmount);
+            bestInBracket = BigNumber.max(...pricesByAmount.map(s => BigNumber.max(...s)));
+            worstBestInBracket = BigNumber.min(...pricesByAmount.map(s => BigNumber.max(...s)));
+        } else {
+            // Buy we want to buy for the lowest price possible
+            bestInBracket = BigNumber.min(...pricesByAmount.map(s => BigNumber.min(...s)));
+            worstBestInBracket = BigNumber.max(...pricesByAmount.map(s => BigNumber.min(...s)));
+        }
+        // return [bestInBracket, worstBestInBracket.minus(bestInBracket).plus(worstBestInBracket)];
+        return [bestInBracket, worstBestInBracket];
+    },
+
+    distributeSamplesToBuckets: (depthSide: MarketDepthSide, buckets: BigNumber[], side: MarketOperation) => {
+        const allocatedBuckets = buckets.map((b, i) => ({ price: b, bucket: i, bucketTotal: ZERO }));
+        const getBucketId = (price: BigNumber): number => {
+            return buckets.findIndex(b =>
+                side === MarketOperation.Sell ? price.isGreaterThanOrEqualTo(b) : price.isLessThanOrEqualTo(b),
+            );
+        };
+        for (const samples of depthSide) {
+            const source = samples[0].source;
+            for (const sample of samples) {
+                if (sample.output.isZero()) {
+                    continue;
+                }
+                const price = sample.output.dividedBy(sample.input);
+                const bucketId = getBucketId(price);
+                if (bucketId === -1) {
+                    console.log('No bucket for price', price, source);
+                    continue;
+                }
+                const bucket = allocatedBuckets[bucketId];
+                bucket.bucketTotal = bucket.bucketTotal.plus(sample.output);
+                bucket[source] = bucket[source] ? bucket[source].plus(sample.output) : sample.output;
+            }
+        }
+        let totalCumulative = ZERO;
+        const cumulativeBuckets = allocatedBuckets.map(b => {
+            totalCumulative = totalCumulative.plus(b.bucketTotal);
+            return { ...b, cumulative: totalCumulative };
+        });
+        return cumulativeBuckets;
+    },
+};

--- a/src/utils/market_depth_utils.ts
+++ b/src/utils/market_depth_utils.ts
@@ -154,10 +154,13 @@ export const marketDepthUtils = {
             }
             switch (source) {
                 case ERC20BridgeSource.Curve:
+                    // tslint:disable-next-line:no-unnecessary-type-assertion
                     return `${source}:${(sample.fillData as CurveFillData).curve.poolAddress}`;
                 case ERC20BridgeSource.Balancer:
+                    // tslint:disable-next-line:no-unnecessary-type-assertion
                     return `${source}:${(sample.fillData as BalancerFillData).poolAddress}`;
                 case ERC20BridgeSource.UniswapV2:
+                    // tslint:disable-next-line:no-unnecessary-type-assertion
                     return `${source}:${(sample.fillData as UniswapV2FillData).tokenAddressPath.join('-')}`;
                 default:
                     break;

--- a/src/utils/market_depth_utils.ts
+++ b/src/utils/market_depth_utils.ts
@@ -9,8 +9,17 @@ import { BigNumber } from '@0x/utils';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import _ = require('lodash');
 
-import { ZERO } from '../constants';
-import { TokenMetadata } from '../types';
+import {
+    MARKET_DEPTH_DEFAULT_DISTRIBUTION,
+    MARKET_DEPTH_END_PRICE_SLIPPAGE_PERC,
+    MARKET_DEPTH_MAX_SAMPLES,
+    ZERO,
+} from '../constants';
+import { BucketedPriceDepth, TokenMetadata } from '../types';
+
+// tslint:disable:custom-no-magic-numbers
+const MAX_DECIMALS = 18;
+const ONE_HUNDRED_PERC = 100;
 
 export const marketDepthUtils = {
     getBucketPrices: (
@@ -21,13 +30,16 @@ export const marketDepthUtils = {
     ): BigNumber[] => {
         const amount = endAmount.minus(startAmount);
         const distribution = [...Array<BigNumber>(numSamples)].map((_v, i) =>
-            new BigNumber(sampleDistributionBase).pow(i),
+            new BigNumber(sampleDistributionBase).pow(i).decimalPlaces(MAX_DECIMALS),
         );
         const stepSizes = distribution.map(d => d.div(BigNumber.sum(...distribution)));
         const amounts = stepSizes.map((_s, i) => {
-            return amount.times(BigNumber.sum(...[0, ...stepSizes.slice(0, i + 1)])).plus(startAmount);
+            return amount
+                .times(BigNumber.sum(...[0, ...stepSizes.slice(0, i + 1)]))
+                .plus(startAmount)
+                .decimalPlaces(MAX_DECIMALS);
         });
-        return [startAmount, ...amounts, endAmount];
+        return [startAmount, ...amounts];
     },
     calculateUnitPrice: (
         input: BigNumber,
@@ -58,7 +70,7 @@ export const marketDepthUtils = {
         return sampleAmounts;
     },
     sampleNativeOrders: (path: Array<DexSample<NativeFillData>>, targetInput: BigNumber): BigNumber => {
-        const sortedPath = path.sort((a, b) => a.output.dividedBy(a.input).comparedTo(b.output.dividedBy(b.input)));
+        const sortedPath = path.sort((a, b) => b.output.dividedBy(b.input).comparedTo(a.output.dividedBy(a.input)));
         let totalOutput = ZERO;
         let totalInput = ZERO;
         for (const fill of sortedPath) {
@@ -71,11 +83,13 @@ export const marketDepthUtils = {
             totalInput = totalInput.plus(input);
         }
         if (totalInput.isLessThan(targetInput)) {
+            // TODO do I really want to do this
             return ZERO;
         }
+        console.log('native sample', { targetInput, totalInput, totalOutput });
         return totalOutput;
     },
-    normalizeMarketDepthToSampleOutput: (depthSide: MarketDepthSide, _operation: MarketOperation): MarketDepthSide => {
+    normalizeMarketDepthToSampleOutput: (depthSide: MarketDepthSide): MarketDepthSide => {
         // Native is not a "sampled" output, here we convert it to be a accumulated sample output
         const nativeIndexIfExists = depthSide.findIndex(
             s => s[0] && s[0].source === ERC20BridgeSource.Native && s[0].output,
@@ -100,11 +114,15 @@ export const marketDepthUtils = {
         return normalizedDepth;
     },
 
-    calculateStartEndBucketPrice: (depthSide: MarketDepthSide, side: MarketOperation): [BigNumber, BigNumber] => {
+    calculateStartEndBucketPrice: (
+        depthSide: MarketDepthSide,
+        side: MarketOperation,
+        endSlippagePerc = 20,
+    ): [BigNumber, BigNumber] => {
         const pricesByAmount = depthSide
             .map(samples =>
                 samples
-                    .map(s => (!s.output.isZero() ? s.output.dividedBy(s.input) : ZERO))
+                    .map(s => (!s.output.isZero() ? s.output.dividedBy(s.input).decimalPlaces(MAX_DECIMALS) : ZERO))
                     .filter(s => s.isGreaterThan(ZERO)),
             )
             .filter(samples => samples.length > 0);
@@ -112,15 +130,13 @@ export const marketDepthUtils = {
         let worstBestInBracket: BigNumber;
         if (side === MarketOperation.Sell) {
             // Sell we want to sell for a higher price as possible
-            console.log(pricesByAmount);
             bestInBracket = BigNumber.max(...pricesByAmount.map(s => BigNumber.max(...s)));
-            worstBestInBracket = BigNumber.min(...pricesByAmount.map(s => BigNumber.max(...s)));
+            worstBestInBracket = bestInBracket.times((ONE_HUNDRED_PERC - endSlippagePerc) / ONE_HUNDRED_PERC);
         } else {
             // Buy we want to buy for the lowest price possible
             bestInBracket = BigNumber.min(...pricesByAmount.map(s => BigNumber.min(...s)));
-            worstBestInBracket = BigNumber.max(...pricesByAmount.map(s => BigNumber.min(...s)));
+            worstBestInBracket = bestInBracket.times((ONE_HUNDRED_PERC + endSlippagePerc) / ONE_HUNDRED_PERC);
         }
-        // return [bestInBracket, worstBestInBracket.minus(bestInBracket).plus(worstBestInBracket)];
         return [bestInBracket, worstBestInBracket];
     },
 
@@ -140,7 +156,7 @@ export const marketDepthUtils = {
                 const price = sample.output.dividedBy(sample.input);
                 const bucketId = getBucketId(price);
                 if (bucketId === -1) {
-                    console.log('No bucket for price', price, source);
+                    // No bucket available so we ignore
                     continue;
                 }
                 const bucket = allocatedBuckets[bucketId];
@@ -154,5 +170,23 @@ export const marketDepthUtils = {
             return { ...b, cumulative: totalCumulative };
         });
         return cumulativeBuckets;
+    },
+
+    calculateDepthForSide: (
+        rawDepthSide: MarketDepthSide,
+        side: MarketOperation,
+        numBuckets: number = MARKET_DEPTH_MAX_SAMPLES,
+        bucketDistribution: number = MARKET_DEPTH_DEFAULT_DISTRIBUTION,
+        maxEndSlippagePercentage: number = MARKET_DEPTH_END_PRICE_SLIPPAGE_PERC,
+    ): BucketedPriceDepth[] => {
+        const depthSide = marketDepthUtils.normalizeMarketDepthToSampleOutput(rawDepthSide);
+        const [startPrice, endPrice] = marketDepthUtils.calculateStartEndBucketPrice(
+            depthSide,
+            side,
+            maxEndSlippagePercentage,
+        );
+        const buckets = marketDepthUtils.getBucketPrices(startPrice, endPrice, numBuckets, bucketDistribution);
+        const distributedBuckets = marketDepthUtils.distributeSamplesToBuckets(depthSide, buckets, side);
+        return distributedBuckets;
     },
 };

--- a/test/market_depth_test.ts
+++ b/test/market_depth_test.ts
@@ -1,0 +1,292 @@
+import { ERC20BridgeSource } from '@0x/asset-swapper';
+import { expect } from '@0x/contracts-test-utils';
+import { MarketOperation } from '@0x/types';
+import { BigNumber } from '@0x/utils';
+import 'mocha';
+
+import { ZERO } from '../src/constants';
+import { marketDepthUtils } from '../src/utils/market_depth_utils';
+
+const B = v => new BigNumber(v);
+
+// tslint:disable:custom-no-magic-numbers
+
+const SUITE_NAME = 'market depth utils';
+describe(SUITE_NAME, () => {
+    describe('getBucketPrices', () => {
+        it('returns a range from start to end', async () => {
+            const start = B('1');
+            const end = B('123');
+            const num = 10;
+            const range = marketDepthUtils.getBucketPrices(start, end, num);
+            expect(range[0]).to.be.bignumber.eq('1');
+            expect(range[10]).to.be.bignumber.eq('123');
+            expect(range.length).to.be.eq(11);
+        });
+        it('can go from high to low', async () => {
+            const start = B('123');
+            const end = B('1');
+            const num = 10;
+            const range = marketDepthUtils.getBucketPrices(start, end, num);
+            expect(range[0]).to.be.bignumber.eq('123');
+            expect(range[10]).to.be.bignumber.eq('1');
+            expect(range.length).to.be.eq(11);
+        });
+    });
+    describe('getSampleAmountsFromDepthSide', () => {
+        it('plucks out the input sample amounts', async () => {
+            const defaultSample = { output: B(10), source: ERC20BridgeSource.Uniswap };
+            const sampleAmounts = marketDepthUtils.getSampleAmountsFromDepthSide([
+                [
+                    { ...defaultSample, input: B(1) },
+                    { ...defaultSample, input: B(2) },
+                ],
+            ]);
+            expect(sampleAmounts).to.deep.include(B(1));
+            expect(sampleAmounts).to.deep.include(B(2));
+        });
+        it('ignores Native results if they are present', async () => {
+            const defaultSample = { output: B(10), source: ERC20BridgeSource.Uniswap };
+            const nativeSample = { output: B(10), source: ERC20BridgeSource.Native };
+            const sampleAmounts = marketDepthUtils.getSampleAmountsFromDepthSide([
+                [{ ...defaultSample, input: B(1) }],
+                [
+                    { ...nativeSample, input: B(1) },
+                    { ...nativeSample, input: B(2) },
+                ],
+            ]);
+            expect(sampleAmounts).to.deep.include(B(1));
+            expect(sampleAmounts).to.not.deep.include(B(2));
+        });
+        it('plucks Native results if it has to', async () => {
+            const nativeSample = { output: B(10), source: ERC20BridgeSource.Native };
+            const sampleAmounts = marketDepthUtils.getSampleAmountsFromDepthSide([
+                [
+                    { ...nativeSample, input: B(1) },
+                    { ...nativeSample, input: B(2) },
+                ],
+            ]);
+            expect(sampleAmounts).to.deep.include(B(1));
+            expect(sampleAmounts).to.deep.include(B(2));
+        });
+    });
+    describe('sampleNativeOrders', () => {
+        it('can partially fill a sample amount', async () => {
+            const nativePath = [{ input: B(100), output: B(200), source: ERC20BridgeSource.Native }];
+            const output = marketDepthUtils.sampleNativeOrders(nativePath, B(10));
+            expect(output).to.be.bignumber.eq(B(20));
+        });
+        it('returns zero if it cannot fully fill the amount', async () => {
+            const nativePath = [{ input: B(100), output: B(200), source: ERC20BridgeSource.Native }];
+            const output = marketDepthUtils.sampleNativeOrders(nativePath, B(101));
+            expect(output).to.be.bignumber.eq(ZERO);
+        });
+        it('runs across multiple orders', async () => {
+            const nativePath = [
+                { input: B(50), output: B(200), source: ERC20BridgeSource.Native },
+                { input: B(50), output: B(50), source: ERC20BridgeSource.Native },
+            ];
+            const output = marketDepthUtils.sampleNativeOrders(nativePath, B(100));
+            expect(output).to.be.bignumber.eq(B(250));
+        });
+    });
+    describe('normalizeMarketDepthToSampleOutput', () => {
+        it('converts raw orders into samples for Native', async () => {
+            const nativePath = [
+                { input: B(50), output: B(200), source: ERC20BridgeSource.Native },
+                { input: B(50), output: B(50), source: ERC20BridgeSource.Native },
+            ];
+            const uniPath = [
+                { input: B(1), output: B(10), source: ERC20BridgeSource.Uniswap },
+                { input: B(2), output: B(20), source: ERC20BridgeSource.Uniswap },
+            ];
+            const results = marketDepthUtils.normalizeMarketDepthToSampleOutput([uniPath, nativePath]);
+            expect(results).to.deep.include(uniPath);
+            expect(results).to.deep.include([
+                { input: B(1), output: B(4), source: ERC20BridgeSource.Native },
+                { input: B(2), output: B(8), source: ERC20BridgeSource.Native },
+            ]);
+        });
+    });
+    describe('calculateStartEndBucketPrice', () => {
+        const nativePath = [
+            { input: B(1), output: B(4), source: ERC20BridgeSource.Native },
+            { input: B(2), output: B(8), source: ERC20BridgeSource.Native },
+        ];
+        const uniPath = [
+            { input: B(1), output: B(10), source: ERC20BridgeSource.Uniswap },
+            { input: B(2), output: B(20), source: ERC20BridgeSource.Uniswap },
+        ];
+        describe('sell', () => {
+            it('starts at the best (highest) price and ends perc lower', async () => {
+                const [start, end] = marketDepthUtils.calculateStartEndBucketPrice(
+                    [nativePath, uniPath],
+                    MarketOperation.Sell,
+                    20,
+                );
+                // Best price is the uniswap 1 for 10
+                expect(start).to.be.bignumber.eq(B(10));
+                expect(end).to.be.bignumber.eq(start.times(0.8));
+            });
+        });
+        describe('buy', () => {
+            it('starts at the best (lowest) price and ends perc higher', async () => {
+                const [start, end] = marketDepthUtils.calculateStartEndBucketPrice(
+                    [nativePath, uniPath],
+                    MarketOperation.Buy,
+                    20,
+                );
+                // Best price is the native 4 to receive 1
+                expect(start).to.be.bignumber.eq(B(4));
+                expect(end).to.be.bignumber.eq(start.times(1.2));
+            });
+        });
+    });
+    describe('distributeSamplesToBuckets', () => {
+        const nativePath = [
+            { input: B(1), output: B(4), source: ERC20BridgeSource.Native },
+            { input: B(2), output: B(8), source: ERC20BridgeSource.Native },
+        ];
+        const uniPath = [
+            { input: B(1), output: B(10), source: ERC20BridgeSource.Uniswap },
+            { input: B(2), output: B(20), source: ERC20BridgeSource.Uniswap },
+        ];
+        describe('sell', () => {
+            it('allocates the samples to the right bucket by price', async () => {
+                const buckets = [B(10), B(8), B(4), B(1)];
+                const allocated = marketDepthUtils.distributeSamplesToBuckets(
+                    [nativePath, uniPath],
+                    buckets,
+                    MarketOperation.Sell,
+                );
+                const [first, second, third, fourth] = allocated;
+                expect(first[ERC20BridgeSource.Uniswap]).to.be.bignumber.eq(30);
+                expect(first.cumulative).to.be.bignumber.eq(30);
+                expect(first.bucketTotal).to.be.bignumber.eq(30);
+                expect(first.bucket).to.be.eq(0);
+                expect(first.price).to.be.bignumber.eq(10);
+
+                expect(second.cumulative).to.be.bignumber.eq(30);
+                expect(second.bucketTotal).to.be.bignumber.eq(0);
+                expect(second.bucket).to.be.eq(1);
+                expect(second.price).to.be.bignumber.eq(8);
+
+                expect(third.cumulative).to.be.bignumber.eq(42);
+                expect(third.bucketTotal).to.be.bignumber.eq(12);
+                expect(third[ERC20BridgeSource.Native]).to.be.bignumber.eq(12);
+                expect(third.bucket).to.be.eq(2);
+                expect(third.price).to.be.bignumber.eq(4);
+
+                expect(fourth.cumulative).to.be.bignumber.eq(42);
+                expect(fourth.bucketTotal).to.be.bignumber.eq(0);
+                expect(fourth.bucket).to.be.eq(3);
+                expect(fourth.price).to.be.bignumber.eq(1);
+            });
+            it('does not allocate to a bucket if there is none available', async () => {
+                const buckets = [B(10)];
+                const badSource = [{ input: B(1), output: B(5), source: ERC20BridgeSource.Uniswap }];
+                const allocated = marketDepthUtils.distributeSamplesToBuckets(
+                    [badSource],
+                    buckets,
+                    MarketOperation.Sell,
+                );
+                const [first] = allocated;
+                expect(first.cumulative).to.be.bignumber.eq(0);
+                expect(first.bucketTotal).to.be.bignumber.eq(0);
+                expect(first.bucket).to.be.eq(0);
+                expect(first.price).to.be.bignumber.eq(10);
+            });
+        });
+        describe('buy', () => {
+            it('allocates the samples to the right bucket by price', async () => {
+                const buckets = [B(1), B(4), B(10)];
+                const allocated = marketDepthUtils.distributeSamplesToBuckets(
+                    [nativePath, uniPath],
+                    buckets,
+                    MarketOperation.Buy,
+                );
+                const [first, second, third] = allocated;
+                expect(first.cumulative).to.be.bignumber.eq(0);
+                expect(first.bucketTotal).to.be.bignumber.eq(0);
+                expect(first.bucket).to.be.eq(0);
+                expect(first.price).to.be.bignumber.eq(1);
+
+                expect(second.cumulative).to.be.bignumber.eq(12);
+                expect(second.bucketTotal).to.be.bignumber.eq(12);
+                expect(second.bucket).to.be.eq(1);
+                expect(second.price).to.be.bignumber.eq(4);
+                expect(second[ERC20BridgeSource.Native]).to.be.bignumber.eq(12);
+
+                expect(third.cumulative).to.be.bignumber.eq(42);
+                expect(third.bucketTotal).to.be.bignumber.eq(30);
+                expect(third[ERC20BridgeSource.Uniswap]).to.be.bignumber.eq(30);
+                expect(third.bucket).to.be.eq(2);
+                expect(third.price).to.be.bignumber.eq(10);
+            });
+        });
+    });
+    describe('calculateDepthForSide', () => {
+        // Essentially orders not samples
+        const nativePath = [{ input: B(10), output: B(80), source: ERC20BridgeSource.Native }];
+        it('calculates prices and allocates into buckets. Partial 0x', async () => {
+            const dexPaths = [
+                [
+                    { input: B(1), output: B(10), source: ERC20BridgeSource.Uniswap },
+                    { input: B(2), output: B(11), source: ERC20BridgeSource.Uniswap },
+                ],
+                [
+                    { input: B(1), output: B(0), source: ERC20BridgeSource.Curve },
+                    { input: B(2), output: B(0), source: ERC20BridgeSource.Curve },
+                ],
+            ];
+            const result = marketDepthUtils.calculateDepthForSide(
+                [nativePath, ...dexPaths],
+                MarketOperation.Sell,
+                4, // buckets
+                1, // distribution
+                20, // max end perc
+            );
+            expect(result).to.be.deep.eq([
+                { price: B(10), bucket: 0, bucketTotal: B(10), cumulative: B(10), [ERC20BridgeSource.Uniswap]: B(10) },
+                { price: B(9.5), bucket: 1, bucketTotal: ZERO, cumulative: B(10) },
+                { price: B(9), bucket: 2, bucketTotal: ZERO, cumulative: B(10) },
+                { price: B(8.5), bucket: 3, bucketTotal: ZERO, cumulative: B(10) },
+                // Native is the sample for 1 (8) and thhe sample for 2 (16), since we didn't sample for 10 it does
+                // not contain the entire order
+                { price: B(8), bucket: 4, bucketTotal: B(24), cumulative: B(34), [ERC20BridgeSource.Native]: B(24) },
+            ]);
+        });
+
+        // Skipped as it is showcasing a misrepresentation of Native orders
+        it.skip('calculates prices and allocates into buckets. Partial Uni', async () => {
+            const dexPaths = [
+                [
+                    { input: B(1), output: B(10), source: ERC20BridgeSource.Uniswap },
+                    { input: B(2), output: B(11), source: ERC20BridgeSource.Uniswap },
+                    { input: B(10), output: B(0), source: ERC20BridgeSource.Uniswap },
+                ],
+                [
+                    { input: B(1), output: B(0), source: ERC20BridgeSource.Curve },
+                    { input: B(2), output: B(0), source: ERC20BridgeSource.Curve },
+                    { input: B(10), output: B(0), source: ERC20BridgeSource.Curve },
+                ],
+            ];
+            const result = marketDepthUtils.calculateDepthForSide(
+                [nativePath, ...dexPaths],
+                MarketOperation.Sell,
+                4, // buckets
+                1, // distribution
+                20, // max end perc
+            );
+            expect(result).to.be.deep.eq([
+                { price: B(10), bucket: 0, bucketTotal: B(10), cumulative: B(10), [ERC20BridgeSource.Uniswap]: B(10) },
+                { price: B(9.5), bucket: 1, bucketTotal: ZERO, cumulative: B(10) },
+                { price: B(9), bucket: 2, bucketTotal: ZERO, cumulative: B(10) },
+                { price: B(8.5), bucket: 3, bucketTotal: ZERO, cumulative: B(10) },
+                // Native is sampled for 1,2,10 and results in 104
+                // This is more than liquiidity available so misrepresents Native as a source
+                { price: B(8), bucket: 4, bucketTotal: B(104), cumulative: B(114), [ERC20BridgeSource.Native]: B(104) },
+            ]);
+        });
+    });
+});

--- a/test/market_depth_test.ts
+++ b/test/market_depth_test.ts
@@ -160,27 +160,31 @@ describe(SUITE_NAME, () => {
                     MarketOperation.Sell,
                 );
                 const [first, second, third, fourth] = allocated;
-                expect(first[ERC20BridgeSource.Uniswap]).to.be.bignumber.eq(20);
                 expect(first.cumulative).to.be.bignumber.eq(20);
                 expect(first.bucketTotal).to.be.bignumber.eq(20);
                 expect(first.bucket).to.be.eq(0);
                 expect(first.price).to.be.bignumber.eq(10);
+                expect(first.sources[ERC20BridgeSource.Uniswap]).to.be.bignumber.eq(20);
 
                 expect(second.cumulative).to.be.bignumber.eq(20);
                 expect(second.bucketTotal).to.be.bignumber.eq(0);
                 expect(second.bucket).to.be.eq(1);
                 expect(second.price).to.be.bignumber.eq(8);
+                expect(second.sources[ERC20BridgeSource.Uniswap]).to.be.bignumber.eq(20);
 
                 expect(third.cumulative).to.be.bignumber.eq(28);
                 expect(third.bucketTotal).to.be.bignumber.eq(8);
-                expect(third[ERC20BridgeSource.Native]).to.be.bignumber.eq(8);
                 expect(third.bucket).to.be.eq(2);
                 expect(third.price).to.be.bignumber.eq(4);
+                expect(third.sources[ERC20BridgeSource.Native]).to.be.bignumber.eq(8);
+                expect(third.sources[ERC20BridgeSource.Uniswap]).to.be.bignumber.eq(20);
 
                 expect(fourth.cumulative).to.be.bignumber.eq(28);
                 expect(fourth.bucketTotal).to.be.bignumber.eq(0);
                 expect(fourth.bucket).to.be.eq(3);
                 expect(fourth.price).to.be.bignumber.eq(1);
+                expect(fourth.sources[ERC20BridgeSource.Native]).to.be.bignumber.eq(8);
+                expect(fourth.sources[ERC20BridgeSource.Uniswap]).to.be.bignumber.eq(20);
             });
             it('does not allocate to a bucket if there is none available', async () => {
                 const buckets = [B(10)];
@@ -195,6 +199,7 @@ describe(SUITE_NAME, () => {
                 expect(first.bucketTotal).to.be.bignumber.eq(0);
                 expect(first.bucket).to.be.eq(0);
                 expect(first.price).to.be.bignumber.eq(10);
+                expect(first.sources[ERC20BridgeSource.Uniswap]).to.be.bignumber.eq(0);
             });
         });
         describe('buy', () => {
@@ -211,17 +216,18 @@ describe(SUITE_NAME, () => {
                 expect(first.bucket).to.be.eq(0);
                 expect(first.price).to.be.bignumber.eq(1);
 
-                expect(second[ERC20BridgeSource.Native]).to.be.bignumber.eq(8);
                 expect(second.cumulative).to.be.bignumber.eq(8);
                 expect(second.bucketTotal).to.be.bignumber.eq(8);
                 expect(second.bucket).to.be.eq(1);
                 expect(second.price).to.be.bignumber.eq(4);
+                expect(second.sources[ERC20BridgeSource.Native]).to.be.bignumber.eq(8);
 
-                expect(third[ERC20BridgeSource.Uniswap]).to.be.bignumber.eq(20);
                 expect(third.cumulative).to.be.bignumber.eq(28);
                 expect(third.bucketTotal).to.be.bignumber.eq(20);
                 expect(third.bucket).to.be.eq(2);
                 expect(third.price).to.be.bignumber.eq(10);
+                expect(third.sources[ERC20BridgeSource.Uniswap]).to.be.bignumber.eq(20);
+                expect(third.sources[ERC20BridgeSource.Native]).to.be.bignumber.eq(8);
             });
         });
     });
@@ -246,14 +252,46 @@ describe(SUITE_NAME, () => {
                 1, // distribution
                 20, // max end perc
             );
+            const emptySources = {};
+            Object.values(ERC20BridgeSource).forEach(s => (emptySources[s] = ZERO));
             expect(result).to.be.deep.eq([
-                { price: B(10), bucket: 0, bucketTotal: B(10), cumulative: B(10), [ERC20BridgeSource.Uniswap]: B(10) },
-                { price: B(9.5), bucket: 1, bucketTotal: ZERO, cumulative: B(10) },
-                { price: B(9), bucket: 2, bucketTotal: ZERO, cumulative: B(10) },
-                { price: B(8.5), bucket: 3, bucketTotal: ZERO, cumulative: B(10) },
+                {
+                    price: B(10),
+                    bucket: 0,
+                    bucketTotal: B(10),
+                    cumulative: B(10),
+                    sources: { ...emptySources, [ERC20BridgeSource.Uniswap]: B(10) },
+                },
+                {
+                    price: B(9.5),
+                    bucket: 1,
+                    bucketTotal: ZERO,
+                    cumulative: B(10),
+                    sources: { ...emptySources, [ERC20BridgeSource.Uniswap]: B(10) },
+                },
+                {
+                    price: B(9),
+                    bucket: 2,
+                    bucketTotal: ZERO,
+                    cumulative: B(10),
+                    sources: { ...emptySources, [ERC20BridgeSource.Uniswap]: B(10) },
+                },
+                {
+                    price: B(8.5),
+                    bucket: 3,
+                    bucketTotal: ZERO,
+                    cumulative: B(10),
+                    sources: { ...emptySources, [ERC20BridgeSource.Uniswap]: B(10) },
+                },
                 // Native is the sample for the sample for 2 (16) (overriding thhe 1 sample), since we didn't sample for 10 it does
                 // not contain the entire order
-                { price: B(8), bucket: 4, bucketTotal: B(16), cumulative: B(26), [ERC20BridgeSource.Native]: B(16) },
+                {
+                    price: B(8),
+                    bucket: 4,
+                    bucketTotal: B(16),
+                    cumulative: B(26),
+                    sources: { ...emptySources, [ERC20BridgeSource.Uniswap]: B(10), [ERC20BridgeSource.Native]: B(16) },
+                },
             ]);
         });
 
@@ -277,12 +315,44 @@ describe(SUITE_NAME, () => {
                 1, // distribution
                 20, // max end perc
             );
+            const emptySources = {};
+            Object.values(ERC20BridgeSource).forEach(s => (emptySources[s] = ZERO));
             expect(result).to.be.deep.eq([
-                { price: B(10), bucket: 0, bucketTotal: B(10), cumulative: B(10), [ERC20BridgeSource.Uniswap]: B(10) },
-                { price: B(9.5), bucket: 1, bucketTotal: ZERO, cumulative: B(10) },
-                { price: B(9), bucket: 2, bucketTotal: ZERO, cumulative: B(10) },
-                { price: B(8.5), bucket: 3, bucketTotal: ZERO, cumulative: B(10) },
-                { price: B(8), bucket: 4, bucketTotal: B(80), cumulative: B(90), [ERC20BridgeSource.Native]: B(80) },
+                {
+                    price: B(10),
+                    bucket: 0,
+                    bucketTotal: B(10),
+                    cumulative: B(10),
+                    sources: { ...emptySources, [ERC20BridgeSource.Uniswap]: B(10) },
+                },
+                {
+                    price: B(9.5),
+                    bucket: 1,
+                    bucketTotal: ZERO,
+                    cumulative: B(10),
+                    sources: { ...emptySources, [ERC20BridgeSource.Uniswap]: B(10) },
+                },
+                {
+                    price: B(9),
+                    bucket: 2,
+                    bucketTotal: ZERO,
+                    cumulative: B(10),
+                    sources: { ...emptySources, [ERC20BridgeSource.Uniswap]: B(10) },
+                },
+                {
+                    price: B(8.5),
+                    bucket: 3,
+                    bucketTotal: ZERO,
+                    cumulative: B(10),
+                    sources: { ...emptySources, [ERC20BridgeSource.Uniswap]: B(10) },
+                },
+                {
+                    price: B(8),
+                    bucket: 4,
+                    bucketTotal: B(80),
+                    cumulative: B(90),
+                    sources: { ...emptySources, [ERC20BridgeSource.Uniswap]: B(10), [ERC20BridgeSource.Native]: B(80) },
+                },
             ]);
         });
     });

--- a/test/market_depth_test.ts
+++ b/test/market_depth_test.ts
@@ -160,24 +160,24 @@ describe(SUITE_NAME, () => {
                     MarketOperation.Sell,
                 );
                 const [first, second, third, fourth] = allocated;
-                expect(first[ERC20BridgeSource.Uniswap]).to.be.bignumber.eq(30);
-                expect(first.cumulative).to.be.bignumber.eq(30);
-                expect(first.bucketTotal).to.be.bignumber.eq(30);
+                expect(first[ERC20BridgeSource.Uniswap]).to.be.bignumber.eq(20);
+                expect(first.cumulative).to.be.bignumber.eq(20);
+                expect(first.bucketTotal).to.be.bignumber.eq(20);
                 expect(first.bucket).to.be.eq(0);
                 expect(first.price).to.be.bignumber.eq(10);
 
-                expect(second.cumulative).to.be.bignumber.eq(30);
+                expect(second.cumulative).to.be.bignumber.eq(20);
                 expect(second.bucketTotal).to.be.bignumber.eq(0);
                 expect(second.bucket).to.be.eq(1);
                 expect(second.price).to.be.bignumber.eq(8);
 
-                expect(third.cumulative).to.be.bignumber.eq(42);
-                expect(third.bucketTotal).to.be.bignumber.eq(12);
-                expect(third[ERC20BridgeSource.Native]).to.be.bignumber.eq(12);
+                expect(third.cumulative).to.be.bignumber.eq(28);
+                expect(third.bucketTotal).to.be.bignumber.eq(8);
+                expect(third[ERC20BridgeSource.Native]).to.be.bignumber.eq(8);
                 expect(third.bucket).to.be.eq(2);
                 expect(third.price).to.be.bignumber.eq(4);
 
-                expect(fourth.cumulative).to.be.bignumber.eq(42);
+                expect(fourth.cumulative).to.be.bignumber.eq(28);
                 expect(fourth.bucketTotal).to.be.bignumber.eq(0);
                 expect(fourth.bucket).to.be.eq(3);
                 expect(fourth.price).to.be.bignumber.eq(1);
@@ -211,15 +211,15 @@ describe(SUITE_NAME, () => {
                 expect(first.bucket).to.be.eq(0);
                 expect(first.price).to.be.bignumber.eq(1);
 
-                expect(second.cumulative).to.be.bignumber.eq(12);
-                expect(second.bucketTotal).to.be.bignumber.eq(12);
+                expect(second[ERC20BridgeSource.Native]).to.be.bignumber.eq(8);
+                expect(second.cumulative).to.be.bignumber.eq(8);
+                expect(second.bucketTotal).to.be.bignumber.eq(8);
                 expect(second.bucket).to.be.eq(1);
                 expect(second.price).to.be.bignumber.eq(4);
-                expect(second[ERC20BridgeSource.Native]).to.be.bignumber.eq(12);
 
-                expect(third.cumulative).to.be.bignumber.eq(42);
-                expect(third.bucketTotal).to.be.bignumber.eq(30);
-                expect(third[ERC20BridgeSource.Uniswap]).to.be.bignumber.eq(30);
+                expect(third[ERC20BridgeSource.Uniswap]).to.be.bignumber.eq(20);
+                expect(third.cumulative).to.be.bignumber.eq(28);
+                expect(third.bucketTotal).to.be.bignumber.eq(20);
                 expect(third.bucket).to.be.eq(2);
                 expect(third.price).to.be.bignumber.eq(10);
             });
@@ -251,14 +251,13 @@ describe(SUITE_NAME, () => {
                 { price: B(9.5), bucket: 1, bucketTotal: ZERO, cumulative: B(10) },
                 { price: B(9), bucket: 2, bucketTotal: ZERO, cumulative: B(10) },
                 { price: B(8.5), bucket: 3, bucketTotal: ZERO, cumulative: B(10) },
-                // Native is the sample for 1 (8) and thhe sample for 2 (16), since we didn't sample for 10 it does
+                // Native is the sample for the sample for 2 (16) (overriding thhe 1 sample), since we didn't sample for 10 it does
                 // not contain the entire order
-                { price: B(8), bucket: 4, bucketTotal: B(24), cumulative: B(34), [ERC20BridgeSource.Native]: B(24) },
+                { price: B(8), bucket: 4, bucketTotal: B(16), cumulative: B(26), [ERC20BridgeSource.Native]: B(16) },
             ]);
         });
 
-        // Skipped as it is showcasing a misrepresentation of Native orders
-        it.skip('calculates prices and allocates into buckets. Partial Uni', async () => {
+        it('calculates prices and allocates into buckets. Partial Uni', async () => {
             const dexPaths = [
                 [
                     { input: B(1), output: B(10), source: ERC20BridgeSource.Uniswap },
@@ -283,9 +282,7 @@ describe(SUITE_NAME, () => {
                 { price: B(9.5), bucket: 1, bucketTotal: ZERO, cumulative: B(10) },
                 { price: B(9), bucket: 2, bucketTotal: ZERO, cumulative: B(10) },
                 { price: B(8.5), bucket: 3, bucketTotal: ZERO, cumulative: B(10) },
-                // Native is sampled for 1,2,10 and results in 104
-                // This is more than liquiidity available so misrepresents Native as a source
-                { price: B(8), bucket: 4, bucketTotal: B(104), cumulative: B(114), [ERC20BridgeSource.Native]: B(104) },
+                { price: B(8), bucket: 4, bucketTotal: B(80), cumulative: B(90), [ERC20BridgeSource.Native]: B(80) },
             ]);
         });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,9 +32,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-9a16f5736":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-ae2a6fb68":
   version "4.6.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/3a630c5dc216a3d5eaa6b2789658a5f3eb5fd4dd"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/209c8324412173f5aa1c4b65fbe5494ea648205e"
   dependencies:
     "@0x/assert" "^3.0.9"
     "@0x/contract-addresses" "^4.11.0"


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

requires: https://github.com/0xProject/0x-monorepo/pull/2641
includes: Quicker Path Finding https://github.com/0xProject/0x-monorepo/pull/2640

# Description

Returns bucketed pricing for all sources.

```
http://localhost:3000/swap/v0/depth?buyToken=USDC&sellToken=DAI&sellAmount=10000e18&numSamples=10&sampleDistributionBase=1
```

```json
{
  "asks": {
    "depth": [
      {
        "price": "0.00315546105784902",
        "bucket": 0,
        "bucketTotal": "0",
        "sources": {
          "Native": "0",
          "Uniswap": "0",
          "Uniswap_V2": "0",
          "Eth2Dai": "0",
          "Kyber": "0",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0",
          "Balancer": "0"
        },
        "cumulative": "0"
      },
      {
        "price": "0.00312390644727053",
        "bucket": 1,
        "bucketTotal": "100524109029123426136",
        "sources": {
          "Uniswap": "9381248534278317553",
          "Kyber": "31432971221060620000",
          "Native": "18895910439660362612",
          "Uniswap_V2": "31424060666061621210",
          "Balancer": "9389918168062504761",
          "Eth2Dai": "0",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0"
        },
        "cumulative": "100524109029123426136"
      },
      {
        "price": "0.00309235183669204",
        "bucket": 2,
        "bucketTotal": "55695462362445505774",
        "sources": {
          "Uniswap": "40305933574386384639",
          "Balancer": "34160695490399943449",
          "Native": "18895910439660362612",
          "Uniswap_V2": "31424060666061621210",
          "Eth2Dai": "0",
          "Kyber": "31432971221060620000",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0"
        },
        "cumulative": "156219571391568931910"
      },
      {
        "price": "0.003060797226113549",
        "bucket": 3,
        "bucketTotal": "61377952177222327205",
        "sources": {
          "Eth2Dai": "30652165725069522639",
          "Balancer": "64886481942552748015",
          "Native": "18895910439660362612",
          "Uniswap": "40305933574386384639",
          "Uniswap_V2": "31424060666061621210",
          "Kyber": "31432971221060620000",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0"
        },
        "cumulative": "217597523568791259115"
      },
      {
        "price": "0.003029242615535059",
        "bucket": 4,
        "bucketTotal": "6097761841126141132",
        "sources": {
          "Balancer": "70984243783678889147",
          "Native": "18895910439660362612",
          "Uniswap": "40305933574386384639",
          "Uniswap_V2": "31424060666061621210",
          "Eth2Dai": "30652165725069522639",
          "Kyber": "31432971221060620000",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0"
        },
        "cumulative": "223695285409917400247"
      },
      {
        "price": "0.002997688004956569",
        "bucket": 5,
        "bucketTotal": "9019700660355993460",
        "sources": {
          "Balancer": "80003944444034882607",
          "Native": "18895910439660362612",
          "Uniswap": "40305933574386384639",
          "Uniswap_V2": "31424060666061621210",
          "Eth2Dai": "30652165725069522639",
          "Kyber": "31432971221060620000",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0"
        },
        "cumulative": "232714986070273393707"
      },
      {
        "price": "0.002966133394378079",
        "bucket": 6,
        "bucketTotal": "0",
        "sources": {
          "Native": "18895910439660362612",
          "Uniswap": "40305933574386384639",
          "Uniswap_V2": "31424060666061621210",
          "Eth2Dai": "30652165725069522639",
          "Kyber": "31432971221060620000",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0",
          "Balancer": "80003944444034882607"
        },
        "cumulative": "232714986070273393707"
      },
      {
        "price": "0.002934578783799589",
        "bucket": 7,
        "bucketTotal": "11861645160418238274",
        "sources": {
          "Balancer": "91865589604453120881",
          "Native": "18895910439660362612",
          "Uniswap": "40305933574386384639",
          "Uniswap_V2": "31424060666061621210",
          "Eth2Dai": "30652165725069522639",
          "Kyber": "31432971221060620000",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0"
        },
        "cumulative": "244576631230691631981"
      },
      {
        "price": "0.002903024173221098",
        "bucket": 8,
        "bucketTotal": "14626836004418825500",
        "sources": {
          "Balancer": "106492425608871946381",
          "Native": "18895910439660362612",
          "Uniswap": "40305933574386384639",
          "Uniswap_V2": "31424060666061621210",
          "Eth2Dai": "30652165725069522639",
          "Kyber": "31432971221060620000",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0"
        },
        "cumulative": "259203467235110457481"
      },
      {
        "price": "0.002871469562642608",
        "bucket": 9,
        "bucketTotal": "23071490648284651262",
        "sources": {
          "LiquidityProvider": "5753149504621641733",
          "Balancer": "123810766752534955910",
          "Native": "18895910439660362612",
          "Uniswap": "40305933574386384639",
          "Uniswap_V2": "31424060666061621210",
          "Eth2Dai": "30652165725069522639",
          "Kyber": "31432971221060620000",
          "Curve": "0",
          "MultiBridge": "0"
        },
        "cumulative": "282274957883395108743"
      },
      {
        "price": "0.002839914952064118",
        "bucket": 10,
        "bucketTotal": "39868080877763923456",
        "sources": {
          "LiquidityProvider": "25682163210128155645",
          "Balancer": "143749833924792365454",
          "Native": "18895910439660362612",
          "Uniswap": "40305933574386384639",
          "Uniswap_V2": "31424060666061621210",
          "Eth2Dai": "30652165725069522639",
          "Kyber": "31432971221060620000",
          "Curve": "0",
          "MultiBridge": "0"
        },
        "cumulative": "322143038761159032199"
      },
      {
        "price": "0.002808360341485628",
        "bucket": 11,
        "bucketTotal": "50725528396477231285",
        "sources": {
          "LiquidityProvider": "53915921809051947533",
          "Balancer": "166241603722345804851",
          "Native": "18895910439660362612",
          "Uniswap": "40305933574386384639",
          "Uniswap_V2": "31424060666061621210",
          "Eth2Dai": "30652165725069522639",
          "Kyber": "31432971221060620000",
          "Curve": "0",
          "MultiBridge": "0"
        },
        "cumulative": "372868567157636263484"
      },
      {
        "price": "0.002776805730907138",
        "bucket": 12,
        "bucketTotal": "0",
        "sources": {
          "Native": "18895910439660362612",
          "Uniswap": "40305933574386384639",
          "Uniswap_V2": "31424060666061621210",
          "Eth2Dai": "30652165725069522639",
          "Kyber": "31432971221060620000",
          "Curve": "0",
          "LiquidityProvider": "53915921809051947533",
          "MultiBridge": "0",
          "Balancer": "166241603722345804851"
        },
        "cumulative": "372868567157636263484"
      },
      {
        "price": "0.002745251120328647",
        "bucket": 13,
        "bucketTotal": "24979063505726290571",
        "sources": {
          "Balancer": "191220667228072095422",
          "Native": "18895910439660362612",
          "Uniswap": "40305933574386384639",
          "Uniswap_V2": "31424060666061621210",
          "Eth2Dai": "30652165725069522639",
          "Kyber": "31432971221060620000",
          "Curve": "0",
          "LiquidityProvider": "53915921809051947533",
          "MultiBridge": "0"
        },
        "cumulative": "397847630663362554055"
      },
      {
        "price": "0.002713696509750157",
        "bucket": 14,
        "bucketTotal": "27403430493757248438",
        "sources": {
          "Balancer": "218624097721829343860",
          "Native": "18895910439660362612",
          "Uniswap": "40305933574386384639",
          "Uniswap_V2": "31424060666061621210",
          "Eth2Dai": "30652165725069522639",
          "Kyber": "31432971221060620000",
          "Curve": "0",
          "LiquidityProvider": "53915921809051947533",
          "MultiBridge": "0"
        },
        "cumulative": "425251061157119802493"
      },
      {
        "price": "0.002682141899171667",
        "bucket": 15,
        "bucketTotal": "0",
        "sources": {
          "Native": "18895910439660362612",
          "Uniswap": "40305933574386384639",
          "Uniswap_V2": "31424060666061621210",
          "Eth2Dai": "30652165725069522639",
          "Kyber": "31432971221060620000",
          "Curve": "0",
          "LiquidityProvider": "53915921809051947533",
          "MultiBridge": "0",
          "Balancer": "218624097721829343860"
        },
        "cumulative": "425251061157119802493"
      },
      {
        "price": "0.002650587288593177",
        "bucket": 16,
        "bucketTotal": "0",
        "sources": {
          "Native": "18895910439660362612",
          "Uniswap": "40305933574386384639",
          "Uniswap_V2": "31424060666061621210",
          "Eth2Dai": "30652165725069522639",
          "Kyber": "31432971221060620000",
          "Curve": "0",
          "LiquidityProvider": "53915921809051947533",
          "MultiBridge": "0",
          "Balancer": "218624097721829343860"
        },
        "cumulative": "425251061157119802493"
      },
      {
        "price": "0.002619032678014687",
        "bucket": 17,
        "bucketTotal": "0",
        "sources": {
          "Native": "18895910439660362612",
          "Uniswap": "40305933574386384639",
          "Uniswap_V2": "31424060666061621210",
          "Eth2Dai": "30652165725069522639",
          "Kyber": "31432971221060620000",
          "Curve": "0",
          "LiquidityProvider": "53915921809051947533",
          "MultiBridge": "0",
          "Balancer": "218624097721829343860"
        },
        "cumulative": "425251061157119802493"
      },
      {
        "price": "0.002587478067436196",
        "bucket": 18,
        "bucketTotal": "0",
        "sources": {
          "Native": "18895910439660362612",
          "Uniswap": "40305933574386384639",
          "Uniswap_V2": "31424060666061621210",
          "Eth2Dai": "30652165725069522639",
          "Kyber": "31432971221060620000",
          "Curve": "0",
          "LiquidityProvider": "53915921809051947533",
          "MultiBridge": "0",
          "Balancer": "218624097721829343860"
        },
        "cumulative": "425251061157119802493"
      },
      {
        "price": "0.002555923456857706",
        "bucket": 19,
        "bucketTotal": "0",
        "sources": {
          "Native": "18895910439660362612",
          "Uniswap": "40305933574386384639",
          "Uniswap_V2": "31424060666061621210",
          "Eth2Dai": "30652165725069522639",
          "Kyber": "31432971221060620000",
          "Curve": "0",
          "LiquidityProvider": "53915921809051947533",
          "MultiBridge": "0",
          "Balancer": "218624097721829343860"
        },
        "cumulative": "425251061157119802493"
      },
      {
        "price": "0.002524368846279216",
        "bucket": 20,
        "bucketTotal": "0",
        "sources": {
          "Native": "18895910439660362612",
          "Uniswap": "40305933574386384639",
          "Uniswap_V2": "31424060666061621210",
          "Eth2Dai": "30652165725069522639",
          "Kyber": "31432971221060620000",
          "Curve": "0",
          "LiquidityProvider": "53915921809051947533",
          "MultiBridge": "0",
          "Balancer": "218624097721829343860"
        },
        "cumulative": "425251061157119802493"
      }
    ]
  },
  "bids": {
    "depth": [
      {
        "price": "0.003166196538594208",
        "bucket": 0,
        "bucketTotal": "0",
        "sources": {
          "Native": "0",
          "Uniswap": "0",
          "Uniswap_V2": "0",
          "Eth2Dai": "0",
          "Kyber": "0",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0",
          "Balancer": "0"
        },
        "cumulative": "0"
      },
      {
        "price": "0.00319785850398015",
        "bucket": 1,
        "bucketTotal": "101881975046370247228",
        "sources": {
          "Uniswap": "22380126298106003818",
          "Kyber": "31748421830137499788",
          "Uniswap_V2": "31780890872923718995",
          "Balancer": "15972536045203024627",
          "Native": "0",
          "Eth2Dai": "0",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0"
        },
        "cumulative": "101881975046370247228"
      },
      {
        "price": "0.003229520469366092",
        "bucket": 2,
        "bucketTotal": "90221178551985887771",
        "sources": {
          "Uniswap": "54508839420778127498",
          "Eth2Dai": "32258064516129032258",
          "Balancer": "41806936958387756460",
          "Native": "0",
          "Uniswap_V2": "31780890872923718995",
          "Kyber": "31748421830137499788",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0"
        },
        "cumulative": "192103153598356134999"
      },
      {
        "price": "0.003261182434752034",
        "bucket": 3,
        "bucketTotal": "38959839376957963357",
        "sources": {
          "Balancer": "80766776335345719817",
          "Native": "0",
          "Uniswap": "54508839420778127498",
          "Uniswap_V2": "31780890872923718995",
          "Eth2Dai": "32258064516129032258",
          "Kyber": "31748421830137499788",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0"
        },
        "cumulative": "231062992975314098356"
      },
      {
        "price": "0.003292844400137976",
        "bucket": 4,
        "bucketTotal": "0",
        "sources": {
          "Native": "0",
          "Uniswap": "54508839420778127498",
          "Uniswap_V2": "31780890872923718995",
          "Eth2Dai": "32258064516129032258",
          "Kyber": "31748421830137499788",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0",
          "Balancer": "80766776335345719817"
        },
        "cumulative": "231062992975314098356"
      },
      {
        "price": "0.003324506365523918",
        "bucket": 5,
        "bucketTotal": "9879380958168657304",
        "sources": {
          "Balancer": "90646157293514377121",
          "Native": "0",
          "Uniswap": "54508839420778127498",
          "Uniswap_V2": "31780890872923718995",
          "Eth2Dai": "32258064516129032258",
          "Kyber": "31748421830137499788",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0"
        },
        "cumulative": "240942373933482755660"
      },
      {
        "price": "0.00335616833090986",
        "bucket": 6,
        "bucketTotal": "13375425547097902225",
        "sources": {
          "Balancer": "104021582840612279346",
          "Native": "0",
          "Uniswap": "54508839420778127498",
          "Uniswap_V2": "31780890872923718995",
          "Eth2Dai": "32258064516129032258",
          "Kyber": "31748421830137499788",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0"
        },
        "cumulative": "254317799480580657885"
      },
      {
        "price": "0.003387830296295803",
        "bucket": 7,
        "bucketTotal": "0",
        "sources": {
          "Native": "0",
          "Uniswap": "54508839420778127498",
          "Uniswap_V2": "31780890872923718995",
          "Eth2Dai": "32258064516129032258",
          "Kyber": "31748421830137499788",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0",
          "Balancer": "104021582840612279346"
        },
        "cumulative": "254317799480580657885"
      },
      {
        "price": "0.003419492261681745",
        "bucket": 8,
        "bucketTotal": "16980865879277522447",
        "sources": {
          "Balancer": "121002448719889801793",
          "Native": "0",
          "Uniswap": "54508839420778127498",
          "Uniswap_V2": "31780890872923718995",
          "Eth2Dai": "32258064516129032258",
          "Kyber": "31748421830137499788",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0"
        },
        "cumulative": "271298665359858180332"
      },
      {
        "price": "0.003451154227067687",
        "bucket": 9,
        "bucketTotal": "20700918268097749159",
        "sources": {
          "Balancer": "141703366987987550952",
          "Native": "0",
          "Uniswap": "54508839420778127498",
          "Uniswap_V2": "31780890872923718995",
          "Eth2Dai": "32258064516129032258",
          "Kyber": "31748421830137499788",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0"
        },
        "cumulative": "291999583627955929491"
      },
      {
        "price": "0.003482816192453629",
        "bucket": 10,
        "bucketTotal": "0",
        "sources": {
          "Native": "0",
          "Uniswap": "54508839420778127498",
          "Uniswap_V2": "31780890872923718995",
          "Eth2Dai": "32258064516129032258",
          "Kyber": "31748421830137499788",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0",
          "Balancer": "141703366987987550952"
        },
        "cumulative": "291999583627955929491"
      },
      {
        "price": "0.003514478157839571",
        "bucket": 11,
        "bucketTotal": "24541136022312971456",
        "sources": {
          "Balancer": "166244503010300522408",
          "Native": "0",
          "Uniswap": "54508839420778127498",
          "Uniswap_V2": "31780890872923718995",
          "Eth2Dai": "32258064516129032258",
          "Kyber": "31748421830137499788",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0"
        },
        "cumulative": "316540719650268900947"
      },
      {
        "price": "0.003546140123225513",
        "bucket": 12,
        "bucketTotal": "0",
        "sources": {
          "Native": "0",
          "Uniswap": "54508839420778127498",
          "Uniswap_V2": "31780890872923718995",
          "Eth2Dai": "32258064516129032258",
          "Kyber": "31748421830137499788",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0",
          "Balancer": "166244503010300522408"
        },
        "cumulative": "316540719650268900947"
      },
      {
        "price": "0.003577802088611455",
        "bucket": 13,
        "bucketTotal": "28507437106906439253",
        "sources": {
          "Balancer": "194751940117206961661",
          "Native": "0",
          "Uniswap": "54508839420778127498",
          "Uniswap_V2": "31780890872923718995",
          "Eth2Dai": "32258064516129032258",
          "Kyber": "31748421830137499788",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0"
        },
        "cumulative": "345048156757175340200"
      },
      {
        "price": "0.003609464053997397",
        "bucket": 14,
        "bucketTotal": "0",
        "sources": {
          "Native": "0",
          "Uniswap": "54508839420778127498",
          "Uniswap_V2": "31780890872923718995",
          "Eth2Dai": "32258064516129032258",
          "Kyber": "31748421830137499788",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0",
          "Balancer": "194751940117206961661"
        },
        "cumulative": "345048156757175340200"
      },
      {
        "price": "0.003641126019383339",
        "bucket": 15,
        "bucketTotal": "32606134573940509603",
        "sources": {
          "Balancer": "227358074691147471264",
          "Native": "0",
          "Uniswap": "54508839420778127498",
          "Uniswap_V2": "31780890872923718995",
          "Eth2Dai": "32258064516129032258",
          "Kyber": "31748421830137499788",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0"
        },
        "cumulative": "377654291331115849803"
      },
      {
        "price": "0.003672787984769281",
        "bucket": 16,
        "bucketTotal": "0",
        "sources": {
          "Native": "0",
          "Uniswap": "54508839420778127498",
          "Uniswap_V2": "31780890872923718995",
          "Eth2Dai": "32258064516129032258",
          "Kyber": "31748421830137499788",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0",
          "Balancer": "227358074691147471264"
        },
        "cumulative": "377654291331115849803"
      },
      {
        "price": "0.003704449950155223",
        "bucket": 17,
        "bucketTotal": "36843970092505497915",
        "sources": {
          "Balancer": "264202044783652969179",
          "Native": "0",
          "Uniswap": "54508839420778127498",
          "Uniswap_V2": "31780890872923718995",
          "Eth2Dai": "32258064516129032258",
          "Kyber": "31748421830137499788",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0"
        },
        "cumulative": "414498261423621347718"
      },
      {
        "price": "0.003736111915541165",
        "bucket": 18,
        "bucketTotal": "0",
        "sources": {
          "Native": "0",
          "Uniswap": "54508839420778127498",
          "Uniswap_V2": "31780890872923718995",
          "Eth2Dai": "32258064516129032258",
          "Kyber": "31748421830137499788",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0",
          "Balancer": "264202044783652969179"
        },
        "cumulative": "414498261423621347718"
      },
      {
        "price": "0.003767773880927108",
        "bucket": 19,
        "bucketTotal": "0",
        "sources": {
          "Native": "0",
          "Uniswap": "54508839420778127498",
          "Uniswap_V2": "31780890872923718995",
          "Eth2Dai": "32258064516129032258",
          "Kyber": "31748421830137499788",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0",
          "Balancer": "264202044783652969179"
        },
        "cumulative": "414498261423621347718"
      },
      {
        "price": "0.00379943584631305",
        "bucket": 20,
        "bucketTotal": "0",
        "sources": {
          "Native": "0",
          "Uniswap": "54508839420778127498",
          "Uniswap_V2": "31780890872923718995",
          "Eth2Dai": "32258064516129032258",
          "Kyber": "31748421830137499788",
          "Curve": "0",
          "LiquidityProvider": "0",
          "MultiBridge": "0",
          "Balancer": "264202044783652969179"
        },
        "cumulative": "414498261423621347718"
      }
    ]
  },
  "buyToken": {
    "symbol": "WETH",
    "decimals": 18,
    "tokenAddress": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
  },
  "sellToken": {
    "symbol": "DAI",
    "decimals": 18,
    "tokenAddress": "0x6b175474e89094c44da98b954eedeac495271d0f"
  }
}

```

TODO:
- [x] Move to a better output format

```json
{
  "asks": [
      {
        "price": "1.030149711",
        "bucket": 0,
        "bucketTotal": "1030149711",
        "sources": { "Curve": "1030149711" },
        "cumulative": "1030149711"
      },
```
- [x] Selling USDC (6 decimals for DAI (18 decimals) seems wonky
- [x] Tests. Native only. Native one sided. On-chain only. Mixed
- [x] Possibly rework the start and end price calculation for buckets
- [x] Remove extra bucket when the price is rounded near at the end


# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
