### PR TITLE
refactor: rewrite _checkSubmissionMapReceiptsAndUpdateDbAsync without a nested for loop

### DIFF
--- a/src/entities/RfqmTransactionSubmissionEntity.ts
+++ b/src/entities/RfqmTransactionSubmissionEntity.ts
@@ -3,7 +3,7 @@ import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
 
 import { BigIntTransformer, BigNumberTransformer } from './transformers';
 
-export enum RfqmTranasctionSubmissionStatus {
+export enum RfqmTransactionSubmissionStatus {
     Submitted = 'submitted',
     Successful = 'successful',
     Reverted = 'reverted',
@@ -49,7 +49,7 @@ export class RfqmTransactionSubmissionEntity {
 
     @Index()
     @Column({ name: 'status', type: 'varchar' })
-    public status: RfqmTranasctionSubmissionStatus;
+    public status: RfqmTransactionSubmissionStatus;
 
     @Column({ name: 'status_reason', type: 'varchar', nullable: true })
     public statusReason: string | null;
@@ -70,7 +70,7 @@ export class RfqmTransactionSubmissionEntity {
         this.metadata = opts.metadata || null;
         this.nonce = opts.nonce || null;
         this.orderHash = opts.orderHash;
-        this.status = opts.status || RfqmTranasctionSubmissionStatus.Submitted;
+        this.status = opts.status || RfqmTransactionSubmissionStatus.Submitted;
         this.statusReason = opts.statusReason || null;
         this.to = opts.to || null;
         this.transactionHash = opts.transactionHash;

--- a/src/entities/RfqmTransactionSubmissionEntity.ts
+++ b/src/entities/RfqmTransactionSubmissionEntity.ts
@@ -8,6 +8,7 @@ export enum RfqmTranasctionSubmissionStatus {
     Successful = 'successful',
     Reverted = 'reverted',
     DroppedAndReplaced = 'droppedAndReplaced',
+    Confirmed = 'confirmed',
 }
 
 @Entity({ name: 'rfqm_transaction_submissions' })

--- a/src/entities/RfqmTransactionSubmissionEntity.ts
+++ b/src/entities/RfqmTransactionSubmissionEntity.ts
@@ -4,12 +4,12 @@ import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
 import { BigIntTransformer, BigNumberTransformer } from './transformers';
 
 export enum RfqmTransactionSubmissionStatus {
+    DroppedAndReplaced = 'dropped_and_replaced',
+    RevertedConfirmed = 'reverted_confirmed',
+    RevertedUnconfirmed = 'reverted_unconfirmed',
     Submitted = 'submitted',
-    Successful = 'successful',
-    Reverted = 'reverted',
-    DroppedAndReplaced = 'droppedAndReplaced',
-    ConfirmedSuccessful = 'confirmedSuccessful',
-    ConfirmedReverted = 'confirmedReverted',
+    SucceededConfirmed = 'succeeded_confirmed',
+    SucceededUnconfirmed = 'succeeded_unconfirmed',
 }
 
 @Entity({ name: 'rfqm_transaction_submissions' })

--- a/src/entities/RfqmTransactionSubmissionEntity.ts
+++ b/src/entities/RfqmTransactionSubmissionEntity.ts
@@ -8,7 +8,8 @@ export enum RfqmTranasctionSubmissionStatus {
     Successful = 'successful',
     Reverted = 'reverted',
     DroppedAndReplaced = 'droppedAndReplaced',
-    Confirmed = 'confirmed',
+    ConfirmedSuccessful = 'confirmedSuccessful',
+    ConfirmedReverted = 'confirmedReverted',
 }
 
 @Entity({ name: 'rfqm_transaction_submissions' })

--- a/src/services/rfqm_service.ts
+++ b/src/services/rfqm_service.ts
@@ -804,68 +804,76 @@ export class RfqmService {
                 };
             }),
         );
+        const minedReceipt = receipts.find((r) => r.response !== undefined);
 
-        for (const receipt of receipts) {
-            if (receipt.response !== undefined) {
-                isTxMined = true;
-                const currentBlock = await this._blockchainUtils.getCurrentBlockAsync();
-                if (currentBlock - receipt.response.blockNumber >= BLOCK_FINALITY_THRESHOLD) {
-                    isTxConfirmed = true;
-                }
-                // update all entities
-                // since the same nonce is being re-used, we expect only 1 defined receipt
-                for (const r of receipts) {
-                    if (r.response !== undefined) {
-                        if (r.response.status === 1) {
-                            const decodedLog = this._blockchainUtils.getDecodedRfqOrderFillEventLogFromLogs(
-                                r.response.logs,
-                            );
-                            jobStatus = isTxConfirmed
-                                ? RfqmJobStatus.SucceededConfirmed
-                                : RfqmJobStatus.SucceededUnconfirmed;
-                            submissionsMap[r.transactionHash].status = isTxConfirmed
-                                ? RfqmTransactionSubmissionStatus.SucceededConfirmed
-                                : RfqmTransactionSubmissionStatus.SucceededUnconfirmed;
-                            submissionsMap[r.transactionHash].metadata = {
-                                expectedTakerTokenFillAmount: expectedTakerTokenFillAmount.toString(),
-                                actualTakerFillAmount: decodedLog.args.takerTokenFilledAmount.toString(),
-                                decodedFillLog: JSON.stringify(decodedLog),
-                            };
-                        } else {
-                            jobStatus = isTxConfirmed
-                                ? RfqmJobStatus.FailedRevertedConfirmed
-                                : RfqmJobStatus.FailedRevertedUnconfirmed;
-                            submissionsMap[r.transactionHash].status = isTxConfirmed
-                                ? RfqmTransactionSubmissionStatus.RevertedConfirmed
-                                : RfqmTransactionSubmissionStatus.RevertedUnconfirmed;
-                            submissionsMap[r.transactionHash].metadata = null;
-                            submissionsMap[r.transactionHash].metadata = {
-                                expectedTakerTokenFillAmount: expectedTakerTokenFillAmount.toString(),
-                                actualTakerFillAmount: '0',
-                                decodedFillLog: '{}',
-                            };
-                        }
-                        submissionsMap[r.transactionHash].blockMined = new BigNumber(r.response.blockNumber);
-                        submissionsMap[r.transactionHash].gasUsed = new BigNumber(r.response.gasUsed);
-                        submissionsMap[r.transactionHash].updatedAt = new Date();
-                    } else {
-                        submissionsMap[r.transactionHash].status = RfqmTransactionSubmissionStatus.DroppedAndReplaced;
-                        submissionsMap[r.transactionHash].blockMined = null;
-                        submissionsMap[r.transactionHash].gasUsed = null;
-                        submissionsMap[r.transactionHash].updatedAt = new Date();
-                        submissionsMap[r.transactionHash].metadata = {
-                            expectedTakerTokenFillAmount: expectedTakerTokenFillAmount.toString(),
-                            actualTakerFillAmount: '0',
-                            decodedFillLog: '{}',
-                        };
-                    }
-                }
-                await this._dbUtils.updateRfqmTransactionSubmissionsAsync(Object.values(submissionsMap));
-                if (jobStatus !== null) {
-                    await this._dbUtils.updateRfqmJobAsync(orderHash, { status: jobStatus });
-                }
-                break;
+        // No txns mined, nothing to do
+        if (minedReceipt === undefined) {
+            return {
+                isTxMined,
+                isTxConfirmed,
+                submissionsMap,
+            };
+        }
+
+        // A txn was mined
+        isTxMined = true;
+        const currentBlock = await this._blockchainUtils.getCurrentBlockAsync();
+        if (currentBlock - minedReceipt.response!.blockNumber >= BLOCK_FINALITY_THRESHOLD) {
+            isTxConfirmed = true;
+        }
+
+        // Update the SubmissionMap for this mined txn
+        if (minedReceipt.response!.status === 1) {
+            // The txn succeeded
+            const decodedLog = this._blockchainUtils.getDecodedRfqOrderFillEventLogFromLogs(
+                minedReceipt.response!.logs,
+            );
+            jobStatus = isTxConfirmed ? RfqmJobStatus.SucceededConfirmed : RfqmJobStatus.SucceededUnconfirmed;
+            submissionsMap[minedReceipt.transactionHash].status = isTxConfirmed
+                ? RfqmTransactionSubmissionStatus.SucceededConfirmed
+                : RfqmTransactionSubmissionStatus.SucceededUnconfirmed;
+            submissionsMap[minedReceipt.transactionHash].metadata = {
+                expectedTakerTokenFillAmount: expectedTakerTokenFillAmount.toString(),
+                actualTakerFillAmount: decodedLog.args.takerTokenFilledAmount.toString(),
+                decodedFillLog: JSON.stringify(decodedLog),
+            };
+        } else {
+            // The txn failed
+            jobStatus = isTxConfirmed ? RfqmJobStatus.FailedRevertedConfirmed : RfqmJobStatus.FailedRevertedUnconfirmed;
+            submissionsMap[minedReceipt.transactionHash].status = isTxConfirmed
+                ? RfqmTransactionSubmissionStatus.RevertedConfirmed
+                : RfqmTransactionSubmissionStatus.RevertedUnconfirmed;
+            submissionsMap[minedReceipt.transactionHash].metadata = null;
+            submissionsMap[minedReceipt.transactionHash].metadata = {
+                expectedTakerTokenFillAmount: expectedTakerTokenFillAmount.toString(),
+                actualTakerFillAmount: '0',
+                decodedFillLog: '{}',
+            };
+        }
+
+        // Update the SubmissionMap for all others
+        for (const r of receipts) {
+            // Ignore the mined txn (already updated)
+            if (r.transactionHash === minedReceipt.transactionHash) {
+                continue;
             }
+
+            // The txn was replaced
+            submissionsMap[r.transactionHash].status = RfqmTransactionSubmissionStatus.DroppedAndReplaced;
+            submissionsMap[r.transactionHash].blockMined = null;
+            submissionsMap[r.transactionHash].gasUsed = null;
+            submissionsMap[r.transactionHash].updatedAt = new Date();
+            submissionsMap[r.transactionHash].metadata = {
+                expectedTakerTokenFillAmount: expectedTakerTokenFillAmount.toString(),
+                actualTakerFillAmount: '0',
+                decodedFillLog: '{}',
+            };
+        }
+
+        // Update the DB
+        await this._dbUtils.updateRfqmTransactionSubmissionsAsync(Object.values(submissionsMap));
+        if (jobStatus !== null) {
+            await this._dbUtils.updateRfqmJobAsync(orderHash, { status: jobStatus });
         }
 
         return {

--- a/src/services/rfqm_service.ts
+++ b/src/services/rfqm_service.ts
@@ -811,7 +811,7 @@ export class RfqmService {
                                 r.response.logs,
                             );
                             submissionsMap[r.transactionHash].status = isTxConfirmed
-                                ? RfqmTranasctionSubmissionStatus.Confirmed
+                                ? RfqmTranasctionSubmissionStatus.ConfirmedSuccessful
                                 : RfqmTranasctionSubmissionStatus.Successful;
                             submissionsMap[r.transactionHash].metadata = {
                                 expectedTakerTokenFillAmount: expectedTakerTokenFillAmount.toString(),
@@ -819,7 +819,9 @@ export class RfqmService {
                                 decodedFillLog: JSON.stringify(decodedLog),
                             };
                         } else {
-                            submissionsMap[r.transactionHash].status = RfqmTranasctionSubmissionStatus.Reverted;
+                            submissionsMap[r.transactionHash].status = isTxConfirmed
+                                ? RfqmTranasctionSubmissionStatus.ConfirmedReverted
+                                : RfqmTranasctionSubmissionStatus.Reverted;
                             submissionsMap[r.transactionHash].metadata = null;
                             submissionsMap[r.transactionHash].metadata = {
                                 expectedTakerTokenFillAmount: expectedTakerTokenFillAmount.toString(),

--- a/src/services/rfqm_service.ts
+++ b/src/services/rfqm_service.ts
@@ -199,9 +199,7 @@ export class RfqmService {
     /**
      * update RfqmJobStatus based on transaction status
      */
-    private static _getJobStatusFromSubmissions(
-        submissionsMap: SubmissionsMap,
-    ): {
+    private static _getJobStatusFromSubmissions(submissionsMap: SubmissionsMap): {
         status: RfqmJobStatus;
         statusReason: string | null;
     } {

--- a/test/rfqm_db_test.ts
+++ b/test/rfqm_db_test.ts
@@ -258,7 +258,7 @@ describe(SUITE_NAME, () => {
             const updatedAt = new Date();
             const newBlockMined = new BigNumber(5);
             const newGasUsed = new BigNumber('165000');
-            const newStatus = RfqmTransactionSubmissionStatus.Successful;
+            const newStatus = RfqmTransactionSubmissionStatus.SucceededUnconfirmed;
 
             initialEntity!.updatedAt = updatedAt;
             initialEntity!.blockMined = newBlockMined;

--- a/test/rfqm_db_test.ts
+++ b/test/rfqm_db_test.ts
@@ -8,7 +8,7 @@ import { Connection } from 'typeorm';
 import { getDBConnectionAsync } from '../src/db_connection';
 import { RfqmJobEntity, RfqmQuoteEntity, RfqmTransactionSubmissionEntity } from '../src/entities';
 import { RfqmJobStatus } from '../src/entities/RfqmJobEntity';
-import { RfqmTranasctionSubmissionStatus } from '../src/entities/RfqmTransactionSubmissionEntity';
+import { RfqmTransactionSubmissionStatus } from '../src/entities/RfqmTransactionSubmissionEntity';
 import { feeToStoredFee, RfqmDbUtils, v4RfqOrderToStoredOrder } from '../src/utils/rfqm_db_utils';
 
 import { setupDependenciesAsync, teardownDependenciesAsync } from './utils/deployment';
@@ -208,7 +208,7 @@ describe(SUITE_NAME, () => {
                 gasUsed,
                 blockMined,
                 nonce,
-                status: RfqmTranasctionSubmissionStatus.Submitted,
+                status: RfqmTransactionSubmissionStatus.Submitted,
                 statusReason: null,
             };
             const testEntity = new RfqmTransactionSubmissionEntity(rfqmTransactionSubmissionEntityOpts);
@@ -247,7 +247,7 @@ describe(SUITE_NAME, () => {
                 gasUsed,
                 blockMined,
                 nonce,
-                status: RfqmTranasctionSubmissionStatus.Submitted,
+                status: RfqmTransactionSubmissionStatus.Submitted,
                 statusReason: null,
             };
 
@@ -258,7 +258,7 @@ describe(SUITE_NAME, () => {
             const updatedAt = new Date();
             const newBlockMined = new BigNumber(5);
             const newGasUsed = new BigNumber('165000');
-            const newStatus = RfqmTranasctionSubmissionStatus.Successful;
+            const newStatus = RfqmTransactionSubmissionStatus.Successful;
 
             initialEntity!.updatedAt = updatedAt;
             initialEntity!.blockMined = newBlockMined;

--- a/test/rfqm_test.ts
+++ b/test/rfqm_test.ts
@@ -1061,7 +1061,7 @@ describe(SUITE_NAME, () => {
             expect(dbSubmissionEntity?.gasUsed).to.deep.equal(new BigNumber(GAS_ESTIMATE));
             expect(dbSubmissionEntity?.gasPrice).to.deep.equal(GAS_PRICE);
             expect(dbSubmissionEntity?.nonce).to.deep.equal(NONCE);
-            expect(dbSubmissionEntity?.status).to.deep.equal(RfqmTransactionSubmissionStatus.Successful);
+            expect(dbSubmissionEntity?.status).to.deep.equal(RfqmTransactionSubmissionStatus.ConfirmedSuccessful);
             expect(dbSubmissionEntity?.blockMined).to.deep.equal(new BigNumber(MINED_BLOCK));
             expect(dbSubmissionEntity?.to).to.deep.equal(MOCK_EXCHANGE_PROXY);
             expect(dbSubmissionEntity?.statusReason).to.deep.equal(null);

--- a/test/rfqm_test.ts
+++ b/test/rfqm_test.ts
@@ -1061,13 +1061,13 @@ describe(SUITE_NAME, () => {
             expect(dbSubmissionEntity?.gasUsed).to.deep.equal(new BigNumber(GAS_ESTIMATE));
             expect(dbSubmissionEntity?.gasPrice).to.deep.equal(GAS_PRICE);
             expect(dbSubmissionEntity?.nonce).to.deep.equal(NONCE);
-            expect(dbSubmissionEntity?.status).to.deep.equal(RfqmTransactionSubmissionStatus.ConfirmedSuccessful);
+            expect(dbSubmissionEntity?.status).to.deep.equal(RfqmTransactionSubmissionStatus.SucceededConfirmed);
             expect(dbSubmissionEntity?.blockMined).to.deep.equal(new BigNumber(MINED_BLOCK));
             expect(dbSubmissionEntity?.to).to.deep.equal(MOCK_EXCHANGE_PROXY);
             expect(dbSubmissionEntity?.statusReason).to.deep.equal(null);
         });
     });
-    describe('processJobAsync', async () => {
+    describe.only('processJobAsync', async () => {
         const feeAddress = randomAddress();
         const mockStoredFee: StoredFee = {
             token: feeAddress,
@@ -1144,7 +1144,7 @@ describe(SUITE_NAME, () => {
             expect(job?.status).to.eq(RfqmJobStatus.Successful);
 
             const submissions = await dbUtils.findRfqmTransactionSubmissionsByOrderHashAsync(orderHash);
-            expect(submissions[0].status).to.eq(RfqmTransactionSubmissionStatus.Successful);
+            expect(submissions[0].status).to.eq(RfqmTransactionSubmissionStatus.SucceededConfirmed);
 
             mockAxios.reset();
         });

--- a/test/rfqm_test.ts
+++ b/test/rfqm_test.ts
@@ -1046,7 +1046,13 @@ describe(SUITE_NAME, () => {
     describe('completeSubmissionLifecycleAsync', async () => {
         const callData = '0x123';
         const orderHash = '0xanOrderHash';
+
         it('should successfully process a transaction', async () => {
+            await dbUtils.writeRfqmJobToDbAsync({
+                ...MOCK_RFQM_JOB,
+                orderHash,
+                calldata: callData,
+            });
             await rfqmService.completeSubmissionLifecycleAsync(orderHash, WORKER_ADDRESS, callData);
 
             // find the saved results

--- a/test/rfqm_test.ts
+++ b/test/rfqm_test.ts
@@ -30,7 +30,7 @@ import { RFQM_PATH } from '../src/constants';
 import { getDBConnectionAsync } from '../src/db_connection';
 import { RfqmJobEntity, RfqmQuoteEntity, RfqmTransactionSubmissionEntity } from '../src/entities';
 import { RfqmJobStatus, RfqmOrderTypes, StoredFee, StoredOrder } from '../src/entities/RfqmJobEntity';
-import { RfqmTranasctionSubmissionStatus } from '../src/entities/RfqmTransactionSubmissionEntity';
+import { RfqmTransactionSubmissionStatus } from '../src/entities/RfqmTransactionSubmissionEntity';
 import { runHttpRfqmServiceAsync } from '../src/runners/http_rfqm_service_runner';
 import { BLOCK_FINALITY_THRESHOLD, RfqmService, RfqmTypes } from '../src/services/rfqm_service';
 import { ConfigManager } from '../src/utils/config_manager';
@@ -1061,7 +1061,7 @@ describe(SUITE_NAME, () => {
             expect(dbSubmissionEntity?.gasUsed).to.deep.equal(new BigNumber(GAS_ESTIMATE));
             expect(dbSubmissionEntity?.gasPrice).to.deep.equal(GAS_PRICE);
             expect(dbSubmissionEntity?.nonce).to.deep.equal(NONCE);
-            expect(dbSubmissionEntity?.status).to.deep.equal(RfqmTranasctionSubmissionStatus.Successful);
+            expect(dbSubmissionEntity?.status).to.deep.equal(RfqmTransactionSubmissionStatus.Successful);
             expect(dbSubmissionEntity?.blockMined).to.deep.equal(new BigNumber(MINED_BLOCK));
             expect(dbSubmissionEntity?.to).to.deep.equal(MOCK_EXCHANGE_PROXY);
             expect(dbSubmissionEntity?.statusReason).to.deep.equal(null);
@@ -1150,7 +1150,7 @@ describe(SUITE_NAME, () => {
             expect(job?.status).to.eq(RfqmJobStatus.Successful);
 
             const submissions = await dbUtils.findRfqmTransactionSubmissionsByOrderHashAsync(orderHash);
-            expect(submissions[0].status).to.eq(RfqmTranasctionSubmissionStatus.Successful);
+            expect(submissions[0].status).to.eq(RfqmTransactionSubmissionStatus.Successful);
 
             mockAxios.reset();
         });

--- a/test/rfqm_test.ts
+++ b/test/rfqm_test.ts
@@ -1066,7 +1066,7 @@ describe(SUITE_NAME, () => {
             expect(dbSubmissionEntity?.statusReason).to.deep.equal(null);
         });
     });
-    describe.only('processJobAsync', async () => {
+    describe('processJobAsync', async () => {
         const feeAddress = randomAddress();
         const mockStoredFee: StoredFee = {
             token: feeAddress,

--- a/test/services/rfqm_service_test.ts
+++ b/test/services/rfqm_service_test.ts
@@ -1176,13 +1176,13 @@ describe('RfqmService', () => {
                 createdAt: new Date(transaction1Time),
                 orderHash: '0x00',
                 transactionHash: '0x01',
-                status: RfqmTransactionSubmissionStatus.Reverted,
+                status: RfqmTransactionSubmissionStatus.RevertedUnconfirmed,
             });
             const submission2 = new RfqmTransactionSubmissionEntity({
                 createdAt: new Date(transaction2Time),
                 orderHash: '0x00',
                 transactionHash: '0x02',
-                status: RfqmTransactionSubmissionStatus.Successful,
+                status: RfqmTransactionSubmissionStatus.SucceededUnconfirmed,
             });
 
             const dbUtilsMock = mock(RfqmDbUtils);
@@ -1226,7 +1226,7 @@ describe('RfqmService', () => {
                 createdAt: new Date(transaction1Time),
                 orderHash: '0x00',
                 transactionHash: '0x01',
-                status: RfqmTransactionSubmissionStatus.Reverted,
+                status: RfqmTransactionSubmissionStatus.RevertedUnconfirmed,
             });
             const submission2 = new RfqmTransactionSubmissionEntity({
                 createdAt: new Date(transaction2Time),
@@ -1267,13 +1267,13 @@ describe('RfqmService', () => {
                 createdAt: new Date(transaction1Time),
                 orderHash: '0x00',
                 transactionHash: '0x01',
-                status: RfqmTransactionSubmissionStatus.Successful,
+                status: RfqmTransactionSubmissionStatus.SucceededUnconfirmed,
             });
             const submission2 = new RfqmTransactionSubmissionEntity({
                 createdAt: new Date(transaction2Time),
                 orderHash: '0x00',
                 transactionHash: '0x02',
-                status: RfqmTransactionSubmissionStatus.Successful,
+                status: RfqmTransactionSubmissionStatus.SucceededUnconfirmed,
             });
 
             const dbUtilsMock = mock(RfqmDbUtils);

--- a/test/services/rfqm_service_test.ts
+++ b/test/services/rfqm_service_test.ts
@@ -20,7 +20,7 @@ import { anything, instance, mock, when } from 'ts-mockito';
 import { ONE_MINUTE_MS } from '../../src/constants';
 import { RfqmJobEntity, RfqmTransactionSubmissionEntity } from '../../src/entities';
 import { RfqmJobStatus } from '../../src/entities/RfqmJobEntity';
-import { RfqmTranasctionSubmissionStatus } from '../../src/entities/RfqmTransactionSubmissionEntity';
+import { RfqmTransactionSubmissionStatus } from '../../src/entities/RfqmTransactionSubmissionEntity';
 import { RfqmService } from '../../src/services/rfqm_service';
 import { QuoteServerClient } from '../../src/utils/quote_server_client';
 import { RfqmDbUtils } from '../../src/utils/rfqm_db_utils';
@@ -1176,13 +1176,13 @@ describe('RfqmService', () => {
                 createdAt: new Date(transaction1Time),
                 orderHash: '0x00',
                 transactionHash: '0x01',
-                status: RfqmTranasctionSubmissionStatus.Reverted,
+                status: RfqmTransactionSubmissionStatus.Reverted,
             });
             const submission2 = new RfqmTransactionSubmissionEntity({
                 createdAt: new Date(transaction2Time),
                 orderHash: '0x00',
                 transactionHash: '0x02',
-                status: RfqmTranasctionSubmissionStatus.Successful,
+                status: RfqmTransactionSubmissionStatus.Successful,
             });
 
             const dbUtilsMock = mock(RfqmDbUtils);
@@ -1226,13 +1226,13 @@ describe('RfqmService', () => {
                 createdAt: new Date(transaction1Time),
                 orderHash: '0x00',
                 transactionHash: '0x01',
-                status: RfqmTranasctionSubmissionStatus.Reverted,
+                status: RfqmTransactionSubmissionStatus.Reverted,
             });
             const submission2 = new RfqmTransactionSubmissionEntity({
                 createdAt: new Date(transaction2Time),
                 orderHash: '0x00',
                 transactionHash: '0x02',
-                status: RfqmTranasctionSubmissionStatus.DroppedAndReplaced,
+                status: RfqmTransactionSubmissionStatus.DroppedAndReplaced,
             });
 
             const dbUtilsMock = mock(RfqmDbUtils);
@@ -1267,13 +1267,13 @@ describe('RfqmService', () => {
                 createdAt: new Date(transaction1Time),
                 orderHash: '0x00',
                 transactionHash: '0x01',
-                status: RfqmTranasctionSubmissionStatus.Successful,
+                status: RfqmTransactionSubmissionStatus.Successful,
             });
             const submission2 = new RfqmTransactionSubmissionEntity({
                 createdAt: new Date(transaction2Time),
                 orderHash: '0x00',
                 transactionHash: '0x02',
-                status: RfqmTranasctionSubmissionStatus.Successful,
+                status: RfqmTransactionSubmissionStatus.Successful,
             });
 
             const dbUtilsMock = mock(RfqmDbUtils);

--- a/test/services/rfqm_service_test.ts
+++ b/test/services/rfqm_service_test.ts
@@ -1226,13 +1226,13 @@ describe('RfqmService', () => {
                 createdAt: new Date(transaction1Time),
                 orderHash: '0x00',
                 transactionHash: '0x01',
-                status: RfqmTranasctionSubmissionStatus.RevertedConfirmed,
+                status: RfqmTransactionSubmissionStatus.RevertedConfirmed,
             });
             const submission2 = new RfqmTransactionSubmissionEntity({
                 createdAt: new Date(transaction2Time),
                 orderHash: '0x00',
                 transactionHash: '0x02',
-                status: RfqmTranasctionSubmissionStatus.SucceededConfirmed,
+                status: RfqmTransactionSubmissionStatus.SucceededConfirmed,
             });
 
             const dbUtilsMock = mock(RfqmDbUtils);

--- a/test/services/rfqm_service_test.ts
+++ b/test/services/rfqm_service_test.ts
@@ -1226,13 +1226,13 @@ describe('RfqmService', () => {
                 createdAt: new Date(transaction1Time),
                 orderHash: '0x00',
                 transactionHash: '0x01',
-                status: RfqmTranasctionSubmissionStatus.Reverted,
+                status: RfqmTranasctionSubmissionStatus.RevertedConfirmed,
             });
             const submission2 = new RfqmTransactionSubmissionEntity({
                 createdAt: new Date(transaction2Time),
                 orderHash: '0x00',
                 transactionHash: '0x02',
-                status: RfqmTranasctionSubmissionStatus.Successful,
+                status: RfqmTranasctionSubmissionStatus.SucceededConfirmed,
             });
 
             const dbUtilsMock = mock(RfqmDbUtils);


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

Small refactor to make this function slightly more readable. The goal was to remove the double for loop so the reader doesn't have to think about iteration

<!--- Describe your changes in detail -->

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
