### PR TITLE
fix: Avoid divide by 0 in the average rewards query

### DIFF
--- a/src/queries/staking_queries.ts
+++ b/src/queries/staking_queries.ts
@@ -235,7 +235,7 @@ export const poolsAvgRewardsQuery = `
                 , AVG(members_reward) / 1e18 AS avg_member_reward_in_eth
                 , AVG(operator_reward + members_reward) / 1e18 AS avg_total_reward_in_eth
                 , AVG(esps.member_zrx_delegated) AS avg_member_stake
-                , AVG((members_reward / 1e18) / esps.member_zrx_delegated) AS avg_member_reward_eth_per_zrx
+                , AVG((members_reward / 1e18) / NULLIF(esps.member_zrx_delegated,0)) AS avg_member_reward_eth_per_zrx
             FROM events.rewards_paid_events rpe
             JOIN staking.current_epoch ce ON rpe.epoch_id > (ce.epoch_id - 4)
             -- subtract one from the reward epoch ID, since reward events are stamped with the epoch


### PR DESCRIPTION

# Description

Alters the average rewards query to ensure no division by zero error.

# Testing Instructions

- [ ] Tested on analytics database

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
