### PR TITLE
feat: turn back on quote reports for firm quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-1ab33aa13",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-c4bcc26e2",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.11.0-beta-bd3387a40",
         "@0x/contract-wrappers": "^13.7.0",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-beta-bd3387a40",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-ee456ea6e",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.11.0-beta-bd3387a40",
         "@0x/contract-wrappers": "^13.7.0",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-ee456ea6e",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-1ab33aa13",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.11.0-beta-bd3387a40",
         "@0x/contract-wrappers": "^13.7.0",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-c4bcc26e2",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-0ba79b060",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.11.0-68a0fca24",
         "@0x/contract-wrappers": "^13.7.0",

--- a/src/services/meta_transaction_service.ts
+++ b/src/services/meta_transaction_service.ts
@@ -118,11 +118,16 @@ export class MetaTransactionService {
                 takerAddress,
             };
         }
+
+        // only generate quote reports for rfqt firm quotes
+        const shouldGenerateQuoteReport = _rfqt && _rfqt.intentOnFilling;
+
         const assetSwapperOpts: Partial<SwapQuoteRequestOpts> = {
             ...ASSET_SWAPPER_MARKET_ORDERS_V0_OPTS,
             bridgeSlippage: slippagePercentage,
             excludedSources: ASSET_SWAPPER_MARKET_ORDERS_V0_OPTS.excludedSources.concat(...(excludedSources || [])),
             rfqt: _rfqt,
+            shouldGenerateQuoteReport,
         };
 
         let swapQuote: MarketSellSwapQuote | MarketBuySwapQuote | undefined;

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -505,6 +505,10 @@ export class SwapService {
                 takerAddress,
             };
         }
+
+        // only generate quote reports for rfqt firm quotes
+        const shouldGenerateQuoteReport = rfqt && rfqt.intentOnFilling;
+
         const swapQuoteRequestOpts =
             swapVersion === SwapVersion.V0 ? ASSET_SWAPPER_MARKET_ORDERS_V0_OPTS : ASSET_SWAPPER_MARKET_ORDERS_V1_OPTS;
         const assetSwapperOpts: Partial<SwapQuoteRequestOpts> = {
@@ -513,6 +517,7 @@ export class SwapService {
             gasPrice: providedGasPrice,
             excludedSources: swapQuoteRequestOpts.excludedSources.concat(...(excludedSources || [])),
             rfqt: _rfqt,
+            shouldGenerateQuoteReport,
         };
         if (sellAmount !== undefined) {
             return this._swapQuoter.getMarketSellSwapQuoteAsync(

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,9 +32,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-beta-bd3387a40":
-  version "4.6.0-beta"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/1b7bfe498c10d7627bd7fa1aa5c2a136432aa121"
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-ee456ea6e":
+  version "4.6.0"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/ca89e0516c4cfc98e8e26899d760b0ec8d2b689b"
   dependencies:
     "@0x/assert" "^3.0.9"
     "@0x/base-contract" "^6.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,9 +32,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-c4bcc26e2":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-0ba79b060":
   version "4.6.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/013da0359532ab3a4af33688044b69315ff9db79"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/4ca47a7ba6a6c95aa3fde2da2ffbb048228ebcd5"
   dependencies:
     "@0x/assert" "^3.0.9"
     "@0x/base-contract" "^6.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,9 +32,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-1ab33aa13":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-c4bcc26e2":
   version "4.6.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/ddafe521d422c18d4e02ead2f2cb4a51e37505c2"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/013da0359532ab3a4af33688044b69315ff9db79"
   dependencies:
     "@0x/assert" "^3.0.9"
     "@0x/base-contract" "^6.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,9 +32,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-ee456ea6e":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.6.0-1ab33aa13":
   version "4.6.0"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/ca89e0516c4cfc98e8e26899d760b0ec8d2b689b"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/ddafe521d422c18d4e02ead2f2cb4a51e37505c2"
   dependencies:
     "@0x/assert" "^3.0.9"
     "@0x/base-contract" "^6.2.3"


### PR DESCRIPTION
# Description

Paired with https://github.com/0xProject/0x-monorepo/pull/2696

* Turns on quote reports _only_ for RFQT firm quotes
* Quote reports are much more optimized by looking up taker amount by signature instead of orderHash ( https://github.com/0xProject/0x-monorepo/pull/2696 )
<!--- Describe your changes in detail -->

# TODO

- [x] Ensure that it is ok to deploy latest asset-swapper changes bundled with this
- [x] Pause QuoteReport job prior to deploying

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.