### PR TITLE
fix: New API key structure

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -95,13 +95,13 @@ export const getApiKeyWhitelistWithFallback = (
         const keyMeta = deserialized[apiKey];
         switch (groupType) {
             case 'plp':
-                if (keyMeta.plp) result.push(apiKey);
+                if (keyMeta.plp) { result.push(apiKey); }
                 break;
             case 'rfqm':
-                if (keyMeta.rfqm) result.push(apiKey);
+                if (keyMeta.rfqm) { result.push(apiKey); }
                 break;
             case 'rfqt':
-                if (keyMeta.rfqt) result.push(apiKey);
+                if (keyMeta.rfqt) { result.push(apiKey); }
                 break;
             default:
                 throw new Error(`Unknown group type inputted: ${groupType}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -98,10 +98,10 @@ export const getApiKeyWhitelistWithFallback = (
                 if (keyMeta.plp) result.push(apiKey);
                 break;
             case 'rfqm':
-                if (keyMeta.rfqm ===sult.push(apiKey);
+                if (keyMeta.rfqm) result.push(apiKey);
                 break;
             case 'rfqt':
-                if (keyMeta.rfqt === tru.push(apiKey);
+                if (keyMeta.rfqt) result.push(apiKey);
                 break;
             default:
                 throw new Error(`Unknown group type inputted: ${groupType}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,9 +30,11 @@ import {
     QUOTE_ORDER_EXPIRATION_BUFFER_MS,
     TX_BASE_GAS,
 } from './constants';
+import { schemas } from './schemas';
 import { TokenMetadatasForChains } from './token_metadatas_for_networks';
 import { ChainId, HttpServiceConfig, MetaTransactionRateLimitConfig } from './types';
 import { parseUtils } from './utils/parse_utils';
+import { schemaUtils } from './utils/schema_utils';
 
 // tslint:disable:no-bitwise
 
@@ -56,6 +58,56 @@ enum EnvVarType {
     RateLimitConfig,
     LiquidityProviderRegistry,
     JsonStringList,
+}
+
+export interface ApiKeyStructure {
+    [key: string]: {
+        label: string,
+        rfqt: boolean,
+        rfqm: boolean,
+        plp: boolean,
+    }
+};
+
+export const getApiKeyWhitelistWithFallback = (
+    legacyEnvKey: string,
+    newEnvKey: string,
+    groupType: 'rfqt' | 'plp' | 'rfqm'
+): string[] => {
+
+    // Try the new path first
+    if (_.isEmpty(process.env[newEnvKey])) {
+        return _.isEmpty(process.env[legacyEnvKey])
+            ? []
+            : assertEnvVarType(legacyEnvKey, process.env[legacyEnvKey], EnvVarType.JsonStringList);
+    }
+
+    let deserialized: ApiKeyStructure;
+    try {
+        deserialized = JSON.parse(process.env[newEnvKey]!);
+        schemaUtils.validateSchema(deserialized, schemas.apiKeySchema as any);
+    } catch (e) {
+        throw new Error(`Key ${newEnvKey} was defined but is not valid JSON`);
+    }
+
+    const result: string[] = [];
+    for (const apiKey of Object.keys(deserialized)) {
+        const keyMeta = deserialized[apiKey];
+        switch (groupType) {
+            case 'plp':
+                if (keyMeta.plp === true) result.push(apiKey);
+                break
+            case 'rfqm':
+                if (keyMeta.rfqm === true) result.push(apiKey);
+                break
+            case 'rfqt':
+                if (keyMeta.rfqt === true) result.push(apiKey);
+                break
+            default:
+                throw new Error(`Unknown group type inputted: ${groupType}`);
+        }
+    }
+    return result.sort();
 }
 
 // Log level for pino.js
@@ -192,13 +244,11 @@ export const RFQT_REGISTRY_PASSWORDS: string[] = _.isEmpty(process.env.RFQT_REGI
     ? []
     : assertEnvVarType('RFQT_REGISTRY_PASSWORDS', process.env.RFQT_REGISTRY_PASSWORDS, EnvVarType.JsonStringList);
 
-export const RFQT_API_KEY_WHITELIST: string[] = _.isEmpty(process.env.RFQT_API_KEY_WHITELIST_JSON)
-    ? []
-    : assertEnvVarType(
-          'RFQT_API_KEY_WHITELIST_JSON',
-          process.env.RFQT_API_KEY_WHITELIST_JSON,
-          EnvVarType.JsonStringList,
-      );
+export const RFQT_API_KEY_WHITELIST: string[] = getApiKeyWhitelistWithFallback(
+    'RFQT_API_KEY_WHITELIST_JSON',
+    'API_KEYS_ACL',
+    'rfqt'
+);
 
 export const RFQT_TX_ORIGIN_BLACKLIST: Set<string> = _.isEmpty(process.env.RFQT_TX_ORIGIN_BLACKLIST)
     ? new Set()
@@ -220,9 +270,11 @@ export const ALT_RFQ_MM_PROFILE: string | undefined = _.isEmpty(process.env.ALT_
     ? undefined
     : assertEnvVarType('ALT_RFQ_MM_PROFILE', process.env.ALT_RFQ_MM_PROFILE, EnvVarType.NonEmptyString);
 
-export const PLP_API_KEY_WHITELIST: string[] = _.isEmpty(process.env.PLP_API_KEY_WHITELIST_JSON)
-    ? []
-    : assertEnvVarType('PLP_API_KEY_WHITELIST_JSON', process.env.PLP_API_KEY_WHITELIST_JSON, EnvVarType.JsonStringList);
+export const PLP_API_KEY_WHITELIST: string[] = getApiKeyWhitelistWithFallback(
+    'PLP_API_KEY_WHITELIST_JSON',
+    'API_KEYS_ACL',
+    'plp'
+);
 
 export const RFQT_MAKER_ASSET_OFFERINGS: RfqMakerAssetOfferings = _.isEmpty(process.env.RFQT_MAKER_ASSET_OFFERINGS)
     ? {}

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,12 +62,12 @@ enum EnvVarType {
 
 export interface ApiKeyStructure {
     [key: string]: {
-        label: string,
-        rfqt: boolean,
-        rfqm: boolean,
-        plp: boolean,
-    }
-};
+        label: string;
+        rfqt: boolean;
+        rfqm: boolean;
+        plp: boolean;
+    };
+}
 
 export const getApiKeyWhitelistWithFallback = (
     legacyEnvKey: string,
@@ -95,20 +95,20 @@ export const getApiKeyWhitelistWithFallback = (
         const keyMeta = deserialized[apiKey];
         switch (groupType) {
             case 'plp':
-                if (keyMeta.plp === true) result.push(apiKey);
-                break
+                if (keyMeta.plp) result.push(apiKey);
+                break;
             case 'rfqm':
-                if (keyMeta.rfqm === true) result.push(apiKey);
-                break
+                if (keyMeta.rfqm ===sult.push(apiKey);
+                break;
             case 'rfqt':
-                if (keyMeta.rfqt === true) result.push(apiKey);
-                break
+                if (keyMeta.rfqt === tru.push(apiKey);
+                break;
             default:
                 throw new Error(`Unknown group type inputted: ${groupType}`);
         }
     }
     return result.sort();
-}
+};
 
 // Log level for pino.js
 export const LOG_LEVEL: string = _.isEmpty(process.env.LOG_LEVEL)

--- a/src/schemas/api_key_schema.json
+++ b/src/schemas/api_key_schema.json
@@ -1,16 +1,11 @@
 {
     "id": "/apiKeySchema",
     "type": "object",
-    "additionalProperties" : {
-        "type" : "object",
-        "required" : [
-            "rfqt",
-            "rfqm",
-            "plp",
-            "label"
-        ],
-        "properties" : {
-             "label": {
+    "additionalProperties": {
+        "type": "object",
+        "required": ["rfqt", "rfqm", "plp", "label"],
+        "properties": {
+            "label": {
                 "type": "string"
             },
             "rfqt": {

--- a/src/schemas/api_key_schema.json
+++ b/src/schemas/api_key_schema.json
@@ -1,0 +1,27 @@
+{
+    "id": "/apiKeySchema",
+    "type": "object",
+    "additionalProperties" : {
+        "type" : "object",
+        "required" : [
+            "rfqt",
+            "rfqm",
+            "plp",
+            "label"
+        ],
+        "properties" : {
+             "label": {
+                "type": "string"
+            },
+            "rfqt": {
+                "type": "boolean"
+            },
+            "rfqm": {
+                "type": "boolean"
+            },
+            "plp": {
+                "type": "boolean"
+            }
+        }
+    }
+}

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -7,6 +7,7 @@ import * as sraPostOrdersPayloadSchema from './sra_post_orders_payload_schema.js
 import * as sraPostOrderPayloadSchema from './sra_post_order_payload_schema.json';
 import * as sraOrdersChannelSubscribeSchema from './sra_ws_orders_channel_subscribe_schema.json';
 import * as swapQuoteRequestSchema from './swap_quote_request_schema.json';
+import * as apiKeySchema from './api_key_schema.json';
 
 export const schemas = {
     sraOrderConfigPayloadSchema,
@@ -18,4 +19,5 @@ export const schemas = {
     swapQuoteRequestSchema,
     metaTransactionFillRequestSchema,
     metaTransactionQuoteRequestSchema,
+    apiKeySchema,
 };

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,3 +1,4 @@
+import * as apiKeySchema from './api_key_schema.json';
 import * as metaTransactionFillRequestSchema from './meta_transaction_fill_request_schema.json';
 import * as metaTransactionQuoteRequestSchema from './meta_transaction_quote_request_schema.json';
 import * as sraOrderbookQuerySchema from './sra_orderbook_query_schema.json';
@@ -7,7 +8,6 @@ import * as sraPostOrdersPayloadSchema from './sra_post_orders_payload_schema.js
 import * as sraPostOrderPayloadSchema from './sra_post_order_payload_schema.json';
 import * as sraOrdersChannelSubscribeSchema from './sra_ws_orders_channel_subscribe_schema.json';
 import * as swapQuoteRequestSchema from './swap_quote_request_schema.json';
-import * as apiKeySchema from './api_key_schema.json';
 
 export const schemas = {
     sraOrderConfigPayloadSchema,

--- a/test/parse_utils_test.ts
+++ b/test/parse_utils_test.ts
@@ -134,10 +134,10 @@ describe(SUITE_NAME, () => {
 
     it('getApiKeyWhitelistWithFallback() is able to decode new format', () => {
         const keys: ApiKeyStructure = {
-            'foo': {'rfqm': false, 'rfqt': true, 'plp': true, 'label': 'Foo key' }, 
-            'bar': {'rfqm': false, 'rfqt': true, 'plp': false, 'label': 'Bar key' }, 
-            'baz': {'rfqm': false, 'rfqt': false, 'plp': true, 'label': 'Baz key' }, 
-            'barf': {'rfqm': true, 'rfqt': false, 'plp': false, 'label': 'Barf key' }, 
+            'foo': {'rfqm': false, 'rfqt': true, 'plp': true, 'label': 'Foo key' },
+            'bar': {'rfqm': false, 'rfqt': true, 'plp': false, 'label': 'Bar key' },
+            'baz': {'rfqm': false, 'rfqt': false, 'plp': true, 'label': 'Baz key' },
+            'barf': {'rfqm': true, 'rfqt': false, 'plp': false, 'label': 'Barf key' },
         };
         process.env.TEST_NEW_KEY = JSON.stringify(keys);
 

--- a/test/parse_utils_test.ts
+++ b/test/parse_utils_test.ts
@@ -2,8 +2,8 @@ import { ERC20BridgeSource } from '@0x/asset-swapper';
 import { expect } from '@0x/contracts-test-utils';
 import { NULL_ADDRESS } from '@0x/utils';
 import 'mocha';
-import { ApiKeyStructure, getApiKeyWhitelistWithFallback } from '../src/config';
 
+import { ApiKeyStructure, getApiKeyWhitelistWithFallback } from '../src/config';
 import { parseUtils } from '../src/utils/parse_utils';
 
 const SUITE_NAME = 'parseUtils';
@@ -12,7 +12,7 @@ describe(SUITE_NAME, () => {
     beforeEach(() => {
         delete process.env.TEST_LEGACY_KEY;
         delete process.env.TEST_NEW_KEY;
-    })
+    });
 
     it('raises a ValidationError if includedSources is RFQT and a taker is not specified', async () => {
         expect(() => {
@@ -122,37 +122,37 @@ describe(SUITE_NAME, () => {
 
     it('getApiKeyWhitelistWithFallback() is able to correctly configure fallback', () => {
         process.env.TEST_LEGACY_KEY = JSON.stringify([
-            "foo",
-            "bar",
+            'foo',
+            'bar',
         ]);
 
-        const response = getApiKeyWhitelistWithFallback("TEST_LEGACY_KEY", "TEST_NEW_KEY", "plp");
+        const response = getApiKeyWhitelistWithFallback('TEST_LEGACY_KEY', 'TEST_NEW_KEY', 'plp');
         expect(response.length).to.eql(2);
         expect(response[0]).to.eql('foo');
         expect(response[1]).to.eql('bar');
-    })
+    });
 
     it('getApiKeyWhitelistWithFallback() is able to decode new format', () => {
-        let keys: ApiKeyStructure = {
-            "foo": {"rfqm": false, "rfqt": true, "plp": true, "label": "Foo key" }, 
-            "bar": {"rfqm": false, "rfqt": true, "plp": false, "label": "Bar key" }, 
-            "baz": {"rfqm": false, "rfqt": false, "plp": true, "label": "Baz key" }, 
-            "barf": {"rfqm": true, "rfqt": false, "plp": false, "label": "Barf key" }, 
+        const keys: ApiKeyStructure = {
+            'foo': {'rfqm': false, 'rfqt': true, 'plp': true, 'label': 'Foo key' }, 
+            'bar': {'rfqm': false, 'rfqt': true, 'plp': false, 'label': 'Bar key' }, 
+            'baz': {'rfqm': false, 'rfqt': false, 'plp': true, 'label': 'Baz key' }, 
+            'barf': {'rfqm': true, 'rfqt': false, 'plp': false, 'label': 'Barf key' }, 
         };
         process.env.TEST_NEW_KEY = JSON.stringify(keys);
 
-        const plpResponse = getApiKeyWhitelistWithFallback("TEST_LEGACY_KEY", "TEST_NEW_KEY", "plp");
+        const plpResponse = getApiKeyWhitelistWithFallback('TEST_LEGACY_KEY', 'TEST_NEW_KEY', 'plp');
         expect(plpResponse.length).to.eql(2);
         expect(plpResponse[0]).to.eql('baz');
         expect(plpResponse[1]).to.eql('foo');
 
-        const rfqtResponse = getApiKeyWhitelistWithFallback("TEST_LEGACY_KEY", "TEST_NEW_KEY", "rfqt");
+        const rfqtResponse = getApiKeyWhitelistWithFallback('TEST_LEGACY_KEY', 'TEST_NEW_KEY', 'rfqt');
         expect(rfqtResponse.length).to.eql(2);
         expect(rfqtResponse[0]).to.eql('bar');
         expect(rfqtResponse[1]).to.eql('foo');
 
-        const rfqmResponse = getApiKeyWhitelistWithFallback("TEST_LEGACY_KEY", "TEST_NEW_KEY", "rfqm");
+        const rfqmResponse = getApiKeyWhitelistWithFallback('TEST_LEGACY_KEY', 'TEST_NEW_KEY', 'rfqm');
         expect(rfqmResponse.length).to.eql(1);
         expect(rfqmResponse[0]).to.eql('barf');
-    })
+    });
 });

--- a/test/parse_utils_test.ts
+++ b/test/parse_utils_test.ts
@@ -2,12 +2,18 @@ import { ERC20BridgeSource } from '@0x/asset-swapper';
 import { expect } from '@0x/contracts-test-utils';
 import { NULL_ADDRESS } from '@0x/utils';
 import 'mocha';
+import { ApiKeyStructure, getApiKeyWhitelistWithFallback } from '../src/config';
 
 import { parseUtils } from '../src/utils/parse_utils';
 
 const SUITE_NAME = 'parseUtils';
 
 describe(SUITE_NAME, () => {
+    beforeEach(() => {
+        delete process.env.TEST_LEGACY_KEY;
+        delete process.env.TEST_NEW_KEY;
+    })
+
     it('raises a ValidationError if includedSources is RFQT and a taker is not specified', async () => {
         expect(() => {
             parseUtils.parseRequestForExcludedSources(
@@ -113,4 +119,40 @@ describe(SUITE_NAME, () => {
             );
         }).throws();
     });
+
+    it('getApiKeyWhitelistWithFallback() is able to correctly configure fallback', () => {
+        process.env.TEST_LEGACY_KEY = JSON.stringify([
+            "foo",
+            "bar",
+        ]);
+
+        const response = getApiKeyWhitelistWithFallback("TEST_LEGACY_KEY", "TEST_NEW_KEY", "plp");
+        expect(response.length).to.eql(2);
+        expect(response[0]).to.eql('foo');
+        expect(response[1]).to.eql('bar');
+    })
+
+    it('getApiKeyWhitelistWithFallback() is able to decode new format', () => {
+        let keys: ApiKeyStructure = {
+            "foo": {"rfqm": false, "rfqt": true, "plp": true, "label": "Foo key" }, 
+            "bar": {"rfqm": false, "rfqt": true, "plp": false, "label": "Bar key" }, 
+            "baz": {"rfqm": false, "rfqt": false, "plp": true, "label": "Baz key" }, 
+            "barf": {"rfqm": true, "rfqt": false, "plp": false, "label": "Barf key" }, 
+        };
+        process.env.TEST_NEW_KEY = JSON.stringify(keys);
+
+        const plpResponse = getApiKeyWhitelistWithFallback("TEST_LEGACY_KEY", "TEST_NEW_KEY", "plp");
+        expect(plpResponse.length).to.eql(2);
+        expect(plpResponse[0]).to.eql('baz');
+        expect(plpResponse[1]).to.eql('foo');
+
+        const rfqtResponse = getApiKeyWhitelistWithFallback("TEST_LEGACY_KEY", "TEST_NEW_KEY", "rfqt");
+        expect(rfqtResponse.length).to.eql(2);
+        expect(rfqtResponse[0]).to.eql('bar');
+        expect(rfqtResponse[1]).to.eql('foo');
+
+        const rfqmResponse = getApiKeyWhitelistWithFallback("TEST_LEGACY_KEY", "TEST_NEW_KEY", "rfqm");
+        expect(rfqmResponse.length).to.eql(1);
+        expect(rfqmResponse[0]).to.eql('barf');
+    })
 });


### PR DESCRIPTION
This PR creates a new API key structure, where every API key can have multiple "features" enabled. The feature is built so that it will fallback on the existing key structure in order to support a phased migration of the configurations.

### New key structure
```json
{
    "foo": {"rfqm": false, "rfqt": true, "plp": true, "label": "Foo key" }, 
    "bar": {"rfqm": false, "rfqt": true, "plp": false, "label": "Bar key" }, 
    "baz": {"rfqm": false, "rfqt": false, "plp": true, "label": "Baz key" }, 
    "barf": {"rfqm": true, "rfqt": false, "plp": false, "label": "Barf key" }, 
}
```