### PR TITLE
chore: Move pagination to db for heavier queries

### DIFF
--- a/src/schemas/sra_get_orders_request_schema.json
+++ b/src/schemas/sra_get_orders_request_schema.json
@@ -21,10 +21,30 @@
             "$ref": "/addressSchema"
         },
         "makerAssetData": {
-            "$ref": "/hexSchema"
+            "oneOf": [
+                {
+                    "$ref": "/hexSchema"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "/hexSchema"
+                    }
+                }
+            ]
         },
         "takerAssetData": {
-            "$ref": "/hexSchema"
+            "oneOf": [
+                {
+                    "$ref": "/hexSchema"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "/hexSchema"
+                    }
+                }
+            ]
         },
         "traderAssetData": {
             "$ref": "/hexSchema"

--- a/src/types.ts
+++ b/src/types.ts
@@ -649,8 +649,8 @@ export interface SRAGetOrdersRequestOpts {
     takerAssetAddress?: string;
     exchangeAddress?: string;
     senderAddress?: string;
-    makerAssetData?: string;
-    takerAssetData?: string;
+    makerAssetData?: string | string[];
+    takerAssetData?: string | string[];
     makerFeeAssetData?: string;
     takerFeeAssetData?: string;
     makerAddress?: string;

--- a/src/utils/order_utils.ts
+++ b/src/utils/order_utils.ts
@@ -15,7 +15,7 @@ import {
     StaticCallAssetData,
 } from '@0x/types';
 import { BigNumber, errorUtils } from '@0x/utils';
-import { Connection } from 'typeorm';
+import { Connection, In, Like } from 'typeorm';
 
 import {
     CHAIN_ID,
@@ -290,6 +290,18 @@ export const orderUtils = {
             takerFeeAssetData: TAKER_FEE_ASSET_DATA,
         };
         return orderConfigResponse;
+    },
+    assetDataOrAssetProxyId: (assetData: string | string[] | undefined, assetProxyId: string | undefined) => {
+        if (!assetData && !assetProxyId) {
+            return undefined;
+        }
+        if (assetProxyId) {
+            return Like(`${assetProxyId}%`);
+        }
+        if (Array.isArray(assetData)) {
+            return In(assetData);
+        }
+        return assetData;
     },
     filterOrders: (apiOrders: APIOrderWithMetaData[], filters: SRAGetOrdersRequestOpts): APIOrderWithMetaData[] => {
         const { traderAddress, makerAssetAddress, takerAssetAddress, makerAssetProxyId, takerAssetProxyId } = filters;

--- a/src/utils/pagination_utils.ts
+++ b/src/utils/pagination_utils.ts
@@ -5,14 +5,34 @@ import { DEFAULT_PAGE, DEFAULT_PER_PAGE } from '../constants';
 import { ValidationError, ValidationErrorCodes } from '../errors';
 
 export const paginationUtils = {
-    paginate: <T>(collection: T[], page: number, perPage: number) => {
-        const paginatedCollection = {
-            total: collection.length,
+    /**
+     *  Paginates locally in memory from a larger collection
+     * @param records The records to paginate
+     * @param page The current page for these records
+     * @param perPage The total number of records to return per page
+     */
+    paginate: <T>(records: T[], page: number, perPage: number) => {
+        return paginationUtils.paginateSerialize(
+            records.slice((page - 1) * perPage, page * perPage),
+            records.length,
             page,
             perPage,
-            records: collection.slice((page - 1) * perPage, page * perPage),
+        );
+    },
+    paginateDBFilters: (page: number, perPage: number) => {
+        return {
+            skip: (page - 1) * perPage,
+            take: perPage,
         };
-        return paginatedCollection;
+    },
+    paginateSerialize: <T>(collection: T[], total: number, page: number, perPage: number) => {
+        const paginated = {
+            total,
+            page,
+            perPage,
+            records: collection,
+        };
+        return paginated;
     },
     parsePaginationConfig: (req: express.Request): { page: number; perPage: number } => {
         const page = req.query.page === undefined ? DEFAULT_PAGE : Number(req.query.page);

--- a/src/utils/parse_utils.ts
+++ b/src/utils/parse_utils.ts
@@ -182,4 +182,11 @@ export const parseUtils = {
 
         return parsedConfig;
     },
+    parseAssetDatasStringFromQueryParam(field: string): string | string[] {
+        if (field.indexOf(',') !== -1) {
+            const fields = field.split(',');
+            return fields;
+        }
+        return field;
+    },
 };

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,7 @@
 {
     "extends": ["@0x/tslint-config"],
     "rules": {
-        "custom-no-magic-numbers": [true, 0, 1, 2, 10],
+        "custom-no-magic-numbers": [true, -1, 0, 1, 2, 10],
         "no-unnecessary-type-assertion": false
     },
     "linterOptions": {


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

<!--- Describe your changes in detail -->
Limits by `perPage` and offsets by by `page * perPage` in the db rather then in memory. It does mean that some of the other filters are less accurate (`traderAddress, makerAssetAddress, takerAssetAddress, makerAssetProxyId, takerAssetProxyId`) but I believe these are rarely used.



### Performance

**no filters**
```
hey -c 1 -n 30 'https://staging.api.0x.org/sra/v3/orders'           feat/fetch-token-and-duration*

Summary:
  Total:	4.8126 secs
  Slowest:	0.6201 secs
  Fastest:	0.1234 secs
  Average:	0.1604 secs
  Requests/sec:	6.2337

  Total data:	603494 bytes
  Size/request:	20116 bytes

Response time histogram:
  0.123 [1]	|■■
  0.173 [26]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.223 [1]	|■■
  0.272 [0]	|
  0.322 [0]	|
  0.372 [0]	|
  0.421 [1]	|■■
  0.471 [0]	|
  0.521 [0]	|
  0.570 [0]	|
  0.620 [1]	|■■
```

```
hey -c 1 -n 30 'https://api.0x.org/sra/v3/orders'

Summary:
  Total:	14.1454 secs
  Slowest:	0.9751 secs
  Fastest:	0.2270 secs
  Average:	0.4715 secs
  Requests/sec:	2.1208

  Total data:	747240 bytes
  Size/request:	24908 bytes

Response time histogram:
  0.227 [1]	|■■■■
  0.302 [9]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.377 [6]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.451 [1]	|■■■■
  0.526 [3]	|■■■■■■■■■■■■■
  0.601 [2]	|■■■■■■■■■
  0.676 [1]	|■■■■
  0.751 [1]	|■■■■
  0.825 [2]	|■■■■■■■■■
  0.900 [2]	|■■■■■■■■■
  0.975 [2]	|■■■■■■■■■
```

**assetProxyId** 

```
λ hey -c 1 -n 30 'https://staging.api.0x.org/sra/v3/orders?makerAssetProxyId=0xf47261b0'

Summary:
  Total:	5.1222 secs
  Slowest:	0.7707 secs
  Fastest:	0.1279 secs
  Average:	0.1707 secs
  Requests/sec:	5.8569

  Total data:	644040 bytes
  Size/request:	21468 bytes

Response time histogram:
  0.128 [1]	|■
  0.192 [27]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.256 [0]	|
  0.321 [0]	|
  0.385 [0]	|
  0.449 [1]	|■
  0.514 [0]	|
  0.578 [0]	|
  0.642 [0]	|
  0.706 [0]	|
  0.771 [1]	|■
```

```
hey -c 1 -n 30 'https://api.0x.org/sra/v3/orders?makerAssetProxyId=0xf47261b0'

Summary:
  Total:	23.7403 secs
  Slowest:	2.5660 secs
  Fastest:	0.3235 secs
  Average:	0.7913 secs
  Requests/sec:	1.2637

  Total data:	675895 bytes
  Size/request:	22529 bytes

Response time histogram:
  0.324 [1]	|■■■■
  0.548 [8]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.772 [10]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.996 [6]	|■■■■■■■■■■■■■■■■■■■■■■■■
  1.221 [1]	|■■■■
  1.445 [1]	|■■■■
  1.669 [0]	|
  1.893 [1]	|■■■■
  2.118 [1]	|■■■■
  2.342 [0]	|
  2.566 [1]	|■■■■
```
# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
