### PR TITLE
fix: [WIP] Adds PRICE_AWARE_RFQ_ENABLED environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.7.1-8de0282d9",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.7.1-771a3f7dc",
         "@0x/base-contract": "^6.2.3",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.11.0-3aaa0ad6b",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.7.1-689a8881c",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.7.1-771a3f7dc",
         "@0x/base-contract": "^6.2.3",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.11.0-3aaa0ad6b",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.7.1-771a3f7dc",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.7.1-689a8881c",
         "@0x/base-contract": "^6.2.3",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v4.11.0-3aaa0ad6b",

--- a/src/config.ts
+++ b/src/config.ts
@@ -270,6 +270,13 @@ export const ETH_GAS_STATION_API_URL: string = _.isEmpty(process.env.ETH_GAS_STA
     ? DEFAULT_ETH_GAS_STATION_API_URL
     : assertEnvVarType('ETH_GAS_STATION_API_URL', process.env.ETH_GAS_STATION_API_URL, EnvVarType.Url);
 
+// If true, Price-Aware RFQ feature will be enabled for RFQ-enabled requests
+// tslint:disable-next-line:boolean-naming
+export const PRICE_AWARE_RFQ_ENABLED: boolean = _.isEmpty(process.env.PRICE_AWARE_RFQ_ENABLED)
+    ? false
+    : assertEnvVarType('PRICE_AWARE_RFQ_ENABLED', process.env.PRICE_AWARE_RFQ_ENABLED, EnvVarType.Boolean);
+
+
 // Max number of entities per page
 export const MAX_PER_PAGE = 1000;
 // Default ERC20 token precision

--- a/src/config.ts
+++ b/src/config.ts
@@ -276,7 +276,6 @@ export const PRICE_AWARE_RFQ_ENABLED: boolean = _.isEmpty(process.env.PRICE_AWAR
     ? false
     : assertEnvVarType('PRICE_AWARE_RFQ_ENABLED', process.env.PRICE_AWARE_RFQ_ENABLED, EnvVarType.Boolean);
 
-
 // Max number of entities per page
 export const MAX_PER_PAGE = 1000;
 // Default ERC20 token precision

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -23,6 +23,7 @@ import {
     ASSET_SWAPPER_MARKET_ORDERS_OPTS,
     ASSET_SWAPPER_MARKET_ORDERS_OPTS_NO_VIP,
     CHAIN_ID,
+    PRICE_AWARE_RFQ_ENABLED,
     PROTOCOL_FEE_MULTIPLIER,
     RFQT_REQUEST_MAX_RESPONSE_MS,
     SWAP_QUOTER_OPTS,
@@ -475,6 +476,7 @@ export class SwapService {
                 apiKey,
                 makerEndpointMaxResponseTimeMs: RFQT_REQUEST_MAX_RESPONSE_MS,
                 takerAddress,
+                isPriceAwareRFQEnabled: PRICE_AWARE_RFQ_ENABLED,
             };
         }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,9 +25,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.7.1-8de0282d9":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.7.1-771a3f7dc":
   version "4.7.1"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/fb2259ef1478efc3960e6ac0d78e611f3d60d523"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/019aab400b99afa5de1918acfd4ab8d43379a6c2"
   dependencies:
     "@0x/assert" "^3.0.13"
     "@0x/base-contract" "^6.2.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,9 +25,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.7.1-771a3f7dc":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.7.1-689a8881c":
   version "4.7.1"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/019aab400b99afa5de1918acfd4ab8d43379a6c2"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/bf00cdbcc4118e5a53e8f559713f1f28009c330a"
   dependencies:
     "@0x/assert" "^3.0.13"
     "@0x/base-contract" "^6.2.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,9 +25,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.7.1-689a8881c":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.7.1-771a3f7dc":
   version "4.7.1"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/bf00cdbcc4118e5a53e8f559713f1f28009c330a"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/019aab400b99afa5de1918acfd4ab8d43379a6c2"
   dependencies:
     "@0x/assert" "^3.0.13"
     "@0x/base-contract" "^6.2.7"


### PR DESCRIPTION
Adds a feature flag called PRICE_AWARE_RFQ_ENABLED that can be used to enable the Price-aware RFQ service. The flag is off by default. Most likely this PR will need a new deploy once https://github.com/0xProject/protocol/pull/13 is merged