### PR TITLE
feat: Allow indicative RFQ-T quotes without takerAddress

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-db0f3a878",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-7b0a1c363",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "^4.11.0",
         "@0x/contract-wrappers": "^13.7.0",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-b065d8015",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-e9b0ac882",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "^4.11.0",
         "@0x/contract-wrappers": "^13.7.0",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-e9b0ac882",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-db0f3a878",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "^4.11.0",
         "@0x/contract-wrappers": "^13.7.0",

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -405,10 +405,10 @@ const parseGetSwapQuoteRequestParams = (
     const affiliateAddress = req.query.affiliateAddress as string;
     const rfqt: Pick<RfqtRequestOpts, 'intentOnFilling' | 'isIndicative' | 'nativeExclusivelyRFQT'> = (() => {
         if (apiKey) {
-            if (takerAddress) {
+            if (endpoint === 'quote' && takerAddress) {
                 return {
-                    intentOnFilling: endpoint === 'quote' && req.query.intentOnFilling === 'true',
-                    isIndicative: endpoint === 'price',
+                    intentOnFilling: req.query.intentOnFilling === 'true',
+                    isIndicative: false,
                     nativeExclusivelyRFQT,
                 };
             } else if (endpoint === 'price') {

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -403,14 +403,24 @@ const parseGetSwapQuoteRequestParams = (
     });
 
     const affiliateAddress = req.query.affiliateAddress as string;
-    const rfqt: Pick<RfqtRequestOpts, 'intentOnFilling' | 'isIndicative' | 'nativeExclusivelyRFQT'> =
-        takerAddress && apiKey
-            ? {
-                  intentOnFilling: endpoint === 'quote' && req.query.intentOnFilling === 'true',
-                  isIndicative: endpoint === 'price',
-                  nativeExclusivelyRFQT,
-              }
-            : undefined;
+    const rfqt: Pick<RfqtRequestOpts, 'intentOnFilling' | 'isIndicative' | 'nativeExclusivelyRFQT'> = (() => {
+        if (apiKey) {
+            if (takerAddress) {
+                return {
+                    intentOnFilling: endpoint === 'quote' && req.query.intentOnFilling === 'true',
+                    isIndicative: endpoint === 'price',
+                    nativeExclusivelyRFQT,
+                };
+            } else if (endpoint === 'price') {
+                return {
+                    intentOnFilling: false,
+                    isIndicative: true,
+                    nativeExclusivelyRFQT,
+                };
+            }
+        }
+        return undefined;
+    })();
     // tslint:disable-next-line:boolean-naming
     const skipValidation = req.query.skipValidation === undefined ? false : req.query.skipValidation === 'true';
     return {

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -493,9 +493,6 @@ export class SwapService {
                 ...rfqt,
                 intentOnFilling: rfqt && rfqt.intentOnFilling ? true : false,
                 apiKey,
-                // If this is a forwarder transaction, then we want to request quotes with the taker as the
-                // forwarder contract. If it's not, then we want to request quotes with the taker set to the
-                // API's takerAddress query parameter, which in this context is known as `from`.
                 makerEndpointMaxResponseTimeMs: RFQT_REQUEST_MAX_RESPONSE_MS,
                 takerAddress,
             };

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -471,7 +471,7 @@ export class SwapService {
                 },
             ]);
         }
-        if (apiKey !== undefined && (isETHSell || from !== undefined)) {
+        if (apiKey !== undefined && (isETHSell || from !== undefined || (rfqt && rfqt.isIndicative))) {
             let takerAddress;
             switch (swapVersion) {
                 case SwapVersion.V0:

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -476,6 +476,9 @@ export class SwapService {
                 },
             ]);
         }
+        // Only enable RFQT if there's an API key and either (a) it's a
+        // forwarder transaction (isETHSell===true), (b) there's a taker
+        // address present, or (c) it's an indicative quote.
         if (apiKey !== undefined && (isETHSell || from !== undefined || (rfqt && rfqt.isIndicative))) {
             let takerAddress;
             switch (swapVersion) {

--- a/test/rfqt_test.ts
+++ b/test/rfqt_test.ts
@@ -216,7 +216,7 @@ describe(SUITE_NAME, () => {
                         },
                     );
                 });
-                it('should fail when taker address is not supplied', async () => {
+                it('should fail when taker address is not supplied for a firm quote', async () => {
                     const appResponse = await request(app)
                         .get(
                             `${SWAP_PATH}/quote?buyToken=ZRX&sellToken=WETH&sellAmount=${DEFAULT_SELL_AMOUNT.toString()}&intentOnFilling=true&excludedSources=${DEFAULT_EXCLUDED_SOURCES}`,
@@ -347,6 +347,31 @@ describe(SUITE_NAME, () => {
                                 .expect(HttpStatus.OK)
                                 .expect('Content-Type', /json/);
 
+                            const responseJson = JSON.parse(appResponse.text);
+                            expect(responseJson.buyAmount).to.equal('100000000000000000');
+                            expect(responseJson.price).to.equal('1');
+                            expect(responseJson.sellAmount).to.equal('100000000000000000');
+                            expect(responseJson.sources).to.deep.include.members([{ name: '0x', proportion: '1' }]);
+                        },
+                        quoteRequestorHttpClient,
+                    );
+                });
+                it('should succeed when taker address is not supplied for an indicative quote', async () => {
+                    return rfqtMocker.withMockedRfqtIndicativeQuotes(
+                        [
+                            {
+                                ...DEFAULT_RFQT_RESPONSE_DATA,
+                                responseData: rfqtIndicativeQuoteResponse,
+                            },
+                        ],
+                        async () => {
+                            const appResponse = await request(app)
+                                .get(
+                                    `${SWAP_PATH}/price?buyToken=ZRX&sellToken=WETH&sellAmount=${DEFAULT_SELL_AMOUNT.toString()}&excludedSources=${DEFAULT_EXCLUDED_SOURCES}&skipValidation=true`,
+                                )
+                                .set('0x-api-key', 'koolApiKey1')
+                                .expect(HttpStatus.OK)
+                                .expect('Content-Type', /json/);
                             const responseJson = JSON.parse(appResponse.text);
                             expect(responseJson.buyAmount).to.equal('100000000000000000');
                             expect(responseJson.price).to.equal('1');
@@ -583,7 +608,7 @@ describe(SUITE_NAME, () => {
                         quoteRequestorHttpClient,
                     );
                 });
-                it('should fail when taker address is not supplied', async () => {
+                it('should fail when taker address is not supplied for a firm quote', async () => {
                     const appResponse = await request(app)
                         .get(
                             `${SWAP_PATH}/quote?buyToken=ZRX&sellToken=WETH&sellAmount=${DEFAULT_SELL_AMOUNT.toString()}&intentOnFilling=true&excludedSources=${DEFAULT_EXCLUDED_SOURCES}`,
@@ -716,6 +741,31 @@ describe(SUITE_NAME, () => {
                                 .expect(HttpStatus.OK)
                                 .expect('Content-Type', /json/);
 
+                            const responseJson = JSON.parse(appResponse.text);
+                            expect(responseJson.buyAmount).to.equal('100000000000000000');
+                            expect(responseJson.price).to.equal('1');
+                            expect(responseJson.sellAmount).to.equal('100000000000000000');
+                            expect(responseJson.sources).to.deep.include.members([{ name: '0x', proportion: '1' }]);
+                        },
+                        quoteRequestorHttpClient,
+                    );
+                });
+                it('should succeed when taker address is not supplied for an indicative quote', async () => {
+                    const response = {
+                        ...DEFAULT_RFQT_RESPONSE_DATA,
+                        responseData: rfqtIndicativeQuoteResponse,
+                    };
+                    response.requestParams.takerAddress = '';
+                    return rfqtMocker.withMockedRfqtIndicativeQuotes(
+                        [response],
+                        async () => {
+                            const appResponse = await request(app)
+                                .get(
+                                    `${SWAP_PATH}/price?buyToken=ZRX&sellToken=WETH&sellAmount=${DEFAULT_SELL_AMOUNT.toString()}&excludedSources=${DEFAULT_EXCLUDED_SOURCES}&skipValidation=true`,
+                                )
+                                .set('0x-api-key', 'koolApiKey1')
+                                .expect(HttpStatus.OK)
+                                .expect('Content-Type', /json/);
                             const responseJson = JSON.parse(appResponse.text);
                             expect(responseJson.buyAmount).to.equal('100000000000000000');
                             expect(responseJson.price).to.equal('1');

--- a/test/rfqt_test.ts
+++ b/test/rfqt_test.ts
@@ -17,7 +17,7 @@ import * as request from 'supertest';
 
 import { AppDependencies, getAppAsync, getDefaultAppDependenciesAsync } from '../src/app';
 import { defaultHttpServiceWithRateLimiterConfig } from '../src/config';
-import { SWAP_PATH as BASE_SWAP_PATH } from '../src/constants';
+import { NULL_ADDRESS, SWAP_PATH as BASE_SWAP_PATH } from '../src/constants';
 
 import { CONTRACT_ADDRESSES } from './constants';
 import { setupDependenciesAsync, teardownDependenciesAsync } from './utils/deployment';
@@ -755,7 +755,7 @@ describe(SUITE_NAME, () => {
                         ...DEFAULT_RFQT_RESPONSE_DATA,
                         responseData: rfqtIndicativeQuoteResponse,
                     };
-                    response.requestParams.takerAddress = '';
+                    response.requestParams.takerAddress = NULL_ADDRESS;
                     return rfqtMocker.withMockedRfqtIndicativeQuotes(
                         [response],
                         async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,9 +32,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-db0f3a878":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-7b0a1c363":
   version "4.6.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/3bf6c545fddf762521c27fc18d76f29f75d3de3b"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/8b0f0a0177c362f7ffc735fb99020fa866108b00"
   dependencies:
     "@0x/assert" "^3.0.9"
     "@0x/base-contract" "^6.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,9 +32,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-b065d8015":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-e9b0ac882":
   version "4.6.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/1c056f69427b46ea1ae9d627b15481ae21ecd4d3"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/5b0ad57706de3342197cb0edd1f3e4da555da97b"
   dependencies:
     "@0x/assert" "^3.0.9"
     "@0x/base-contract" "^6.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,9 +32,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-e9b0ac882":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-db0f3a878":
   version "4.6.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/5b0ad57706de3342197cb0edd1f3e4da555da97b"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/3bf6c545fddf762521c27fc18d76f29f75d3de3b"
   dependencies:
     "@0x/assert" "^3.0.9"
     "@0x/base-contract" "^6.2.3"


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

Changed RFQ-T enablement constraints such that a `takerAddress` query parameter is no longer required when coming through the `/price` endpoint.

# Testing Instructions

Use [Matcha on staging](https://api-staging.matcha.xyz/markets/DAI/USDC), and don't connect your wallet, and request some pricing, and check the API staging logs to ensure that RFQ-T liquidity was accessed.

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Implement.
-   [x] Test manually on staging.
-   [x] Merge [monorepo PR](https://github.com/0xProject/0x-monorepo/pull/2684) and re-pin the dependency herein to the `development` branch.
-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**