### PR TITLE
refactor: small cleanup of rfqmDbUtils

### DIFF
--- a/src/entities/RfqmJobEntity.ts
+++ b/src/entities/RfqmJobEntity.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@0x/asset-swapper';
 import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
 
-import { RfqmJobOpts, RfqmJobStatus, StoredFee, StoredOrder } from '../utils/rfqm_db_utils';
+import { RfqmJobStatus, StoredFee, StoredOrder } from '../utils/rfqm_db_utils';
 
 import { BigNumberTransformer } from './transformers';
 
@@ -51,7 +51,7 @@ export class RfqmJobEntity {
     @Column({ name: 'metadata', type: 'jsonb', nullable: true })
     public metadata: object | null;
 
-    constructor(opts: RfqmJobOpts = {}) {
+    constructor(opts: Partial<RfqmJobEntity> = {}) {
         this.orderHash = opts.orderHash;
         this.metaTransactionHash = opts.metaTransactionHash || null;
         this.createdAt = opts.createdAt || new Date();

--- a/src/entities/RfqmQuoteEntity.ts
+++ b/src/entities/RfqmQuoteEntity.ts
@@ -29,18 +29,7 @@ export class RfqmQuoteEntity {
     @Column({ name: 'order', type: 'jsonb', nullable: true })
     public order: StoredOrder | null;
 
-    constructor(
-        opts: {
-            orderHash?: string;
-            metaTransactionHash?: string;
-            createdAt?: Date;
-            chainId?: number;
-            integratorId?: string;
-            makerUri?: string;
-            fee?: StoredFee;
-            order?: StoredOrder;
-        } = {},
-    ) {
+    constructor(opts: Partial<RfqmQuoteEntity> = {}) {
         this.orderHash = opts.orderHash;
         this.metaTransactionHash = opts.metaTransactionHash || null;
         this.createdAt = opts.createdAt;

--- a/src/runners/http_rfqm_service_runner.ts
+++ b/src/runners/http_rfqm_service_runner.ts
@@ -40,6 +40,7 @@ import { HttpServiceConfig } from '../types';
 import { ConfigManager } from '../utils/config_manager';
 import { providerUtils } from '../utils/provider_utils';
 import { QuoteServerClient } from '../utils/quote_server_client';
+import { RfqmDbUtils } from '../utils/rfqm_db_utils';
 import { RfqBlockchainUtils } from '../utils/rfq_blockchain_utils';
 
 process.on('uncaughtException', (err) => {
@@ -115,6 +116,8 @@ export async function buildRfqmServiceAsync(connection: Connection, asWorker: bo
 
     const rfqBlockchainUtils = new RfqBlockchainUtils(provider, contractAddresses.exchangeProxy);
 
+    const dbUtils = new RfqmDbUtils(connection);
+
     const sqsProducer = Producer.create({
         queueUrl: RFQM_META_TX_SQS_URL,
     });
@@ -127,7 +130,7 @@ export async function buildRfqmServiceAsync(connection: Connection, asWorker: bo
         contractAddresses,
         META_TX_WORKER_REGISTRY!,
         rfqBlockchainUtils,
-        connection,
+        dbUtils,
         sqsProducer,
         quoteServerClient,
     );

--- a/src/utils/rfqm_db_utils.ts
+++ b/src/utils/rfqm_db_utils.ts
@@ -5,23 +5,6 @@ import { Connection } from 'typeorm/connection/Connection';
 
 import { RfqmJobEntity, RfqmQuoteEntity } from '../entities';
 
-export interface RfqmJobOpts {
-    orderHash?: string;
-    metaTransactionHash?: string;
-    createdAt?: Date;
-    updatedAt?: Date;
-    expiry?: BigNumber;
-    chainId?: number;
-    integratorId?: string | null;
-    makerUri?: string;
-    status?: RfqmJobStatus;
-    statusReason?: string | null;
-    calldata?: string;
-    fee?: StoredFee | null;
-    order?: StoredOrder | null;
-    metadata?: object;
-}
-
 export enum RfqmJobStatus {
     InQueue = 'inQueue',
     Processing = 'processing',
@@ -154,11 +137,15 @@ export class RfqmDbUtils {
     /**
      * updateRfqmJobAsync allows for partial updates of an RfqmJob at the given orderHash
      */
-    public async updateRfqmJobAsync(orderHash: string, rfqmJobOpts: RfqmJobOpts): Promise<void> {
+    public async updateRfqmJobAsync(orderHash: string, rfqmJobOpts: Partial<RfqmJobEntity>): Promise<void> {
         await this._connection.getRepository(RfqmJobEntity).save({ ...rfqmJobOpts, orderHash });
     }
 
-    public async writeRfqmJobToDbAsync(rfqmJobOpts: RfqmJobOpts): Promise<void> {
+    public async writeRfqmQuoteToDbAsync(rfqmQuoteOpts: Partial<RfqmQuoteEntity>): Promise<void> {
+        await this._connection.getRepository(RfqmQuoteEntity).insert(new RfqmQuoteEntity(rfqmQuoteOpts));
+    }
+
+    public async writeRfqmJobToDbAsync(rfqmJobOpts: Partial<RfqmJobEntity>): Promise<void> {
         await this._connection.getRepository(RfqmJobEntity).insert(new RfqmJobEntity(rfqmJobOpts));
     }
 }

--- a/test/rfqm_db_test.ts
+++ b/test/rfqm_db_test.ts
@@ -7,13 +7,7 @@ import { Connection } from 'typeorm';
 
 import { getDBConnectionAsync } from '../src/db_connection';
 import { RfqmJobEntity, RfqmQuoteEntity } from '../src/entities';
-import {
-    feeToStoredFee,
-    RfqmDbUtils,
-    RfqmJobOpts,
-    RfqmJobStatus,
-    v4RfqOrderToStoredOrder,
-} from '../src/utils/rfqm_db_utils';
+import { feeToStoredFee, RfqmDbUtils, RfqmJobStatus, v4RfqOrderToStoredOrder } from '../src/utils/rfqm_db_utils';
 
 import { setupDependenciesAsync, teardownDependenciesAsync } from './utils/deployment';
 
@@ -98,7 +92,7 @@ describe(SUITE_NAME, () => {
             expect(dbEntity).to.deep.eq(testRfqmQuoteEntity);
         });
         it('should be able to save and read an rfqm job entity w/ no change in information', async () => {
-            const rfqmJobOpts: RfqmJobOpts = {
+            const rfqmJobOpts = {
                 orderHash,
                 metaTransactionHash,
                 createdAt,
@@ -123,7 +117,7 @@ describe(SUITE_NAME, () => {
         });
 
         it('should be able to update an rfqm job entity', async () => {
-            const rfqmJobOpts: RfqmJobOpts = {
+            const rfqmJobOpts = {
                 orderHash,
                 metaTransactionHash,
                 createdAt,

--- a/test/rfqm_test.ts
+++ b/test/rfqm_test.ts
@@ -143,8 +143,10 @@ describe(SUITE_NAME, () => {
             },
         ];
 
+        // Create the dbUtils
         connection = await getDBConnectionAsync();
         await connection.synchronize(true);
+        const dbUtils = new RfqmDbUtils(connection);
 
         // Create the mock sqsProducer
         const sqsProducerMock = mock(Producer);
@@ -160,7 +162,7 @@ describe(SUITE_NAME, () => {
             contractAddresses,
             MOCK_WORKER_REGISTRY_ADDRESS,
             rfqBlockchainUtils,
-            connection,
+            dbUtils,
             sqsProducer,
             quoteServerClient,
         );

--- a/test/services/rfqm_service_test.ts
+++ b/test/services/rfqm_service_test.ts
@@ -16,11 +16,11 @@ import { MetaTransaction, RfqOrder } from '@0x/protocol-utils';
 import { BigNumber } from '@0x/utils';
 import { Producer } from 'sqs-producer';
 import { anything, instance, mock, when } from 'ts-mockito';
-import { Connection, InsertResult, Repository } from 'typeorm';
 
 import { ONE_MINUTE_MS } from '../../src/constants';
 import { RfqmService } from '../../src/services/rfqm_service';
 import { QuoteServerClient } from '../../src/utils/quote_server_client';
+import { RfqmDbUtils } from '../../src/utils/rfqm_db_utils';
 import { RfqBlockchainUtils } from '../../src/utils/rfq_blockchain_utils';
 
 const NEVER_EXPIRES = new BigNumber(9999999999999999);
@@ -32,7 +32,7 @@ const buildRfqmServiceForUnitTest = (
         quoteRequestor?: QuoteRequestor;
         protocolFeeUtils?: ProtocolFeeUtils;
         rfqBlockchainUtils?: RfqBlockchainUtils;
-        connection?: Connection;
+        dbUtils?: RfqmDbUtils;
         producer?: Producer;
         quoteServerClient?: QuoteServerClient;
     } = {},
@@ -63,7 +63,7 @@ const buildRfqmServiceForUnitTest = (
     when(protocolFeeUtilsMock.getGasPriceEstimationOrThrowAsync()).thenResolve(MOCK_GAS_PRICE);
     const protocolFeeUtilsInstance = instance(protocolFeeUtilsMock);
     const rfqBlockchainUtilsMock = mock(RfqBlockchainUtils);
-    const connectionMock = mock(Connection);
+    const dbUtilsMock = mock(RfqmDbUtils);
     const sqsMock = mock(Producer);
     const quoteServerClientMock = mock(QuoteServerClient);
 
@@ -73,7 +73,7 @@ const buildRfqmServiceForUnitTest = (
         contractAddresses,
         MOCK_WORKER_REGISTRY_ADDRESS,
         overrides.rfqBlockchainUtils || rfqBlockchainUtilsMock,
-        overrides.connection || connectionMock,
+        overrides.dbUtils || dbUtilsMock,
         overrides.producer || sqsMock,
         overrides.quoteServerClient || quoteServerClientMock,
     );
@@ -581,20 +581,15 @@ describe('RfqmService', () => {
                 ).thenReturn(MOCK_META_TX);
                 const rfqBlockchainUtils = instance(rfqBlockchainUtilsMock);
 
-                // Mock out the repository
-                const repositoryMock = mock(Repository);
-                when(repositoryMock.insert(anything())).thenResolve(new InsertResult());
-                const repositoryInstance = instance(repositoryMock);
-
-                // Mock out the connection
-                const connectionMock = mock(Connection);
-                when(connectionMock.getRepository(anything())).thenReturn(repositoryInstance);
-                const connectionInstance = instance(connectionMock);
+                // Mock out the dbUtils
+                const dbUtilsMock = mock(RfqmDbUtils);
+                when(dbUtilsMock.writeRfqmQuoteToDbAsync(anything())).thenResolve();
+                const dbUtils = instance(dbUtilsMock);
 
                 const service = buildRfqmServiceForUnitTest({
                     quoteRequestor: quoteRequestorInstance,
                     rfqBlockchainUtils,
-                    connection: connectionInstance,
+                    dbUtils,
                 });
 
                 // When
@@ -664,20 +659,15 @@ describe('RfqmService', () => {
                 ).thenReturn(MOCK_META_TX);
                 const rfqBlockchainUtils = instance(rfqBlockchainUtilsMock);
 
-                // Mock out the repository
-                const repositoryMock = mock(Repository);
-                when(repositoryMock.insert(anything())).thenResolve(new InsertResult());
-                const repositoryInstance = instance(repositoryMock);
-
-                // Mock out the connection
-                const connectionMock = mock(Connection);
-                when(connectionMock.getRepository(anything())).thenReturn(repositoryInstance);
-                const connectionInstance = instance(connectionMock);
+                // Mock out the dbUtils
+                const dbUtilsMock = mock(RfqmDbUtils);
+                when(dbUtilsMock.writeRfqmQuoteToDbAsync(anything())).thenResolve();
+                const dbUtils = instance(dbUtilsMock);
 
                 const service = buildRfqmServiceForUnitTest({
                     quoteRequestor: quoteRequestorInstance,
                     rfqBlockchainUtils,
-                    connection: connectionInstance,
+                    dbUtils,
                 });
 
                 // When
@@ -748,20 +738,15 @@ describe('RfqmService', () => {
                 ).thenReturn(MOCK_META_TX);
                 const rfqBlockchainUtils = instance(rfqBlockchainUtilsMock);
 
-                // Mock out the repository
-                const repositoryMock = mock(Repository);
-                when(repositoryMock.insert(anything())).thenResolve(new InsertResult());
-                const repositoryInstance = instance(repositoryMock);
-
-                // Mock out the connection
-                const connectionMock = mock(Connection);
-                when(connectionMock.getRepository(anything())).thenReturn(repositoryInstance);
-                const connectionInstance = instance(connectionMock);
+                // Mock out the dbUtils
+                const dbUtilsMock = mock(RfqmDbUtils);
+                when(dbUtilsMock.writeRfqmQuoteToDbAsync(anything())).thenResolve();
+                const dbUtils = instance(dbUtilsMock);
 
                 const service = buildRfqmServiceForUnitTest({
                     quoteRequestor: quoteRequestorInstance,
                     rfqBlockchainUtils,
-                    connection: connectionInstance,
+                    dbUtils,
                 });
 
                 // When
@@ -832,20 +817,15 @@ describe('RfqmService', () => {
                 ).thenReturn(MOCK_META_TX);
                 const rfqBlockchainUtils = instance(rfqBlockchainUtilsMock);
 
-                // Mock out the repository
-                const repositoryMock = mock(Repository);
-                when(repositoryMock.insert(anything())).thenResolve(new InsertResult());
-                const repositoryInstance = instance(repositoryMock);
-
-                // Mock out the connection
-                const connectionMock = mock(Connection);
-                when(connectionMock.getRepository(anything())).thenReturn(repositoryInstance);
-                const connectionInstance = instance(connectionMock);
+                // Mock out the dbUtils
+                const dbUtilsMock = mock(RfqmDbUtils);
+                when(dbUtilsMock.writeRfqmQuoteToDbAsync(anything())).thenResolve();
+                const dbUtils = instance(dbUtilsMock);
 
                 const service = buildRfqmServiceForUnitTest({
                     quoteRequestor: quoteRequestorInstance,
                     rfqBlockchainUtils,
-                    connection: connectionInstance,
+                    dbUtils,
                 });
 
                 // When
@@ -916,20 +896,15 @@ describe('RfqmService', () => {
                 ).thenReturn(MOCK_META_TX);
                 const rfqBlockchainUtils = instance(rfqBlockchainUtilsMock);
 
-                // Mock out the repository
-                const repositoryMock = mock(Repository);
-                when(repositoryMock.insert(anything())).thenResolve(new InsertResult());
-                const repositoryInstance = instance(repositoryMock);
-
-                // Mock out the connection
-                const connectionMock = mock(Connection);
-                when(connectionMock.getRepository(anything())).thenReturn(repositoryInstance);
-                const connectionInstance = instance(connectionMock);
+                // Mock out the dbUtils
+                const dbUtilsMock = mock(RfqmDbUtils);
+                when(dbUtilsMock.writeRfqmQuoteToDbAsync(anything())).thenResolve();
+                const dbUtils = instance(dbUtilsMock);
 
                 const service = buildRfqmServiceForUnitTest({
                     quoteRequestor: quoteRequestorInstance,
                     rfqBlockchainUtils,
-                    connection: connectionInstance,
+                    dbUtils,
                 });
 
                 // When
@@ -1015,20 +990,15 @@ describe('RfqmService', () => {
                 ).thenReturn(MOCK_META_TX);
                 const rfqBlockchainUtils = instance(rfqBlockchainUtilsMock);
 
-                // Mock out the repository
-                const repositoryMock = mock(Repository);
-                when(repositoryMock.insert(anything())).thenResolve(new InsertResult());
-                const repositoryInstance = instance(repositoryMock);
-
-                // Mock out the connection
-                const connectionMock = mock(Connection);
-                when(connectionMock.getRepository(anything())).thenReturn(repositoryInstance);
-                const connectionInstance = instance(connectionMock);
+                // Mock out the dbUtils
+                const dbUtilsMock = mock(RfqmDbUtils);
+                when(dbUtilsMock.writeRfqmQuoteToDbAsync(anything())).thenResolve();
+                const dbUtils = instance(dbUtilsMock);
 
                 const service = buildRfqmServiceForUnitTest({
                     quoteRequestor: quoteRequestorInstance,
                     rfqBlockchainUtils,
-                    connection: connectionInstance,
+                    dbUtils,
                 });
 
                 // When


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

Very small refactor:
- instead of having both `connection` and `dbUtils` in rfqmService, only use `dbUtils` - this cleans up boilerplate in unit tests a bit
- replace `RfqmJobOpts` with `Partial<RfqmJobEntity>` - allows removing of an extra type

<!--- Describe your changes in detail -->

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
