### PR TITLE
feat: Perform gas estimation with a single call

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -107,4 +107,13 @@ export const utils = {
         })();
         return intervalUtils.setAsyncExcludingInterval(fn, intervalMs, onError);
     },
+    calculateCallDataGas: (bytes: string) => {
+        const buf = Buffer.from(bytes.replace(/0x/g, ''), 'hex');
+        let gas = 21000;
+        for (const b of buf) {
+            // 4 gas per 0 byte, 16 gas per non-zero
+            gas += b === 0 ? 4 : 16;
+        }
+        return gas;
+    },
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -112,6 +112,7 @@ export const utils = {
         let gas = 21000;
         for (const b of buf) {
             // 4 gas per 0 byte, 16 gas per non-zero
+            // tslint:disable-next-line
             gas += b === 0 ? 4 : 16;
         }
         return gas;


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

Requires https://github.com/0xProject/protocol/pull/151

Previously a single `swap/v1/quote` request would perform the following:  
1. Sample (`eth_call`)
2. Gas estimation (`eth_estimateGas`)
3. Validation (`eth_call` using the gas + data to surface any revert data)

This resulted in 3 RPC calls, we now get the gas estimation in an `eth_call` by making use of Geth overrides. We add in the base gas cost and the per byte call data cost.

<!--- Describe your changes in detail -->

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
