### PR TITLE
feat: return a liquidityAvailable flag on rfqm /price and /quote endpoints

### DIFF
--- a/src/handlers/rfqm_handlers.ts
+++ b/src/handlers/rfqm_handlers.ts
@@ -103,7 +103,7 @@ export class RfqmHandlers {
         // Result
         res.status(HttpStatus.OK).send({
             liquidityAvailable: indicativeQuote !== null,
-            ...indicativeQuote
+            ...indicativeQuote,
         });
     }
 
@@ -132,7 +132,7 @@ export class RfqmHandlers {
         // Result
         res.status(HttpStatus.OK).send({
             liquidityAvailable: firmQuote !== null,
-            ...firmQuote
+            ...firmQuote,
         });
     }
 

--- a/src/handlers/rfqm_handlers.ts
+++ b/src/handlers/rfqm_handlers.ts
@@ -3,7 +3,6 @@ import {
     InternalServerError,
     InvalidAPIKeyError,
     isAPIError,
-    NotFoundError,
     NotImplementedError,
     ValidationError,
     ValidationErrorCodes,
@@ -96,14 +95,16 @@ export class RfqmHandlers {
             throw new InternalServerError('Unexpected error encountered');
         }
 
-        // Handle no quote returned
+        // Log no quote returned
         if (indicativeQuote === null) {
             RFQM_INDICATIVE_QUOTE_NOT_FOUND.labels(apiKeyLabel).inc();
-            throw new NotFoundError('Unable to retrieve a price');
         }
 
         // Result
-        res.status(HttpStatus.OK).send(indicativeQuote);
+        res.status(HttpStatus.OK).send({
+            liquidityAvailable: indicativeQuote !== null,
+            ...indicativeQuote
+        });
     }
 
     public async getFirmQuoteAsync(req: express.Request, res: express.Response): Promise<void> {
@@ -123,14 +124,16 @@ export class RfqmHandlers {
             throw new InternalServerError('Unexpected error encountered');
         }
 
-        // Handle no quote returned
+        // Log no quote returned
         if (firmQuote === null) {
             RFQM_FIRM_QUOTE_NOT_FOUND.labels(apiKeyLabel).inc();
-            throw new NotFoundError('Unable to retrieve a quote');
         }
 
         // Result
-        res.status(HttpStatus.OK).send(firmQuote);
+        res.status(HttpStatus.OK).send({
+            liquidityAvailable: firmQuote !== null,
+            ...firmQuote
+        });
     }
 
     public async getHealthAsync(req: express.Request, res: express.Response): Promise<void> {

--- a/test/rfqm_test.ts
+++ b/test/rfqm_test.ts
@@ -441,7 +441,7 @@ describe(SUITE_NAME, () => {
             );
         });
 
-        it('should return a 404 NOT FOUND Error if no valid quotes found', async () => {
+        it('should return a 200 OK, liquidityAvailable === false if no valid quotes found', async () => {
             const sellAmount = 100000000000000000;
             const quotedAmount = 200000000000000000;
             const params = new URLSearchParams({
@@ -499,10 +499,11 @@ describe(SUITE_NAME, () => {
                     const appResponse = await request(app)
                         .get(`${RFQM_PATH}/price?${params.toString()}`)
                         .set('0x-api-key', API_KEY)
-                        .expect(HttpStatus.NOT_FOUND)
+                        .expect(HttpStatus.OK)
                         .expect('Content-Type', /json/);
 
-                    expect(appResponse.body.reason).to.equal('Not Found');
+                    expect(appResponse.body.liquidityAvailable).to.equal(false);
+                    expect(appResponse.body.price).to.equal(undefined);
                 },
                 axiosClient,
             );
@@ -766,7 +767,7 @@ describe(SUITE_NAME, () => {
             );
         });
 
-        it('should return a 404 NOT FOUND if no valid firm quotes found', async () => {
+        it('should return a 200 OK, liquidityAvailable === false if no valid firm quotes found', async () => {
             const sellAmount = 100000000000000000;
             const insufficientSellAmount = 1;
 
@@ -848,10 +849,11 @@ describe(SUITE_NAME, () => {
                     const appResponse = await request(app)
                         .get(`${RFQM_PATH}/quote?${params.toString()}`)
                         .set('0x-api-key', API_KEY)
-                        .expect(HttpStatus.NOT_FOUND)
+                        .expect(HttpStatus.OK)
                         .expect('Content-Type', /json/);
 
-                    expect(appResponse.body.reason).to.equal('Not Found');
+                    expect(appResponse.body.liquidityAvailable).to.equal(false);
+                    expect(appResponse.body.price).to.equal(undefined);
                 },
                 axiosClient,
             );


### PR DESCRIPTION
Right now, returning a 404 if liquidity is unavailable. Change this to a boolean value `liquidityAvailable`

<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

<!--- Describe your changes in detail -->

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

Tests updated

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
