### PR TITLE
chore: Remap SRA v3 endpoints + Cache control header + Log RPC provider errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,6 @@
         "express": "^4.17.1",
         "express-async-handler": "^1.1.4",
         "http-status-codes": "^1.3.2",
-        "json-rpc-error": "^2.0.0",
         "jsonschema": "^1.2.5",
         "lodash": "^4.17.15",
         "pg": "^7.12.1",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,7 +46,7 @@ export const AFFILIATE_FEE_TRANSFORMER_GAS = new BigNumber(15000);
 export const ONE_GWEI = new BigNumber(1000000000);
 
 // API namespaces
-export const SRA_PATH = '/sra/v3';
+export const SRA_PATH = '/sra';
 export const STAKING_PATH = '/staking';
 export const SWAP_PATH = '/swap/v1';
 export const META_TRANSACTION_PATH = '/meta_transaction/v1';

--- a/src/middleware/cache_control.ts
+++ b/src/middleware/cache_control.ts
@@ -1,0 +1,15 @@
+import * as express from 'express';
+// tslint:disable-next-line:no-implicit-dependencies
+import * as core from 'express-serve-static-core';
+
+const DEFAULT_CACHE_AGE_SECONDS = 10;
+
+/**
+ *  Sets the Cache related headers in a response
+ */
+export function cacheControl(req: express.Request, res: express.Response, next: core.NextFunction): void {
+    if (req.method === 'GET') {
+        res.set('Cache-control', `public, max-age=${DEFAULT_CACHE_AGE_SECONDS}, s-maxage=${DEFAULT_CACHE_AGE_SECONDS}`);
+    }
+    next();
+}

--- a/src/routers/sra_router.ts
+++ b/src/routers/sra_router.ts
@@ -10,51 +10,62 @@ export function createSRARouter(orderBook: OrderBookService): express.Router {
     const handlers = new SRAHandlers(orderBook);
     // Link to docs in the root.
     router.get('/', asyncHandler(SRAHandlers.rootAsync.bind(SRAHandlers)));
+    router.get('/v3', asyncHandler(SRAHandlers.rootAsync.bind(SRAHandlers)));
     /**
      * GET AssetPairs endpoint retrieves a list of available asset pairs and the information required to trade them.
      * http://sra3-spec.s3-website-us-east-1.amazonaws.com/#operation/getAssetPairs
      */
     router.get('/asset_pairs', asyncHandler(handlers.assetPairsAsync.bind(handlers)));
+    router.get('/v3/asset_pairs', asyncHandler(handlers.assetPairsAsync.bind(handlers)));
     /**
      * GET Orders endpoint retrieves a list of orders given query parameters.
      * http://sra3-spec.s3-website-us-east-1.amazonaws.com/#operation/getOrders
      */
     router.get('/orders', asyncHandler(handlers.ordersAsync.bind(handlers)));
+    router.get('/v3/orders', asyncHandler(handlers.ordersAsync.bind(handlers)));
     /**
      * GET Orderbook endpoint retrieves the orderbook for a given asset pair.
      * http://sra3-spec.s3-website-us-east-1.amazonaws.com/#operation/getOrderbook
      */
     router.get('/orderbook', asyncHandler(handlers.orderbookAsync.bind(handlers)));
+    router.get('/v3/orderbook', asyncHandler(handlers.orderbookAsync.bind(handlers)));
     /**
      * GET FeeRecepients endpoint retrieves a collection of all fee recipient addresses for a relayer.
      * http://sra3-spec.s3-website-us-east-1.amazonaws.com/v3/fee_recipients
      */
     router.get('/fee_recipients', SRAHandlers.feeRecipients.bind(SRAHandlers));
+    router.get('/v3/fee_recipients', SRAHandlers.feeRecipients.bind(SRAHandlers));
     /**
      * POST Order config endpoint retrives the values for order fields that the relayer requires.
      * http://sra3-spec.s3-website-us-east-1.amazonaws.com/#operation/getOrderConfig
      */
     router.post('/order_config', SRAHandlers.orderConfig.bind(SRAHandlers));
+    router.post('/v3/order_config', SRAHandlers.orderConfig.bind(SRAHandlers));
     /**
      * POST Order endpoint submits an order to the Relayer.
      * http://sra3-spec.s3-website-us-east-1.amazonaws.com/#operation/postOrder
      */
     router.post('/order', asyncHandler(handlers.postOrderAsync.bind(handlers)));
+    router.post('/v3/order', asyncHandler(handlers.postOrderAsync.bind(handlers)));
     /**
      * POST Orders endpoint submits several orders to the Relayer.
      * This is an additional endpoint not a part of the official SRA standard
      */
     router.post('/orders', asyncHandler(handlers.postOrdersAsync.bind(handlers)));
+    router.post('/v3/orders', asyncHandler(handlers.postOrdersAsync.bind(handlers)));
     /**
      * POST Persistent order endpoint submits an order that will be persisted even after cancellation or expiration.
      * Requires an API Key
      * This is an additional endpoint not a part of the official SRA standard
      */
     router.post('/order/persistent', asyncHandler(handlers.postPersistentOrderAsync.bind(handlers)));
+    router.post('/v3/order/persistent', asyncHandler(handlers.postPersistentOrderAsync.bind(handlers)));
     /**
      * GET Order endpoint retrieves the order by order hash.
      * http://sra3-spec.s3-website-us-east-1.amazonaws.com/#operation/getOrder
      */
     router.get('/order/:orderHash', asyncHandler(handlers.getOrderByHashAsync.bind(handlers)));
+    router.get('/v3/order/:orderHash', asyncHandler(handlers.getOrderByHashAsync.bind(handlers)));
+
     return router;
 }

