### PR TITLE
fix: avoid making a post request to mesh with no orders

### DIFF
--- a/src/services/order_watcher_service.ts
+++ b/src/services/order_watcher_service.ts
@@ -22,9 +22,9 @@ export class OrderWatcherService {
         logger.info('OrderWatcherService syncing orderbook with Mesh');
 
         // 1. Get orders from local cache
-        const signedOrderModels = (await this._connection.manager.find(SignedOrderV4Entity)) as Required<
-            SignedOrderV4Entity
-        >[];
+        const signedOrderModels = (await this._connection.manager.find(
+            SignedOrderV4Entity,
+        )) as Required<SignedOrderV4Entity>[];
         const signedOrders = signedOrderModels.map(orderUtils.deserializeOrder);
 
         // 2. Get orders from Mesh

--- a/src/services/order_watcher_service.ts
+++ b/src/services/order_watcher_service.ts
@@ -22,9 +22,9 @@ export class OrderWatcherService {
         logger.info('OrderWatcherService syncing orderbook with Mesh');
 
         // 1. Get orders from local cache
-        const signedOrderModels = (await this._connection.manager.find(
-            SignedOrderV4Entity,
-        )) as Required<SignedOrderV4Entity>[];
+        const signedOrderModels = (await this._connection.manager.find(SignedOrderV4Entity)) as Required<
+            SignedOrderV4Entity
+        >[];
         const signedOrders = signedOrderModels.map(orderUtils.deserializeOrder);
 
         // 2. Get orders from Mesh
@@ -204,6 +204,12 @@ export class OrderWatcherService {
         orders: SignedLimitOrder[],
         pinned: boolean = false,
     ): Promise<ValidationResults> {
+        if (orders.length === 0) {
+            return {
+                accepted: [],
+                rejected: [],
+            };
+        }
         const { accepted, rejected } = await this._meshClient.addOrdersV4Async(orders, pinned);
         return {
             accepted: meshUtils.orderInfosToApiOrders(accepted),

--- a/src/services/orderbook_service.ts
+++ b/src/services/orderbook_service.ts
@@ -226,6 +226,12 @@ export class OrderBookService {
         signedOrders: SignedLimitOrder[],
         pinned: boolean,
     ): Promise<AcceptedOrderResult<OrderWithMetadataV4>[]> {
+        // Avoid making a request with no orders to save mesh roundtrip time and
+        // error handling as an empty array of orders fails initial validation
+        // on Mesh >=v11.2.
+        if (signedOrders.length === 0) {
+            return [];
+        }
         if (this._meshClient) {
             const { rejected, accepted } = await this._meshClient.addOrdersV4Async(signedOrders, pinned);
             if (rejected.length !== 0) {


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

<!--- Describe your changes in detail -->
This change prevents 0xAPI to send a request to Mesh with no orders, saving on roundtrip time as well as on uneccessary handling as v11.2 will return an error.

SRA was sending empty orders because of  :
```
          const pinResult = await orderUtils.splitOrdersByPinningAsync(signedOrders);
          await Promise.all([
            this._orderBook.addOrdersAsync(pinResult.pin, true),
            this._orderBook.addOrdersAsync(pinResult.doNotPin, false),
        ]);
```

in https://github.com/0xProject/0x-api/blob/master/src/handlers/sra_handlers.ts#L108
# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
