### PR TITLE
fix: expect sra pool filter to be a hex number just like in the order

### DIFF
--- a/src/schemas/sra_orders_query_schema.json
+++ b/src/schemas/sra_orders_query_schema.json
@@ -21,7 +21,7 @@
             "$ref": "/addressSchema"
         },
         "pool": {
-            "type": "number"
+            "type": "hexSchema"
         },
         "expiry": {
             "$ref": "/wholeNumberSchema"


### PR DESCRIPTION
# Description

If filtering SRA order by pool, it needs to be the padded hex number that is in the order (`0x0000000000000000000000000000000000000000000000000000000000000001`) so we should validate that it's a hex number.

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
