### PR TITLE
fix: fetch persistent orders

### DIFF
--- a/src/handlers/sra_handlers.ts
+++ b/src/handlers/sra_handlers.ts
@@ -64,8 +64,9 @@ export class SRAHandlers {
     }
     public async ordersAsync(req: express.Request, res: express.Response): Promise<void> {
         schemaUtils.validateSchema(req.query, apiSchemas.sraGetOrdersRequestSchema);
+        const isUnfillable = req.query.unfillable ? req.query.unfillable === 'true' : false;
         const { page, perPage } = paginationUtils.parsePaginationConfig(req);
-        const paginatedOrders = await this._orderBook.getOrdersAsync(page, perPage, req.query);
+        const paginatedOrders = await this._orderBook.getOrdersAsync(page, perPage, { ...req.query, isUnfillable });
         res.status(HttpStatus.OK).send(paginatedOrders);
     }
     public async orderbookAsync(req: express.Request, res: express.Response): Promise<void> {

--- a/src/services/orderbook_service.ts
+++ b/src/services/orderbook_service.ts
@@ -135,7 +135,7 @@ export class OrderBookService {
 
         // Join with persistent orders
         let persistentOrders: APIOrderWithMetaData[] = [];
-        if (ordersFilterParams.unfillable === true) {
+        if (ordersFilterParams.isUnfillable === true) {
             if (filterObject.makerAddress === undefined) {
                 throw new ValidationError([
                     {

--- a/src/types.ts
+++ b/src/types.ts
@@ -681,6 +681,6 @@ export interface SRAGetOrdersRequestOpts {
     takerAddress?: string;
     traderAddress?: string;
     feeRecipientAddress?: string;
-    unfillable?: boolean; // default false
+    isUnfillable?: boolean; // default false
 }
 // tslint:disable-line:max-file-line-count

--- a/test/orderbook_service_test.ts
+++ b/test/orderbook_service_test.ts
@@ -171,7 +171,7 @@ describe(SUITE_NAME, () => {
             apiOrder.metaData.state = OrderEventEndState.Cancelled; // only unfillable orders are removed from SignedOrders but remain in PersistentOrders
             await savePersistentOrderAsync(apiOrder);
             const response = await orderBookService.getOrdersAsync(DEFAULT_PAGE, DEFAULT_PER_PAGE, {
-                unfillable: true,
+                isUnfillable: true,
                 makerAddress: apiOrder.order.makerAddress,
             });
             expect(response).to.deep.eq({


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

This PR converts the query param from string to boolean and allows to fetch persistent orders properly.

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