--- a/src/runners/http_service_runner.ts
+++ b/src/runners/http_service_runner.ts
@@ -9,6 +9,7 @@ import { META_TRANSACTION_PATH, METRICS_PATH, SRA_PATH, STAKING_PATH, SWAP_PATH 
 import { rootHandler } from '../handlers/root_handler';
 import { logger } from '../logger';
 import { addressNormalizer } from '../middleware/address_normalizer';
+import { cacheControl } from '../middleware/cache_control';
 import { errorHandler } from '../middleware/error_handling';
 import { createMetaTransactionRouter } from '../routers/meta_transaction_router';
 import { createMetricsRouter } from '../routers/metrics_router';
@@ -71,6 +72,7 @@ export async function runHttpServiceAsync(
 
     // transform all values of `req.query.[xx]Address` to lowercase
     app.use(addressNormalizer);
+    app.use(cacheControl);
 
     // staking http service
     app.use(STAKING_PATH, createStakingRouter(dependencies.stakingDataService));

--- a/src/runners/http_sra_service_runner.ts
+++ b/src/runners/http_sra_service_runner.ts
@@ -12,6 +12,7 @@ import { SRA_PATH } from '../constants';
 import { rootHandler } from '../handlers/root_handler';
 import { logger } from '../logger';
 import { addressNormalizer } from '../middleware/address_normalizer';
+import { cacheControl } from '../middleware/cache_control';
 import { errorHandler } from '../middleware/error_handling';
 import { createSRARouter } from '../routers/sra_router';
 import { WebsocketService } from '../services/websocket_service';
@@ -46,6 +47,7 @@ async function runHttpServiceAsync(
 ): Promise<Server> {
     const app = _app || express();
     app.use(addressNormalizer);
+    app.use(cacheControl);
     const server = createDefaultServer(dependencies, config, app);
 
     app.get('/', rootHandler);

--- a/src/runners/http_staking_service_runner.ts
+++ b/src/runners/http_staking_service_runner.ts
@@ -12,6 +12,7 @@ import { STAKING_PATH } from '../constants';
 import { rootHandler } from '../handlers/root_handler';
 import { logger } from '../logger';
 import { addressNormalizer } from '../middleware/address_normalizer';
+import { cacheControl } from '../middleware/cache_control';
 import { errorHandler } from '../middleware/error_handling';
 import { createStakingRouter } from '../routers/staking_router';
 import { HttpServiceConfig } from '../types';
@@ -45,6 +46,7 @@ async function runHttpServiceAsync(
 ): Promise<Server> {
     const app = _app || express();
     app.use(addressNormalizer);
+    app.use(cacheControl);
     const server = createDefaultServer(dependencies, config, app);
 
     app.get('/', rootHandler);

--- a/src/runners/http_swap_service_runner.ts
+++ b/src/runners/http_swap_service_runner.ts
@@ -13,6 +13,7 @@ import { SWAP_PATH } from '../constants';
 import { rootHandler } from '../handlers/root_handler';
 import { logger } from '../logger';
 import { addressNormalizer } from '../middleware/address_normalizer';
+import { cacheControl } from '../middleware/cache_control';
 import { errorHandler } from '../middleware/error_handling';
 import { createSwapRouter } from '../routers/swap_router';
 import { HttpServiceConfig } from '../types';
@@ -46,6 +47,7 @@ async function runHttpServiceAsync(
 ): Promise<Server> {
     const app = _app || express();
     app.use(addressNormalizer);
+    app.use(cacheControl);
     const server = createDefaultServer(dependencies, config, app);
 
     app.get('/', rootHandler);

--- a/src/token_metadatas_for_networks.ts
+++ b/src/token_metadatas_for_networks.ts
@@ -501,16 +501,6 @@ export const TokenMetadatasForChains: TokenMetadataAndChainAddresses[] = [
     },
     {
         decimals: 18,
-        symbol: 'ICX',
-        name: 'ICON',
-        tokenAddresses: {
-            [ChainId.Mainnet]: '0xb5a5f22694352c15b00323844ad545abb2b11028',
-            [ChainId.Kovan]: NULL_ADDRESS,
-            [ChainId.Ganache]: NULL_ADDRESS,
-        },
-    },
-    {
-        decimals: 18,
         symbol: 'NMR',
         name: 'Numeraire',
         tokenAddresses: {

--- a/src/token_metadatas_for_networks.ts
+++ b/src/token_metadatas_for_networks.ts
@@ -1079,4 +1079,14 @@ export const TokenMetadatasForChains: TokenMetadataAndChainAddresses[] = [
             [ChainId.Ganache]: NULL_ADDRESS,
         },
     },
+    {
+        symbol: 'AAVE',
+        name: 'AAVE',
+        decimals: 18,
+        tokenAddresses: {
+            [ChainId.Mainnet]: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
+            [ChainId.Kovan]: NULL_ADDRESS,
+            [ChainId.Ganache]: NULL_ADDRESS,
+        },
+    },
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,7 +48,6 @@
 "@0x/asset-swapper@^5.6.2":
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/@0x/asset-swapper/-/asset-swapper-5.6.2.tgz#946cbc7f6db328f61d54d73e871e9774fe475e32"
-  integrity sha512-9ecxrFxX13IKwJiTaZxxfoia1IldAYEyJ9wfXRjvKGIBwx3WK6dZrzGrEej3wOT7Fo84ydAiqU+u4aMaU0DGBw==
   dependencies:
     "@0x/assert" "^3.0.19"
     "@0x/base-contract" "^6.2.14"
@@ -191,7 +190,6 @@
 "@0x/contract-wrappers@^13.12.0":
   version "13.12.0"
   resolved "https://registry.yarnpkg.com/@0x/contract-wrappers/-/contract-wrappers-13.12.0.tgz#7847090571fe4db18b84f20e5be0e38950c4f26c"
-  integrity sha512-mw+jgQQVSdzuzRv1buNwrTg7hOukRN9L3HW8p1biz9S5TeykQZA7NDfL7ASBW8f3LVO/bc6TI2hUJ/Nujm6nYg==
   dependencies:
     "@0x/assert" "^3.0.19"
     "@0x/base-contract" "^6.2.14"
@@ -642,7 +640,6 @@
 "@0x/order-utils@^10.4.13":
   version "10.4.13"
   resolved "https://registry.yarnpkg.com/@0x/order-utils/-/order-utils-10.4.13.tgz#9be075a94c446459508b1d92dbcec7a909bfaf45"
-  integrity sha512-12Q7F+LjVuJZFH1V7fpB3+TiFIdhzNiGlWJOEW3LDlE4NghgKOHkan/uPbtaF2kgUJr2AqNaMrkmnVMsZflLaQ==
   dependencies:
     "@0x/assert" "^3.0.19"
     "@0x/contract-addresses" "^5.8.0"
@@ -668,7 +665,7 @@
     ethers "~4.0.4"
     lodash "^4.17.11"
 
-"@0x/orderbook@0xProject/gitpkg-registry#0x-orderbook-v2.2.7-e10a81023", "@0x/orderbook@github:0xProject/gitpkg-registry#0x-orderbook-v2.2.7-e10a81023":
+"@0x/orderbook@0xProject/gitpkg-registry#0x-orderbook-v2.2.7-e10a81023":
   version "2.2.7"
   resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/c4b7cdf7770608fa1005a3f91c740ed417541fd9"
   dependencies:


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

Changing ingress so need to manually have the `/sra/orders -> /sra/v3/orders` mapping

Added a default Cache control header for browsers to cache (`10s`) results.

Logs out RPC errors and throws a more helpful error for developer debugging when 429's are encountered from the RPC subprovider.

<!--- Describe your changes in detail -->

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
