### PR TITLE
fix: add createdAt to SignedOrders table

### DIFF
--- a/src/entities/PersistentSignedOrderEntity.ts
+++ b/src/entities/PersistentSignedOrderEntity.ts
@@ -92,7 +92,6 @@ export class PersistentSignedOrderEntity extends SignedOrderEntity {
             signature?: string;
             remainingFillableTakerAssetAmount?: string;
             orderState?: OrderEventEndState;
-            createdAt?: string;
         } = {},
     ) {
         super(opts);

--- a/src/entities/SignedOrderEntity.ts
+++ b/src/entities/SignedOrderEntity.ts
@@ -55,6 +55,9 @@ export class SignedOrderEntity {
 
     @Column({ name: 'taker_fee_asset_data', type: 'varchar' })
     public takerFeeAssetData?: string;
+
+    @Column({ name: 'created_at', type: 'timestamptz', default: 'now()' })
+    public createdAt?: string;
     constructor(
         opts: {
             hash?: string;

--- a/test/orderbook_service_test.ts
+++ b/test/orderbook_service_test.ts
@@ -143,9 +143,8 @@ describe(SUITE_NAME, () => {
             await saveSignedOrderAsync(apiOrder);
 
             const response = await orderBookService.getOrdersAsync(DEFAULT_PAGE, DEFAULT_PER_PAGE, {});
-            // state and createdAt is not saved in SignedOrders table, only saved in PersistentOrders
-            apiOrder.metaData.state = undefined;
-            apiOrder.metaData.createdAt = undefined;
+            apiOrder.metaData.state = undefined; // state is not saved in SignedOrders table
+            apiOrder.metaData.createdAt = response.records[0].metaData.createdAt; // createdAt is saved in the SignedOrders table directly
             expect(response).to.deep.eq({
                 ...EMPTY_PAGINATED_RESPONSE,
                 total: 1,
@@ -158,9 +157,8 @@ describe(SUITE_NAME, () => {
             await saveSignedOrderAsync(apiOrder);
             await savePersistentOrderAsync(apiOrder);
             const response = await orderBookService.getOrdersAsync(DEFAULT_PAGE, DEFAULT_PER_PAGE, {});
-            // state and createdAt is not saved in SignedOrders table, only saved in PersistentOrders
-            apiOrder.metaData.state = undefined;
-            apiOrder.metaData.createdAt = undefined;
+            apiOrder.metaData.state = undefined; // state is not saved in SignedOrders table
+            apiOrder.metaData.createdAt = response.records[0].metaData.createdAt; // createdAt is saved in the SignedOrders table directly
             expect(response).to.deep.eq({
                 ...EMPTY_PAGINATED_RESPONSE,
                 total: 1,

--- a/test/sra_test.ts
+++ b/test/sra_test.ts
@@ -129,6 +129,7 @@ describe(SUITE_NAME, () => {
         it('should return orders in the local cache', async () => {
             const apiOrder = await addNewSignedOrderAsync(orderFactory, {});
             const response = await httpGetAsync({ route: `${SRA_PATH}/orders` });
+            apiOrder.metaData.createdAt = response.body.records[0].metaData.createdAt; // createdAt is saved in the SignedOrders table directly
 
             expect(response.type).to.eq(`application/json`);
             expect(response.status).to.eq(HttpStatus.OK);
@@ -145,6 +146,7 @@ describe(SUITE_NAME, () => {
             const response = await httpGetAsync({
                 route: `${SRA_PATH}/orders?makerAddress=${apiOrder.order.makerAddress}`,
             });
+            apiOrder.metaData.createdAt = response.body.records[0].metaData.createdAt; // createdAt is saved in the SignedOrders table directly
 
             expect(response.type).to.eq(`application/json`);
             expect(response.status).to.eq(HttpStatus.OK);
@@ -171,6 +173,7 @@ describe(SUITE_NAME, () => {
             const response = await httpGetAsync({
                 route: `${SRA_PATH}/orders?makerAddress=${apiOrder.order.makerAddress.toUpperCase()}`,
             });
+            apiOrder.metaData.createdAt = response.body.records[0].metaData.createdAt; // createdAt is saved in the SignedOrders table directly
 
             expect(response.type).to.eq(`application/json`);
             expect(response.status).to.eq(HttpStatus.OK);
@@ -187,6 +190,7 @@ describe(SUITE_NAME, () => {
         it('should return order by order hash', async () => {
             const apiOrder = await addNewSignedOrderAsync(orderFactory, {});
             const response = await httpGetAsync({ route: `${SRA_PATH}/order/${apiOrder.metaData.orderHash}` });
+            apiOrder.metaData.createdAt = response.body.metaData.createdAt; // createdAt is saved in the SignedOrders table directly
 
             expect(response.type).to.eq(`application/json`);
             expect(response.status).to.eq(HttpStatus.OK);
@@ -226,6 +230,7 @@ describe(SUITE_NAME, () => {
                     },
                 }),
             });
+            apiOrder.metaData.createdAt = response.body.asks.records[0].metaData.createdAt; // createdAt is saved in the SignedOrders table directly
 
             expect(response.type).to.eq(`application/json`);
             expect(response.status).to.eq(HttpStatus.OK);


### PR DESCRIPTION
- adding `createdAt` to SignedOrders table. 
- previously added `createdAt` to PersistentSignedOrders table (https://github.com/0xProject/0x-api/pull/443) but since we only return PersistentSignedOrders entities for expired/inactive orders, I had to add `createdAt` to the SignedOrders table for active orders. 

# Description

<!--- Describe your changes in detail -->

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
