### PR TITLE
fix: price comparisons not accounting for tx base gas & quote gas buffer

### DIFF
--- a/src/utils/price_comparison_utils.ts
+++ b/src/utils/price_comparison_utils.ts
@@ -131,8 +131,8 @@ function getPriceComparisonFromQuoteOrThrow(
             gas,
             unitTakerAmount,
             unitMakerAmount,
-            unitTakerAmountAfterGasCosts,
-            unitMakerAmountAfterGasCosts,
+            unitTakerAmountAfterGasCosts, // isSelling ? same : plus TX_BASE_GAS
+            unitMakerAmountAfterGasCosts, // isSelling ? minus TX_BASE_GAS : same
         };
     });
 
@@ -151,11 +151,9 @@ function getPriceComparisonFromQuoteOrThrow(
 
     // *** Calculate additional fields that we want to return *** //
 
-    // Remove gas estimate safety buffer that we add to to the quote
-    const estimatedGasWithoutBuffer = quote.estimatedGas.dividedBy(GAS_LIMIT_BUFFER_MULTIPLIER);
-
     // Calculate savings (Part 1): Cost of the quote including gas
-    const quoteGasCostInTokens = estimatedGasWithoutBuffer
+    const quoteGasCostInTokens = quote.estimatedGas
+        .dividedBy(GAS_LIMIT_BUFFER_MULTIPLIER) // Remove gas estimate safety buffer that we added to the quote
         .times(quote.gasPrice)
         .dividedBy(ethUnitAmount)
         .times(quoteTokenToEthRate);

--- a/test/price_comparison_utils_test.ts
+++ b/test/price_comparison_utils_test.ts
@@ -36,6 +36,10 @@ const daiWethQuoteBase = {
 
 describe(SUITE_NAME, () => {
     describe('getPriceComparisonFromQuote', () => {
+        const savingsInEthVsUniswapV1 = new BigNumber('-0.001263636363636364');
+        const savingsInEthVsUniswapV2 = new BigNumber('0.004736363636363636');
+        const savingsInEthVsKyber = new BigNumber('0.034736363636363636');
+
         it('returns comparison prices for quote reporter sources when quoting sellAmount', () => {
             const price = buyAmount.div(sellAmount).decimalPlaces(18);
 
@@ -64,10 +68,10 @@ describe(SUITE_NAME, () => {
                 {
                     name: ERC20BridgeSource.Uniswap,
                     price,
-                    gas: new BigNumber(90e3),
-                    savingsInEth: new BigNumber('-0.0046'),
                     sellAmount,
                     buyAmount,
+                    gas: new BigNumber(111e3),
+                    savingsInEth: savingsInEthVsUniswapV1,
                 },
 
                 // Kyber sample not found
@@ -106,10 +110,10 @@ describe(SUITE_NAME, () => {
                 {
                     name: ERC20BridgeSource.Uniswap,
                     price,
-                    gas: new BigNumber(90e3),
-                    savingsInEth: new BigNumber('-0.0046'),
                     sellAmount,
                     buyAmount,
+                    gas: new BigNumber(111e3),
+                    savingsInEth: savingsInEthVsUniswapV1,
                 },
 
                 // Balancer sample not found
@@ -158,10 +162,10 @@ describe(SUITE_NAME, () => {
                 {
                     name: ERC20BridgeSource.Uniswap,
                     price,
-                    gas: new BigNumber(90e3),
-                    savingsInEth: new BigNumber('-0.0046'),
                     sellAmount,
                     buyAmount,
+                    gas: new BigNumber(111e3),
+                    savingsInEth: savingsInEthVsUniswapV1,
                 },
 
                 // MStable placeholder instead of invalid 0 amount result
@@ -206,10 +210,10 @@ describe(SUITE_NAME, () => {
                 {
                     name: ERC20BridgeSource.Uniswap,
                     price,
-                    gas: new BigNumber(90e3),
-                    savingsInEth: new BigNumber('-0.0046'),
                     sellAmount,
                     buyAmount,
+                    gas: new BigNumber(111e3),
+                    savingsInEth: savingsInEthVsUniswapV1,
                 },
 
                 // MStable placeholder instead of invalid 0 amount result
@@ -259,10 +263,10 @@ describe(SUITE_NAME, () => {
                 {
                     name: ERC20BridgeSource.Kyber,
                     price: higherPrice,
-                    gas: new BigNumber(4.5e5),
-                    savingsInEth: new BigNumber(0.0314),
                     sellAmount,
                     buyAmount: higherBuyAmount,
+                    gas: new BigNumber(4.71e5),
+                    savingsInEth: savingsInEthVsKyber,
                 },
             ]);
         });
@@ -298,10 +302,10 @@ describe(SUITE_NAME, () => {
                 {
                     name: ERC20BridgeSource.Kyber,
                     price: lowerSellPrice,
-                    gas: new BigNumber(4.5e5),
-                    savingsInEth: new BigNumber(0.0314),
                     sellAmount: lowerSellAmount,
                     buyAmount,
+                    gas: new BigNumber(4.71e5),
+                    savingsInEth: savingsInEthVsKyber,
                 },
             ]);
         });
@@ -344,10 +348,10 @@ describe(SUITE_NAME, () => {
                 {
                     name: ERC20BridgeSource.Uniswap,
                     price,
-                    gas: new BigNumber(90e3),
-                    savingsInEth: new BigNumber('-0.0046'),
                     sellAmount: usdcAmount,
                     buyAmount: wethAmount,
+                    gas: new BigNumber(111e3),
+                    savingsInEth: savingsInEthVsUniswapV1,
                 },
             ]);
         });
@@ -386,10 +390,10 @@ describe(SUITE_NAME, () => {
                 {
                     name: ERC20BridgeSource.Uniswap,
                     price,
-                    gas: new BigNumber(90e3),
-                    savingsInEth: new BigNumber('-0.0046'),
                     sellAmount: usdcAmount,
                     buyAmount: wethAmount,
+                    gas: new BigNumber(111e3),
+                    savingsInEth: savingsInEthVsUniswapV1,
                 },
             ]);
         });
@@ -431,10 +435,10 @@ describe(SUITE_NAME, () => {
                 {
                     name: ERC20BridgeSource.Uniswap,
                     price,
-                    gas: new BigNumber(90e3),
-                    savingsInEth: new BigNumber('-0.0046'),
                     sellAmount: usdcAmount,
                     buyAmount: daiAmount,
+                    gas: new BigNumber(111e3),
+                    savingsInEth: savingsInEthVsUniswapV1,
                 },
             ]);
         });
@@ -481,10 +485,10 @@ describe(SUITE_NAME, () => {
                 {
                     name: ERC20BridgeSource.UniswapV2,
                     price,
-                    gas: new BigNumber(1.5e5),
-                    savingsInEth: new BigNumber('0.0014'),
                     buyAmount,
                     sellAmount,
+                    gas: new BigNumber(1.71e5),
+                    savingsInEth: savingsInEthVsUniswapV2,
                 },
             ]);
         });
@@ -536,10 +540,10 @@ describe(SUITE_NAME, () => {
                 {
                     name: ERC20BridgeSource.UniswapV2,
                     price,
-                    gas: new BigNumber(1.5e5),
-                    savingsInEth: new BigNumber('0.0014'),
                     buyAmount,
                     sellAmount,
+                    gas: new BigNumber(1.71e5),
+                    savingsInEth: savingsInEthVsUniswapV2,
                 },
             ]);
         });
@@ -581,10 +585,10 @@ describe(SUITE_NAME, () => {
                 {
                     name: ERC20BridgeSource.UniswapV2,
                     price,
-                    gas: new BigNumber(1.5e5),
-                    savingsInEth: new BigNumber('0.0014'),
                     buyAmount,
                     sellAmount,
+                    gas: new BigNumber(1.71e5),
+                    savingsInEth: savingsInEthVsUniswapV2,
                 },
             ]);
         });
