### PR TITLE
fix: upgrades asset swapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.4",
-        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.8.1-866f958a1",
+        "@0x/asset-swapper": "0xProject/gitpkg-registry#0x-asset-swapper-v4.8.1-e2e14a977",
         "@0x/base-contract": "^6.2.3",
         "@0x/connect": "^6.0.4",
         "@0x/contract-addresses": "0xProject/gitpkg-registry#0x-contract-addresses-v5.0.1-9816019bc",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,9 +34,9 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.8.1-866f958a1":
+"@0x/asset-swapper@0xProject/gitpkg-registry#0x-asset-swapper-v4.8.1-e2e14a977":
   version "4.8.1"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/01631215c0a48c161e45b83a42c3cb53393326dc"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/2e6fdf537ebcf7ebd4c2ab5264a94161b63dae57"
   dependencies:
     "@0x/assert" "^3.0.17"
     "@0x/base-contract" "^6.2.11"


### PR DESCRIPTION
Upgrades Asset Swapper to support the new `comparisonPrice` logging