### PR TITLE
fix: lowercase addresses in order update event data received from Mesh

### DIFF
--- a/src/middleware/address_normalizer.ts
+++ b/src/middleware/address_normalizer.ts
@@ -1,21 +1,15 @@
-import { addressUtils } from '@0x/utils';
 import * as express from 'express';
 // tslint:disable-next-line:no-implicit-dependencies
 import * as core from 'express-serve-static-core';
+
+import { objectETHAddressNormalizer } from '../utils/address_utils';
 
 /**
  * Searches for query param values that match the ETH address format, and transforms them to lowercase
  */
 export function addressNormalizer(req: express.Request, _: express.Response, next: core.NextFunction): void {
-    const normalized: { [key: string]: any } = {};
-    for (const [key, value] of Object.entries(req.query)) {
-        if (value && addressUtils.isAddress(value as string)) {
-            normalized[key] = (value as string).toLowerCase();
-        }
-    }
-    req.query = {
-        ...req.query,
-        ...normalized,
-    };
+    const normalizedQuery = objectETHAddressNormalizer(req.query);
+    req.query = normalizedQuery;
+
     next();
 }

--- a/src/utils/address_utils.ts
+++ b/src/utils/address_utils.ts
@@ -1,0 +1,19 @@
+import { addressUtils } from '@0x/utils';
+
+/**
+ * Checks top level attributes of an object for values matching an ETH address
+ * and normalizes the address by turning it to lowercase
+ */
+export const objectETHAddressNormalizer = <T>(obj: T) => {
+    const normalized: { [key: string]: any } = {};
+    for (const [key, value] of Object.entries(obj)) {
+        if (value && addressUtils.isAddress(value as string)) {
+            normalized[key] = (value as string).toLowerCase();
+        }
+    }
+
+    return {
+        ...obj,
+        ...normalized,
+    };
+};

--- a/src/utils/mesh_utils.ts
+++ b/src/utils/mesh_utils.ts
@@ -13,6 +13,7 @@ import { ZERO } from '../constants';
 import { ValidationErrorCodes } from '../errors';
 import { logger } from '../logger';
 import { OrdersByLifecycleEvents, SignedLimitOrder, SRAOrder } from '../types';
+import { objectETHAddressNormalizer } from '../utils/address_utils';
 
 type AcceptedOrderWithEndState = AcceptedOrderResult<OrderWithMetadataV4> & { endState: OrderEventEndState };
 type OrderData =
@@ -33,7 +34,9 @@ export type OrderEventV4 = OrderEvent & { orderv4: OrderWithMetadataV4 };
 
 export const meshUtils = {
     orderWithMetadataToSignedOrder(order: OrderWithMetadataV4): SignedLimitOrder {
-        const cleanedOrder: SignedLimitOrder = _.omit(order, ['hash', 'fillableTakerAssetAmount']);
+        const cleanedOrder: SignedLimitOrder = objectETHAddressNormalizer(
+            _.omit(order, ['hash', 'fillableTakerAssetAmount']),
+        );
 
         return cleanedOrder;
     },


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description
There is an inconsistency in the address casing of v4 order data received from Mesh, it seems like query responses return strictly lower case addresses, whereas the subscription order event updates can return checksummed addresses. This lead to some issues with checksummed addresses temporarily getting into the DB when inserted from an `ADDED` event, but then lowercased when API was restarted and it does a full sync query to Mesh.
<!--- Describe your changes in detail -->

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
