### PR TITLE
fix: Fix support for passing ETH as buyToken and sellToken

### DIFF
--- a/src/handlers/meta_transaction_handlers.ts
+++ b/src/handlers/meta_transaction_handlers.ts
@@ -37,7 +37,11 @@ import { parseUtils } from '../utils/parse_utils';
 import { priceComparisonUtils } from '../utils/price_comparison_utils';
 import { isRateLimitedMetaTransactionResponse, MetaTransactionRateLimiter } from '../utils/rate-limiters';
 import { schemaUtils } from '../utils/schema_utils';
-import { findTokenAddressOrThrowApiError, getTokenMetadataIfExists, isETHSymbol } from '../utils/token_metadata_utils';
+import {
+    findTokenAddressOrThrowApiError,
+    getTokenMetadataIfExists,
+    isETHSymbolOrAddress,
+} from '../utils/token_metadata_utils';
 
 export class MetaTransactionHandlers {
     private readonly _metaTransactionService: MetaTransactionService;
@@ -79,10 +83,10 @@ export class MetaTransactionHandlers {
         } = params;
         const sellToken = getTokenMetadataIfExists(sellTokenAddress, CHAIN_ID);
         const buyToken = getTokenMetadataIfExists(buyTokenAddress, CHAIN_ID);
-        const isETHBuy = isETHSymbol(buyToken!.symbol);
+        const isETHBuy = isETHSymbolOrAddress(buyToken!.symbol);
 
         // ETH selling isn't supported.
-        if (isETHSymbol(sellToken!.symbol)) {
+        if (isETHSymbolOrAddress(sellToken!.symbol)) {
             throw new EthSellNotSupportedError();
         }
 
@@ -189,8 +193,8 @@ export class MetaTransactionHandlers {
         } = parseGetTransactionRequestParams(req);
         const sellToken = getTokenMetadataIfExists(sellTokenAddress, CHAIN_ID);
         const buyToken = getTokenMetadataIfExists(buyTokenAddress, CHAIN_ID);
-        const isETHSell = isETHSymbol(sellToken!.symbol);
-        const isETHBuy = isETHSymbol(buyToken!.symbol);
+        const isETHSell = isETHSymbolOrAddress(sellToken!.symbol);
+        const isETHBuy = isETHSymbolOrAddress(buyToken!.symbol);
         try {
             const metaTransactionPrice = await this._metaTransactionService.calculateMetaTransactionPriceAsync({
                 takerAddress,

--- a/src/handlers/meta_transaction_handlers.ts
+++ b/src/handlers/meta_transaction_handlers.ts
@@ -1,5 +1,6 @@
 import { assert } from '@0x/assert';
 import { ERC20BridgeSource, SwapQuoterError } from '@0x/asset-swapper';
+import { ETH_TOKEN_ADDRESS } from '@0x/order-utils';
 import { BigNumber, NULL_ADDRESS } from '@0x/utils';
 import * as express from 'express';
 import * as HttpStatus from 'http-status-codes';
@@ -98,9 +99,9 @@ export class MetaTransactionHandlers {
                 apiKey,
                 includePriceComparisons,
                 isETHBuy,
+                isETHSell: false,
                 affiliateFee,
                 from: takerAddress,
-                isETHSell: false,
             });
 
             let priceComparisons: SourceComparison[] | undefined;
@@ -223,8 +224,8 @@ export class MetaTransactionHandlers {
                 price: metaTransactionPrice.price,
                 buyAmount: metaTransactionPrice.buyAmount!,
                 sellAmount: metaTransactionPrice.sellAmount!,
-                sellTokenAddress,
-                buyTokenAddress,
+                sellTokenAddress: isETHSell ? ETH_TOKEN_ADDRESS : sellTokenAddress,
+                buyTokenAddress: isETHBuy ? ETH_TOKEN_ADDRESS : buyTokenAddress,
                 sources: metaTransactionPrice.sources,
                 value: metaTransactionPrice.protocolFee,
                 gasPrice: metaTransactionPrice.gasPrice,

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -245,6 +245,7 @@ export class SwapHandlers {
 
         const isETHSell = isETHSymbolOrAddress(sellToken);
         const isETHBuy = isETHSymbolOrAddress(buyToken);
+        // NOTE: Internally all ETH trades are for WETH, we just wrap/unwrap automatically
         const sellTokenAddress = findTokenAddressOrThrowApiError(isETHSell ? 'WETH' : sellToken, 'sellToken', CHAIN_ID);
         const buyTokenAddress = findTokenAddressOrThrowApiError(isETHBuy ? 'WETH' : buyToken, 'buyToken', CHAIN_ID);
         const isWrap = isETHSell && isWETHSymbolOrAddress(buyToken, CHAIN_ID);

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -39,7 +39,7 @@ import { serviceUtils } from '../utils/service_utils';
 import {
     findTokenAddressOrThrowApiError,
     getTokenMetadataIfExists,
-    isETHSymbol,
+    isETHSymbolOrAddress,
     isWETHSymbolOrAddress,
 } from '../utils/token_metadata_utils';
 
@@ -243,8 +243,8 @@ export class SwapHandlers {
             includePriceComparisons,
         } = params;
 
-        const isETHSell = isETHSymbol(sellToken);
-        const isETHBuy = isETHSymbol(buyToken);
+        const isETHSell = isETHSymbolOrAddress(sellToken);
+        const isETHBuy = isETHSymbolOrAddress(buyToken);
         const sellTokenAddress = findTokenAddressOrThrowApiError(isETHSell ? 'WETH' : sellToken, 'sellToken', CHAIN_ID);
         const buyTokenAddress = findTokenAddressOrThrowApiError(isETHBuy ? 'WETH' : buyToken, 'buyToken', CHAIN_ID);
         const isWrap = isETHSell && isWETHSymbolOrAddress(buyToken, CHAIN_ID);

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -245,8 +245,8 @@ export class SwapHandlers {
 
         const isETHSell = isETHSymbol(sellToken);
         const isETHBuy = isETHSymbol(buyToken);
-        const sellTokenAddress = findTokenAddressOrThrowApiError(sellToken, 'sellToken', CHAIN_ID);
-        const buyTokenAddress = findTokenAddressOrThrowApiError(buyToken, 'buyToken', CHAIN_ID);
+        const sellTokenAddress = findTokenAddressOrThrowApiError(isETHSell ? 'WETH' : sellToken, 'sellToken', CHAIN_ID);
+        const buyTokenAddress = findTokenAddressOrThrowApiError(isETHBuy ? 'WETH' : buyToken, 'buyToken', CHAIN_ID);
         const isWrap = isETHSell && isWETHSymbolOrAddress(buyToken, CHAIN_ID);
         const isUnwrap = isWETHSymbolOrAddress(sellToken, CHAIN_ID) && isETHBuy;
         // if token addresses are the same but a unwrap or wrap operation is requested, ignore error

--- a/src/services/meta_transaction_service.ts
+++ b/src/services/meta_transaction_service.ts
@@ -51,7 +51,10 @@ import {
 import { ethGasStationUtils } from '../utils/gas_station_utils';
 import { quoteReportUtils } from '../utils/quote_report_utils';
 import { serviceUtils } from '../utils/service_utils';
+import { getTokenMetadataIfExists } from '../utils/token_metadata_utils';
 import { utils } from '../utils/utils';
+
+const WETHToken = getTokenMetadataIfExists('WETH', CHAIN_ID)!;
 
 interface SwapService {
     calculateSwapQuoteAsync(params: CalculateSwapQuoteParams): Promise<GetSwapQuoteResponse>;
@@ -347,6 +350,9 @@ export class MetaTransactionService {
             },
             isMetaTransaction: true,
             ...params,
+            // NOTE: Internally all ETH trades are for WETH, we just wrap/unwrap automatically
+            buyTokenAddress: params.isETHBuy ? WETHToken.tokenAddress : params.buyTokenAddress,
+            sellTokenAddress: params.isETHSell ? WETHToken.tokenAddress : params.sellTokenAddress,
         };
 
         const quote = await this._swapService.calculateSwapQuoteAsync(quoteParams);

--- a/src/services/meta_transaction_service.ts
+++ b/src/services/meta_transaction_service.ts
@@ -352,7 +352,7 @@ export class MetaTransactionService {
             ...params,
             // NOTE: Internally all ETH trades are for WETH, we just wrap/unwrap automatically
             buyTokenAddress: params.isETHBuy ? WETHToken.tokenAddress : params.buyTokenAddress,
-            sellTokenAddress: params.isETHSell ? WETHToken.tokenAddress : params.sellTokenAddress,
+            sellTokenAddress: params.sellTokenAddress,
         };
 
         const quote = await this._swapService.calculateSwapQuoteAsync(quoteParams);

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -13,7 +13,7 @@ import {
 import { SwapQuoteRequestOpts, SwapQuoterOpts } from '@0x/asset-swapper/lib/src/types';
 import { ContractAddresses } from '@0x/contract-addresses';
 import { WETH9Contract } from '@0x/contract-wrappers';
-import { assetDataUtils, SupportedProvider } from '@0x/order-utils';
+import { assetDataUtils, ETH_TOKEN_ADDRESS, SupportedProvider } from '@0x/order-utils';
 import { MarketOperation } from '@0x/types';
 import { BigNumber, decodeThrownErrorAsRevertError, RevertError } from '@0x/utils';
 import { TxData, Web3Wrapper } from '@0x/web3-wrapper';
@@ -196,8 +196,9 @@ export class SwapService {
             gasPrice,
             protocolFee: adjustedWorstCaseProtocolFee,
             minimumProtocolFee: BigNumber.min(adjustedWorstCaseProtocolFee, bestCaseProtocolFee),
-            buyTokenAddress,
-            sellTokenAddress,
+            // NOTE: Internally all ETH trades are for WETH, we just wrap/unwrap automatically
+            buyTokenAddress: isETHBuy ? ETH_TOKEN_ADDRESS : buyTokenAddress,
+            sellTokenAddress: isETHSell ? ETH_TOKEN_ADDRESS : sellTokenAddress,
             buyAmount: makerAssetAmount.minus(buyTokenFeeAmount),
             sellAmount: totalTakerAssetAmount,
             sources: serviceUtils.convertSourceBreakdownToArray(sourceBreakdown),

--- a/src/token_metadatas_for_networks.ts
+++ b/src/token_metadatas_for_networks.ts
@@ -1,3 +1,5 @@
+import { ETH_TOKEN_ADDRESS } from '@0x/order-utils';
+
 import { NULL_ADDRESS } from './constants';
 import { ChainId } from './types';
 
@@ -35,6 +37,16 @@ export const TokenMetadatasForChains: TokenMetadataAndChainAddresses[] = [
             [ChainId.Mainnet]: '0x1985365e9f78359a9B6AD760e32412f4a445E862',
             [ChainId.Kovan]: '0x4e5cb5a0caca30d1ad27d8cd8200a907854fb518',
             [ChainId.Ganache]: '0x34d402f14d58e001d8efbe6585051bf9706aa064',
+        },
+    },
+    {
+        symbol: 'ETH',
+        name: 'Ether',
+        decimals: 18,
+        tokenAddresses: {
+            [ChainId.Mainnet]: ETH_TOKEN_ADDRESS,
+            [ChainId.Kovan]: ETH_TOKEN_ADDRESS,
+            [ChainId.Ganache]: ETH_TOKEN_ADDRESS,
         },
     },
     {

--- a/src/utils/token_metadata_utils.ts
+++ b/src/utils/token_metadata_utils.ts
@@ -1,3 +1,5 @@
+import { ETH_TOKEN_ADDRESS } from '@0x/order-utils';
+
 import { ADDRESS_HEX_LENGTH, ETH_SYMBOL, WETH_SYMBOL } from '../constants';
 import { ValidationError, ValidationErrorCodes } from '../errors';
 import { TokenMetadataAndChainAddresses, TokenMetadatasForChains } from '../token_metadatas_for_networks';
@@ -30,12 +32,15 @@ export function getTokenMetadataIfExists(tokenAddressOrSymbol: string, chainId: 
 }
 
 /**
- *  Returns true if this symbol represents ETH
+ *  Returns true if this symbol or address represents ETH
  *
- * @param tokenSymbol the symbol of the token
+ * @param tokenSymbolOrAddress the symbol of the token
  */
-export function isETHSymbol(tokenSymbol: string): boolean {
-    return tokenSymbol.toLowerCase() === ETH_SYMBOL.toLowerCase();
+export function isETHSymbolOrAddress(tokenSymbolOrAddress: string): boolean {
+    return (
+        tokenSymbolOrAddress.toLowerCase() === ETH_SYMBOL.toLowerCase() ||
+        tokenSymbolOrAddress.toLowerCase() === ETH_TOKEN_ADDRESS.toLowerCase()
+    );
 }
 
 /**

--- a/src/utils/token_metadata_utils.ts
+++ b/src/utils/token_metadata_utils.ts
@@ -16,7 +16,7 @@ export function getTokenMetadataIfExists(tokenAddressOrSymbol: string, chainId: 
             tm => tm.tokenAddresses[chainId].toLowerCase() === tokenAddressOrSymbol.toLowerCase(),
         );
     } else {
-        const normalizedSymbol = (isETHSymbol(tokenAddressOrSymbol) ? 'WETH' : tokenAddressOrSymbol).toLowerCase();
+        const normalizedSymbol = tokenAddressOrSymbol.toLowerCase();
         entry = TokenMetadatasForChains.find(tm => tm.symbol.toLowerCase() === normalizedSymbol);
     }
 

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,5 +1,5 @@
 import { ContractAddresses, getContractAddressesForChainOrThrow } from '@0x/contract-addresses';
-import { assetDataUtils } from '@0x/order-utils';
+import { assetDataUtils, ETH_TOKEN_ADDRESS } from '@0x/order-utils';
 import { ObjectMap } from '@0x/types';
 import { BigNumber } from '@0x/utils';
 
@@ -10,6 +10,8 @@ export const MAX_MINT_AMOUNT = new BigNumber('10000000000000000000000');
 export const CONTRACT_ADDRESSES: ContractAddresses = getContractAddressesForChainOrThrow(CHAIN_ID);
 export const ZRX_TOKEN_ADDRESS = CONTRACT_ADDRESSES.zrxToken;
 export const WETH_TOKEN_ADDRESS = CONTRACT_ADDRESSES.etherToken;
+export { ETH_TOKEN_ADDRESS };
+
 export const ZRX_ASSET_DATA = assetDataUtils.encodeERC20AssetData(ZRX_TOKEN_ADDRESS);
 export const WETH_ASSET_DATA = assetDataUtils.encodeERC20AssetData(WETH_TOKEN_ADDRESS);
 export const UNKNOWN_TOKEN_ADDRESS = '0xbe0037eaf2d64fe5529bca93c18c9702d3930376';
@@ -17,5 +19,7 @@ export const UNKNOWN_TOKEN_ASSET_DATA = assetDataUtils.encodeERC20AssetData(UNKN
 export const SYMBOL_TO_ADDRESS: ObjectMap<string> = {
     ZRX: ZRX_TOKEN_ADDRESS,
     WETH: WETH_TOKEN_ADDRESS,
+    ETH: ETH_TOKEN_ADDRESS,
 };
+export const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
 export const AFFILIATE_DATA_SELECTOR = '869584cd';

--- a/test/swap_test.ts
+++ b/test/swap_test.ts
@@ -15,11 +15,14 @@ import { AFFILIATE_FEE_TRANSFORMER_GAS, GAS_LIMIT_BUFFER_MULTIPLIER, SWAP_PATH }
 import { ValidationErrorCodes, ValidationErrorItem, ValidationErrorReasons } from '../src/errors';
 import { logger } from '../src/logger';
 import { GetSwapQuoteResponse } from '../src/types';
+import { isETHSymbolOrAddress } from '../src/utils/token_metadata_utils';
 
 import {
     CONTRACT_ADDRESSES,
+    ETH_TOKEN_ADDRESS,
     MAX_INT,
     MAX_MINT_AMOUNT,
+    NULL_ADDRESS,
     SYMBOL_TO_ADDRESS,
     UNKNOWN_TOKEN_ADDRESS,
     UNKNOWN_TOKEN_ASSET_DATA,
@@ -147,6 +150,10 @@ describe(SUITE_NAME, () => {
                 { buyToken: ZRX_TOKEN_ADDRESS, sellToken: 'WETH', buyAmount: '1000' },
                 { buyToken: ZRX_TOKEN_ADDRESS, sellToken: WETH_TOKEN_ADDRESS, buyAmount: '1000' },
                 { buyToken: 'ZRX', sellToken: UNKNOWN_TOKEN_ADDRESS, buyAmount: '1000' },
+                { buyToken: 'ZRX', sellToken: 'ETH', buyAmount: '1000' },
+                { buyToken: 'ETH', sellToken: 'ZRX', buyAmount: '1000' },
+                { buyToken: 'ZRX', sellToken: ETH_TOKEN_ADDRESS, buyAmount: '1000' },
+                { buyToken: ETH_TOKEN_ADDRESS, sellToken: 'ZRX', buyAmount: '1000' },
             ];
             for (const parameters of parameterPermutations) {
                 it(`should return a valid quote with ${JSON.stringify(parameters)}`, async () => {
@@ -158,7 +165,9 @@ describe(SUITE_NAME, () => {
                         buyTokenAddress: parameters.buyToken.startsWith('0x')
                             ? parameters.buyToken
                             : SYMBOL_TO_ADDRESS[parameters.buyToken],
-                        allowanceTarget: CONTRACT_ADDRESSES.exchangeProxyAllowanceTarget,
+                        allowanceTarget: isETHSymbolOrAddress(parameters.sellToken)
+                            ? NULL_ADDRESS
+                            : CONTRACT_ADDRESSES.exchangeProxyAllowanceTarget,
                     });
                 });
             }


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description
This adds support for passing ETH as `buyToken` or `sellToken` via symbol and our fake ETH token address (`0xeee...`). `buyTokenAddress` and `sellTokenAddress` address is now correct reflecting ETH in the response, even with the trade being handled as a WETH trade + wrap/unwrap internally.

The meta transaction endpoints now correctly support buying and receiving ETH with a metatx.
<!--- Describe your changes in detail -->

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [X] Add tests to cover changes as needed.