@@ -622,10 +626,10 @@ describe(SUITE_NAME, () => {
                 {
                     name: ERC20BridgeSource.UniswapV2,
                     price,
-                    gas: new BigNumber(1.5e5),
-                    savingsInEth: new BigNumber('0.0014'),
                     buyAmount,
                     sellAmount,
+                    gas: new BigNumber(1.71e5),
+                    savingsInEth: savingsInEthVsUniswapV2,
                 },
             ]);
         });
@@ -668,7 +672,7 @@ describe(SUITE_NAME, () => {
                 {
                     name: ERC20BridgeSource.UniswapV2,
                     price,
-                    gas: new BigNumber(2e5),
+                    gas: new BigNumber(2.21e5),
                     savingsInEth: ZERO,
                     buyAmount: buyAmount.plus(1e18),
                     sellAmount,
@@ -710,7 +714,7 @@ describe(SUITE_NAME, () => {
                 {
                     name: ERC20BridgeSource.UniswapV2,
                     price,
-                    gas: new BigNumber(2e5),
+                    gas: new BigNumber(2.21e5),
                     savingsInEth: ZERO,
                     buyAmount,
                     sellAmount: sellAmount.minus(0.004e18),


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description
This fixes the issue with incorrect gas estimates in price comparisons. We should hold off with shipping this until we've figured how to migrate and correct the historical data we already have.

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
