### PR TITLE
[WIP] feat: opt-in positive slippage fee for integrators

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -149,6 +149,8 @@ export enum ValidationErrorReasons {
     TakerAddressInvalid = 'TAKER_ADDRESS_INVALID',
     RequiresIntentOnFilling = 'REQUIRES_INTENT_ON_FILLING',
     UnfillableRequiresMakerAddress = 'MAKER_ADDRESS_REQUIRED_TO_FETCH_UNFILLABLE_ORDERS',
+    MultipleFeeTypesUsed = 'MULTIPLE_FEE_TYPES_USED',
+    FeeRecipientMissing = 'FEE_RECIPIENT_MISSING',
 }
 export abstract class AlertError {
     public abstract message: string;

--- a/src/handlers/meta_transaction_handlers.ts
+++ b/src/handlers/meta_transaction_handlers.ts
@@ -1,5 +1,5 @@
 import { assert } from '@0x/assert';
-import { ERC20BridgeSource, SwapQuoterError } from '@0x/asset-swapper';
+import { AffiliateFeeType, ERC20BridgeSource, SwapQuoterError } from '@0x/asset-swapper';
 import { MarketOperation } from '@0x/types';
 import { BigNumber, NULL_ADDRESS } from '@0x/utils';
 import * as express from 'express';
@@ -26,7 +26,6 @@ import { isAPIError, isRevertError } from '../middleware/error_handling';
 import { schemas } from '../schemas/schemas';
 import { MetaTransactionService } from '../services/meta_transaction_service';
 import {
-    AffiliateFeeType,
     ChainId,
     ExchangeProxyMetaTransactionWithoutDomain,
     GetMetaTransactionPriceResponse,

--- a/src/handlers/meta_transaction_handlers.ts
+++ b/src/handlers/meta_transaction_handlers.ts
@@ -26,6 +26,7 @@ import { isAPIError, isRevertError } from '../middleware/error_handling';
 import { schemas } from '../schemas/schemas';
 import { MetaTransactionService } from '../services/meta_transaction_service';
 import {
+    AffiliateFeeType,
     ChainId,
     ExchangeProxyMetaTransactionWithoutDomain,
     GetMetaTransactionPriceResponse,
@@ -403,11 +404,13 @@ const parseGetTransactionRequestParams = (req: express.Request): GetTransactionR
     }
     const affiliateFee = feeRecipient
         ? {
+              feeType: AffiliateFeeType.PercentageFee,
               recipient: feeRecipient,
               sellTokenPercentageFee,
               buyTokenPercentageFee,
           }
         : {
+              feeType: AffiliateFeeType.None,
               recipient: NULL_ADDRESS,
               sellTokenPercentageFee: 0,
               buyTokenPercentageFee: 0,

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -1,5 +1,5 @@
 // tslint:disable:max-file-line-count
-import { RfqtRequestOpts, SwapQuoterError } from '@0x/asset-swapper';
+import { AffiliateFeeType, RfqtRequestOpts, SwapQuoterError } from '@0x/asset-swapper';
 import { MarketOperation } from '@0x/types';
 import { BigNumber, NULL_ADDRESS } from '@0x/utils';
 import * as express from 'express';
@@ -27,7 +27,6 @@ import { schemas } from '../schemas/schemas';
 import { SwapService } from '../services/swap_service';
 import { TokenMetadatasForChains } from '../token_metadatas_for_networks';
 import {
-    AffiliateFeeType,
     CalculateSwapQuoteParams,
     GetSwapPriceResponse,
     GetSwapQuoteRequestParams,

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -1,5 +1,6 @@
 import {
     AffiliateFeeAmount,
+    AffiliateFeeType,
     AssetSwapperContractAddresses,
     ERC20BridgeSource,
     ExtensionContractType,
@@ -49,7 +50,6 @@ import { logger } from '../logger';
 import { TokenMetadatasForChains } from '../token_metadatas_for_networks';
 import {
     AffiliateFee,
-    AffiliateFeeType,
     BucketedPriceDepth,
     CalaculateMarketDepthParams,
     CalculateSwapQuoteParams,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import {
+    AffiliateFeeType,
     ContractAddresses,
     ERC20BridgeSource,
     QuoteReport,
@@ -422,12 +423,6 @@ export interface SourceComparison {
     price: BigNumber | null;
     gas: BigNumber | null;
     savingsInEth?: BigNumber;
-}
-
-export enum AffiliateFeeType {
-    None,
-    PercentageFee,
-    PositiveSlippageFee,
 }
 
 export interface AffiliateFee {

--- a/src/types.ts
+++ b/src/types.ts
@@ -424,7 +424,14 @@ export interface SourceComparison {
     savingsInEth?: BigNumber;
 }
 
-export interface PercentageFee {
+export enum AffiliateFeeType {
+    None,
+    PercentageFee,
+    PositiveSlippageFee,
+}
+
+export interface AffiliateFee {
+    feeType: AffiliateFeeType;
     recipient: string;
     sellTokenPercentageFee: number;
     buyTokenPercentageFee: number;
@@ -437,7 +444,7 @@ interface SwapQuoteParamsBase {
     excludedSources: ERC20BridgeSource[];
     includedSources?: ERC20BridgeSource[];
     affiliateAddress?: string;
-    affiliateFee: PercentageFee;
+    affiliateFee: AffiliateFee;
     includePriceComparisons?: boolean;
 }
 

--- a/test/service_utils_test.ts
+++ b/test/service_utils_test.ts
@@ -5,6 +5,8 @@ import { BigNumber } from '@0x/utils';
 import 'mocha';
 
 import { AFFILIATE_FEE_TRANSFORMER_GAS, ZERO } from '../src/constants';
+import { POSITIVE_SLIPPAGE_FEE_TRANSFORMER_GAS } from '@0x/asset-swapper/lib/src/constants';
+import { AffiliateFeeType } from '../src/types';
 import { serviceUtils } from '../src/utils/service_utils';
 
 import { AFFILIATE_DATA_SELECTOR } from './constants';
@@ -76,6 +78,7 @@ describe(SUITE_NAME, () => {
     describe('getAffiliateFeeAmounts', () => {
         it('returns the correct amounts if the fee is zero', () => {
             const affiliateFee = {
+                feeType: AffiliateFeeType.PercentageFee,
                 recipient: '',
                 buyTokenPercentageFee: 0,
                 sellTokenPercentageFee: 0,
@@ -89,6 +92,7 @@ describe(SUITE_NAME, () => {
         });
         it('returns the correct amounts if the fee is non-zero', () => {
             const affiliateFee = {
+                feeType: AffiliateFeeType.PercentageFee,
                 recipient: '',
                 buyTokenPercentageFee: 0.01,
                 sellTokenPercentageFee: 0,
@@ -101,6 +105,20 @@ describe(SUITE_NAME, () => {
                     .integerValue(BigNumber.ROUND_DOWN),
                 sellTokenFeeAmount: ZERO,
                 gasCost: AFFILIATE_FEE_TRANSFORMER_GAS,
+            });
+        });
+        it('returns the correct amounts if the positive slippage fee is non-zero', () => {
+            const affiliateFee = {
+                feeType: AffiliateFeeType.PositiveSlippageFee,
+                recipient: '',
+                buyTokenPercentageFee: 0,
+                sellTokenPercentageFee: 0,
+            };
+            const costInfo = serviceUtils.getAffiliateFeeAmounts(randomSellQuote, affiliateFee);
+            expect(costInfo).to.deep.equal({
+                buyTokenFeeAmount: ZERO,
+                sellTokenFeeAmount: ZERO,
+                gasCost: POSITIVE_SLIPPAGE_FEE_TRANSFORMER_GAS,
             });
         });
     });

--- a/test/service_utils_test.ts
+++ b/test/service_utils_test.ts
@@ -1,12 +1,11 @@
-import { ERC20BridgeSource, getSwapMinBuyAmount } from '@0x/asset-swapper';
+import { AffiliateFeeType, ERC20BridgeSource, getSwapMinBuyAmount } from '@0x/asset-swapper';
+import { POSITIVE_SLIPPAGE_FEE_TRANSFORMER_GAS } from '@0x/asset-swapper/lib/src/constants';
 import { expect } from '@0x/contracts-test-utils';
 import { BigNumber } from '@0x/utils';
 // tslint:disable-next-line:no-implicit-dependencies
 import 'mocha';
 
 import { AFFILIATE_FEE_TRANSFORMER_GAS, ZERO } from '../src/constants';
-import { POSITIVE_SLIPPAGE_FEE_TRANSFORMER_GAS } from '@0x/asset-swapper/lib/src/constants';
-import { AffiliateFeeType } from '../src/types';
 import { serviceUtils } from '../src/utils/service_utils';
 
 import { AFFILIATE_DATA_SELECTOR } from './constants';

--- a/test/swap_test.ts
+++ b/test/swap_test.ts
@@ -393,6 +393,29 @@ describe(SUITE_NAME, () => {
                     },
                 );
             });
+            it('validation error if both percentage and positive slippage fee enabled', async () => {
+                await quoteAndExpectAsync(
+                    {
+                        ...sellQuoteParams,
+                        feeType: 'positive-slippage',
+                        buyTokenPercentageFee: '0.9',
+                    },
+                    {
+                        validationErrors: [
+                            {
+                                code: ValidationErrorCodes.UnsupportedOption,
+                                field: 'buyTokenPercentageFee',
+                                reason: ValidationErrorReasons.MultipleFeeTypesUsed,
+                            },
+                            {
+                                code: ValidationErrorCodes.UnsupportedOption,
+                                field: 'feeType',
+                                reason: ValidationErrorReasons.MultipleFeeTypesUsed,
+                            },
+                        ],
+                    },
+                );
+            });
         });
 
         describe('affiliate address', () => {

--- a/test/utils/mocks.ts
+++ b/test/utils/mocks.ts
@@ -161,6 +161,6 @@ export const randomSellQuote: SwapQuote = {
     isTwoHop: false,
     makerTokenDecimals: 18,
     takerTokenDecimals: 18,
-    takerAssetToEthRate: new BigNumber(0),
-    makerAssetToEthRate: new BigNumber(0),
+    takerAssetPriceForOneEth: new BigNumber(0),
+    makerAssetPriceForOneEth: new BigNumber(0),
 };

--- a/test/utils/mocks.ts
+++ b/test/utils/mocks.ts
@@ -161,6 +161,6 @@ export const randomSellQuote: SwapQuote = {
     isTwoHop: false,
     makerTokenDecimals: 18,
     takerTokenDecimals: 18,
-    takerAssetPriceForOneEth: new BigNumber(0),
-    makerAssetPriceForOneEth: new BigNumber(0),
+    takerAssetsPerEth: new BigNumber(0),
+    makerAssetsPerEth: new BigNumber(0),
 };


### PR DESCRIPTION
# Description

- Integrators now have the option to send the extra positive slippage funds (if any) of a trade to a `feeRecipientAddress` address. 
- Adding `feeType` param to the `/quote` endpoint. With `feeType='slippage'`, the extra positive slippage funds will be sent to `feeRecipient`. If `feeType` is undefined, the fee percentage `buyTokenPercentageFee` strategy will be used.  
- protocol changes: https://github.com/0xProject/protocol/pull/101


# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [x] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
