### PR TITLE
chore: Change allowance target to 0xdef1

### DIFF
--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -228,12 +228,6 @@ export class SwapService {
         let adjustedWorstCaseProtocolFee = protocolFee;
         let adjustedValue = value;
 
-        // If the entire caller amount is requested to be sold, this requires the new allowance target
-        // i.e the exchange proxy. The old allowance target will eventually be deprecated
-        const erc20AllowanceTarget = shouldSellEntireBalance
-            ? this._contractAddresses.exchangeProxy
-            : this._contractAddresses.exchangeProxyAllowanceTarget;
-
         // With v1 we are able to fill bridges directly so the protocol fee is lower
         const nativeFills = _.flatten(swapQuote.orders.map(order => order.fills)).filter(
             fill => fill.source === ERC20BridgeSource.Native,
@@ -269,7 +263,8 @@ export class SwapService {
             ? adjustedWorstCaseProtocolFee.plus(swapQuote.worstCaseQuoteInfo.takerAssetAmount)
             : adjustedWorstCaseProtocolFee;
 
-        const allowanceTarget = isETHSell ? NULL_ADDRESS : erc20AllowanceTarget;
+        // No allowance target is needed if this is an ETH sell, so set to 0x000..
+        const allowanceTarget = isETHSell ? NULL_ADDRESS : this._contractAddresses.exchangeProxy;
 
         const { takerAssetToEthRate, makerAssetToEthRate } = swapQuote;
 

--- a/test/swap_test.ts
+++ b/test/swap_test.ts
@@ -169,7 +169,7 @@ describe(SUITE_NAME, () => {
                             : SYMBOL_TO_ADDRESS[parameters.buyToken],
                         allowanceTarget: isETHSymbolOrAddress(parameters.sellToken)
                             ? NULL_ADDRESS
-                            : CONTRACT_ADDRESSES.exchangeProxyAllowanceTarget,
+                            : CONTRACT_ADDRESSES.exchangeProxy,
                     });
                 });
             }


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

Changes the default allowance target value to the new target (0x Exchange Proxy).

[Sims](https://metabase.spaceship.0x.org/dashboard/139?run_id=new-allowance-target&adjusted_amount_bought_win_tolerance__bps_=0.5)

<!--- Describe your changes in detail -->

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
