### PR TITLE
fix: Add 10% to eth_estimateGas

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,7 +27,7 @@ export const MESH_ORDERS_BATCH_HTTP_BYTE_LENGTH = 2500000;
 
 // Swap Quoter
 export const QUOTE_ORDER_EXPIRATION_BUFFER_MS = ONE_SECOND_MS * 60; // Ignore orders that expire in 60 seconds
-export const GAS_LIMIT_BUFFER_PERCENTAGE = 0.2; // Add 20% to the estimated gas limit
+export const GAS_LIMIT_BUFFER_PERCENTAGE = 0.1; // Add 10% to the estimated gas limit
 export const GAS_LIMIT_BUFFER_MULTIPLIER = GAS_LIMIT_BUFFER_PERCENTAGE + 1;
 export const DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE = 0.01; // 1% Slippage
 export const DEFAULT_FALLBACK_SLIPPAGE_PERCENTAGE = 0.015; // 1.5% Slippage in a fallback route

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -164,11 +164,15 @@ export class SwapService {
                 gasPrice,
             });
             // Take the max of the faux estimate or the real estimate
-            conservativeBestCaseGasEstimate = BigNumber.max(estimateGasCallResult, conservativeBestCaseGasEstimate);
+            conservativeBestCaseGasEstimate = BigNumber.max(
+                // Add a little buffer to eth_estimateGas as it is not always correct
+                estimateGasCallResult.times(GAS_LIMIT_BUFFER_MULTIPLIER).integerValue(),
+                conservativeBestCaseGasEstimate,
+            );
         }
         // If any sources can be undeterministic in gas costs, we add a buffer
         const hasUndeterministicFills = _.flatten(swapQuote.orders.map(order => order.fills)).some(fill =>
-            [ERC20BridgeSource.Native, ERC20BridgeSource.Kyber, ERC20BridgeSource.MultiBridge].includes(fill.source),
+            [ERC20BridgeSource.Native, ERC20BridgeSource.MultiBridge].includes(fill.source),
         );
         const undeterministicMultiplier = hasUndeterministicFills ? GAS_LIMIT_BUFFER_MULTIPLIER : 1;
         // Add a buffer to get the worst case gas estimate


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

<!--- Describe your changes in detail -->

* Added a buffer around eth_estimateGas when it is higher than our fauxEstimate
* Kyber should now also be deterministic as we always go through a specific reserve

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
