### PR TITLE
fix: use correct decimal precision for price and price comparisons

### DIFF
--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -90,26 +90,29 @@ export class SwapService {
         const affiliateFeeUnitMakerAssetAmount = guaranteedUnitMakerAssetAmount.times(
             affiliateFee.buyTokenPercentageFee,
         );
+
+        const isSelling = buyAmount === undefined;
+        // NOTE: In order to not communicate a price better than the actual quote we
+        // should make sure to always round towards a worse price
+        const roundingStrategy = isSelling ? BigNumber.ROUND_FLOOR : BigNumber.ROUND_CEIL;
         // Best price
-        const price =
-            buyAmount === undefined
-                ? unitMakerAssetAmount
-                      .minus(affiliateFeeUnitMakerAssetAmount)
-                      .dividedBy(unitTakerAssetAmount)
-                      .decimalPlaces(buyTokenDecimals)
-                : unitTakerAssetAmount
-                      .dividedBy(unitMakerAssetAmount.minus(affiliateFeeUnitMakerAssetAmount))
-                      .decimalPlaces(sellTokenDecimals);
+        const price = isSelling
+            ? unitMakerAssetAmount
+                  .minus(affiliateFeeUnitMakerAssetAmount)
+                  .dividedBy(unitTakerAssetAmount)
+                  .decimalPlaces(buyTokenDecimals, roundingStrategy)
+            : unitTakerAssetAmount
+                  .dividedBy(unitMakerAssetAmount.minus(affiliateFeeUnitMakerAssetAmount))
+                  .decimalPlaces(sellTokenDecimals, roundingStrategy);
         // Guaranteed price before revert occurs
-        const guaranteedPrice =
-            buyAmount === undefined
-                ? guaranteedUnitMakerAssetAmount
-                      .minus(affiliateFeeUnitMakerAssetAmount)
-                      .dividedBy(guaranteedUnitTakerAssetAmount)
-                      .decimalPlaces(buyTokenDecimals)
-                : guaranteedUnitTakerAssetAmount
-                      .dividedBy(guaranteedUnitMakerAssetAmount.minus(affiliateFeeUnitMakerAssetAmount))
-                      .decimalPlaces(sellTokenDecimals);
+        const guaranteedPrice = isSelling
+            ? guaranteedUnitMakerAssetAmount
+                  .minus(affiliateFeeUnitMakerAssetAmount)
+                  .dividedBy(guaranteedUnitTakerAssetAmount)
+                  .decimalPlaces(buyTokenDecimals, roundingStrategy)
+            : guaranteedUnitTakerAssetAmount
+                  .dividedBy(guaranteedUnitMakerAssetAmount.minus(affiliateFeeUnitMakerAssetAmount))
+                  .decimalPlaces(sellTokenDecimals, roundingStrategy);
         return {
             price,
             guaranteedPrice,
@@ -337,7 +340,9 @@ export class SwapService {
                 const { makerAssetAmount, totalTakerAssetAmount } = quote.bestCaseQuoteInfo;
                 const unitMakerAssetAmount = Web3Wrapper.toUnitAmount(makerAssetAmount, buyTokenDecimals);
                 const unitTakerAssetAmount = Web3Wrapper.toUnitAmount(totalTakerAssetAmount, sellTokenDecimals);
-                const price = unitTakerAssetAmount.dividedBy(unitMakerAssetAmount).decimalPlaces(sellTokenDecimals);
+                const price = unitTakerAssetAmount
+                    .dividedBy(unitMakerAssetAmount)
+                    .decimalPlaces(sellTokenDecimals, BigNumber.ROUND_CEIL);
                 return {
                     symbol: queryAssetData[i].symbol,
                     price,

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -96,20 +96,20 @@ export class SwapService {
                 ? unitMakerAssetAmount
                       .minus(affiliateFeeUnitMakerAssetAmount)
                       .dividedBy(unitTakerAssetAmount)
-                      .decimalPlaces(sellTokenDecimals)
+                      .decimalPlaces(buyTokenDecimals)
                 : unitTakerAssetAmount
                       .dividedBy(unitMakerAssetAmount.minus(affiliateFeeUnitMakerAssetAmount))
-                      .decimalPlaces(buyTokenDecimals);
+                      .decimalPlaces(sellTokenDecimals);
         // Guaranteed price before revert occurs
         const guaranteedPrice =
             buyAmount === undefined
                 ? guaranteedUnitMakerAssetAmount
                       .minus(affiliateFeeUnitMakerAssetAmount)
                       .dividedBy(guaranteedUnitTakerAssetAmount)
-                      .decimalPlaces(sellTokenDecimals)
+                      .decimalPlaces(buyTokenDecimals)
                 : guaranteedUnitTakerAssetAmount
                       .dividedBy(guaranteedUnitMakerAssetAmount.minus(affiliateFeeUnitMakerAssetAmount))
-                      .decimalPlaces(buyTokenDecimals);
+                      .decimalPlaces(sellTokenDecimals);
         return {
             price,
             guaranteedPrice,

--- a/src/utils/price_comparison_utils.ts
+++ b/src/utils/price_comparison_utils.ts
@@ -122,8 +122,8 @@ export const priceComparisonUtils = {
                 const unitTakerAmount = Web3Wrapper.toUnitAmount(takerAmount, sellToken.decimals);
 
                 const price = isSelling
-                    ? unitMakerAmount.dividedBy(unitTakerAmount).decimalPlaces(sellToken.decimals)
-                    : unitTakerAmount.dividedBy(unitMakerAmount).decimalPlaces(buyToken.decimals);
+                    ? unitMakerAmount.dividedBy(unitTakerAmount).decimalPlaces(buyToken.decimals)
+                    : unitTakerAmount.dividedBy(unitMakerAmount).decimalPlaces(sellToken.decimals);
 
                 return {
                     name: liquiditySource,

--- a/src/utils/price_comparison_utils.ts
+++ b/src/utils/price_comparison_utils.ts
@@ -121,9 +121,13 @@ export const priceComparisonUtils = {
                 const unitMakerAmount = Web3Wrapper.toUnitAmount(makerAmount, buyToken.decimals);
                 const unitTakerAmount = Web3Wrapper.toUnitAmount(takerAmount, sellToken.decimals);
 
+                // NOTE: In order to not communicate a price better than the actual quote we
+                // should make sure to always round towards a worse price
+                const roundingStrategy = isSelling ? BigNumber.ROUND_FLOOR : BigNumber.ROUND_CEIL;
+
                 const price = isSelling
-                    ? unitMakerAmount.dividedBy(unitTakerAmount).decimalPlaces(buyToken.decimals)
-                    : unitTakerAmount.dividedBy(unitMakerAmount).decimalPlaces(sellToken.decimals);
+                    ? unitMakerAmount.dividedBy(unitTakerAmount).decimalPlaces(buyToken.decimals, roundingStrategy)
+                    : unitTakerAmount.dividedBy(unitMakerAmount).decimalPlaces(sellToken.decimals, roundingStrategy);
 
                 return {
                     name: liquiditySource,

--- a/test/price_comparison_utils_test.ts
+++ b/test/price_comparison_utils_test.ts
@@ -275,23 +275,67 @@ describe(SUITE_NAME, () => {
             ]);
         });
 
-        it('handles buying tokens with a different number of decimals', () => {
-            const price = new BigNumber(1).decimalPlaces(6);
-            const daiAmount = new BigNumber(1e18);
-            const usdcAmount = new BigNumber(1e6);
+        it('should match price decimal places to maker asset for sell quotes', () => {
+            const wethAmount = new BigNumber(1 / 3).times(1e18).decimalPlaces(0, BigNumber.ROUND_FLOOR);
+            const usdcAmount = new BigNumber(100e6);
+
+            const price = wethAmount
+                .div(usdcAmount)
+                .div(1e12)
+                .decimalPlaces(18);
 
             const comparisons = priceComparisonUtils.getPriceComparisonFromQuote(
                 ChainId.Mainnet,
-                { buyAmount: daiAmount },
+                { sellAmount: usdcAmount },
                 {
-                    buyTokenAddress: DAI.tokenAddress,
+                    buyTokenAddress: WETH.tokenAddress,
                     sellTokenAddress: USDC.tokenAddress,
-                    buyAmount: daiAmount,
+                    buyAmount: wethAmount,
                     sellAmount: usdcAmount,
                     quoteReport: {
                         sourcesConsidered: [
                             {
-                                makerAmount: daiAmount,
+                                makerAmount: wethAmount,
+                                takerAmount: usdcAmount,
+                                liquiditySource: ERC20BridgeSource.Uniswap,
+                                fillData: {},
+                            },
+                        ],
+                    },
+                },
+            );
+
+            expect(comparisons).to.deep.include.members([
+                // Uniswap sample found
+                {
+                    name: ERC20BridgeSource.Uniswap,
+                    price,
+                    gas: new BigNumber(90e3),
+                },
+            ]);
+        });
+
+        it('should match price decimal places to taker asset for buy quotes', () => {
+            const usdcAmount = new BigNumber(100e6);
+            const wethAmount = new BigNumber(7 / 3).times(1e18).decimalPlaces(0, BigNumber.ROUND_FLOOR);
+
+            const price = usdcAmount
+                .div(wethAmount)
+                .times(1e12)
+                .decimalPlaces(6);
+
+            const comparisons = priceComparisonUtils.getPriceComparisonFromQuote(
+                ChainId.Mainnet,
+                { buyAmount: wethAmount },
+                {
+                    buyTokenAddress: WETH.tokenAddress,
+                    sellTokenAddress: USDC.tokenAddress,
+                    buyAmount: wethAmount,
+                    sellAmount: usdcAmount,
+                    quoteReport: {
+                        sourcesConsidered: [
+                            {
+                                makerAmount: wethAmount,
                                 takerAmount: usdcAmount,
                                 liquiditySource: ERC20BridgeSource.Uniswap,
                                 fillData: {},

--- a/test/price_comparison_utils_test.ts
+++ b/test/price_comparison_utils_test.ts
@@ -197,7 +197,7 @@ describe(SUITE_NAME, () => {
 
         it('returns the Kyber results with highest makerAmount when quoting sellAmount', () => {
             const higherBuyAmount = buyAmount.plus(1e18);
-            const higherPrice = higherBuyAmount.div(sellAmount).decimalPlaces(18);
+            const higherPrice = higherBuyAmount.div(sellAmount).decimalPlaces(18, BigNumber.ROUND_FLOOR);
 
             const comparisons = priceComparisonUtils.getPriceComparisonFromQuote(
                 ChainId.Mainnet,


### PR DESCRIPTION
Price decimals should match maker asset for sell quotes and
taker asset for buy quotes

<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

<!--- Describe your changes in detail -->

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [x] SRA/Limit orders
    -   [x] Swap endpoints
    -   [x] Meta transaction endpoints
    -   [x] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
