### PR TITLE
fix: Altered orderUtils to use a much less expensive query to get pool mak…

### DIFF
--- a/src/utils/order_utils.ts
+++ b/src/utils/order_utils.ts
@@ -33,7 +33,7 @@ import { MAX_TOKEN_SUPPLY_POSSIBLE, NULL_ADDRESS, ONE_SECOND_MS, TEN_MINUTES_MS 
 import { SignedOrderEntity } from '../entities';
 import { logger } from '../logger';
 import * as queries from '../queries/staking_queries';
-import { APIOrderWithMetaData, PinResult, RawEpochPoolStats } from '../types';
+import { APIOrderWithMetaData, PinResult, RawPool } from '../types';
 
 import { createResultCache } from './result_cache';
 
@@ -88,10 +88,10 @@ const assetDataToAsset = (assetData: string): Asset => {
 
 // Cache the expensive query of current epoch stats
 let PIN_CACHE;
-const getEpochStatsAsync = async (connection: Connection) => {
+const getPoolsAsync = async (connection: Connection) => {
     if (!PIN_CACHE) {
         PIN_CACHE = createResultCache<any[]>(
-            () => connection.query(queries.currentEpochPoolsStatsQuery),
+            () => connection.query(queries.stakingPoolsQuery),
             TEN_MINUTES_MS,
         );
     }
@@ -301,17 +301,17 @@ export const orderUtils = {
     // those we wish not to pin. We wish to pin the orders of MMers with a lot of ZRX at stake and
     // who have a track record of acting benevolently.
     async splitOrdersByPinningAsync(connection: Connection, signedOrders: SignedOrder[]): Promise<PinResult> {
-        let currentPoolStats = [];
+        let currentPools = [];
         // HACK(jalextowle): This query will fail when running against Ganache, so we
         // skip it an only use pinned MMers. A deployed staking system that allows this
         // functionality to be tested would improve the testing infrastructure.
         try {
-            currentPoolStats = (await getEpochStatsAsync(connection)) || [];
+            currentPools = (await getPoolsAsync(connection)) || [];
         } catch (error) {
-            logger.warn(`currentEpochPoolsStatsQuery threw an error: ${error}`);
+            logger.warn(`stakingPoolsQuery threw an error: ${error}`);
         }
         let makerAddresses: string[] = PINNED_MM_ADDRESSES;
-        currentPoolStats.forEach((poolStats: RawEpochPoolStats) => {
+        currentPools.forEach((poolStats: RawPool) => {
             if (!PINNED_POOL_IDS.includes(poolStats.pool_id)) {
                 return;
             }

--- a/src/utils/order_utils.ts
+++ b/src/utils/order_utils.ts
@@ -90,10 +90,7 @@ const assetDataToAsset = (assetData: string): Asset => {
 let PIN_CACHE;
 const getPoolsAsync = async (connection: Connection) => {
     if (!PIN_CACHE) {
-        PIN_CACHE = createResultCache<any[]>(
-            () => connection.query(queries.stakingPoolsQuery),
-            TEN_MINUTES_MS,
-        );
+        PIN_CACHE = createResultCache<any[]>(() => connection.query(queries.stakingPoolsQuery), TEN_MINUTES_MS);
     }
     return (await PIN_CACHE.getResultAsync()).result;
 };


### PR DESCRIPTION
…er addresses

<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

<!--- Describe your changes in detail -->

Alters OrderUtils to use a much less expensive query. OrderUtils is pinning orders with the maker addresses of well-known pools.

All that's required is a current list of maker addresses by pool. The previous query `currentEpochPoolsStatsQuery` pulled a lot of unnecessary info and summed over fills. The replacement query, `stakingPoolsQuery`, just pulls basic pool information, including maker addresses.

On hashalytics the query execution time change is 3s -> 100ms.

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
