### PR TITLE
feat: add affiliateAddress to rfqm calldata

### DIFF
--- a/migrations/1625865121323-AddRfqmAffiliateAddressField.ts
+++ b/migrations/1625865121323-AddRfqmAffiliateAddressField.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+const AffiliateAddressColumn = new TableColumn({
+    name: 'affiliate_address',
+    type: 'varchar',
+    isNullable: true,
+});
+
+export class AddRfqmAffiliateAddressField1625865121323 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn('rfqm_quotes', AffiliateAddressColumn);
+        await queryRunner.addColumn('rfqm_jobs', AffiliateAddressColumn);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn('rfqm_quotes', AffiliateAddressColumn);
+        await queryRunner.dropColumn('rfqm_jobs', AffiliateAddressColumn);
+    }
+}

--- a/src/entities/RfqmJobEntity.ts
+++ b/src/entities/RfqmJobEntity.ts
@@ -133,6 +133,9 @@ export class RfqmJobEntity {
     @Column({ name: 'last_look_result', type: 'boolean', nullable: true })
     public lastLookResult: boolean | null;
 
+    @Column({ name: 'affiliate_address', type: 'varchar', nullable: true })
+    public affiliateAddress: string | null;
+
     // TypeORM runs a validation check where it calls this initializer with no argument.
     // With no default `opts`, `opts` will be undefined and the validation will throw,
     // therefore, add this hacky default.
@@ -143,6 +146,7 @@ export class RfqmJobEntity {
             this.createdAt = opts.createdAt;
         }
 
+        this.affiliateAddress = opts.affiliateAddress || null;
         this.calldata = opts.calldata;
         this.chainId = opts.chainId;
         this.expiry = opts.expiry;

--- a/src/entities/RfqmQuoteEntity.ts
+++ b/src/entities/RfqmQuoteEntity.ts
@@ -32,6 +32,9 @@ export class RfqmQuoteEntity {
     @Column({ name: 'order', type: 'jsonb', nullable: true })
     public order: StoredOrder | null;
 
+    @Column({ name: 'affiliate_address', type: 'varchar', nullable: true })
+    public affiliateAddress: string | null;
+
     // tslint:disable-next-line no-object-literal-type-assertion
     constructor(opts: RfqmQuoteConstructorOpts = {} as RfqmQuoteConstructorOpts) {
         // allow createdAt overrides for testing
@@ -39,6 +42,7 @@ export class RfqmQuoteEntity {
             this.createdAt = opts.createdAt;
         }
 
+        this.affiliateAddress = opts.affiliateAddress || null;
         this.chainId = opts.chainId;
         this.fee = opts.fee || null;
         this.integratorId = opts.integratorId || null;

--- a/src/handlers/rfqm_handlers.ts
+++ b/src/handlers/rfqm_handlers.ts
@@ -242,7 +242,7 @@ export class RfqmHandlers {
         const apiKey = this._validateAndReturnApiKey(req.header('0x-api-key'));
 
         // Parse string params
-        const { takerAddress } = req.query;
+        const { takerAddress, affiliateAddress } = req.query;
 
         // Parse tokens
         const sellTokenRaw = req.query.sellToken as string;
@@ -270,6 +270,7 @@ export class RfqmHandlers {
             sellToken,
             sellTokenDecimals,
             takerAddress: takerAddress as string,
+            affiliateAddress: affiliateAddress as string,
         };
     }
 

--- a/src/services/rfqm_service.ts
+++ b/src/services/rfqm_service.ts
@@ -57,6 +57,7 @@ export interface FetchIndicativeQuoteParams {
     sellToken: string;
     sellTokenDecimals: number;
     takerAddress?: string;
+    affiliateAddress?: string;
 }
 
 export interface FetchIndicativeQuoteResponse {
@@ -78,6 +79,7 @@ export interface FetchFirmQuoteParams {
     sellToken: string;
     sellTokenDecimals: number;
     takerAddress: string;
+    affiliateAddress?: string;
 }
 
 export interface BaseRfqmQuoteResponse {
@@ -381,6 +383,7 @@ export class RfqmService {
             buyTokenDecimals: makerTokenDecimals,
             apiKey,
             takerAddress,
+            affiliateAddress,
         } = params;
 
         // Quote Requestor specific params
@@ -495,6 +498,7 @@ export class RfqmService {
                 fee: feeToStoredFee(fee),
                 order: v4RfqOrderToStoredOrder(rfqOrder),
                 makerUri,
+                affiliateAddress,
             }),
         );
         RFQM_QUOTE_INSERTED.labels(apiKey, makerUri).inc();
@@ -703,12 +707,17 @@ export class RfqmService {
             makerUri: quote.makerUri,
             status: RfqmJobStatus.PendingEnqueued,
             statusReason: null,
-            calldata: this._blockchainUtils.generateMetaTransactionCallData(params.metaTransaction, params.signature),
+            calldata: this._blockchainUtils.generateMetaTransactionCallData(
+                params.metaTransaction,
+                params.signature,
+                quote.affiliateAddress === null ? undefined : quote.affiliateAddress,
+            ),
             fee: quote.fee,
             order: quote.order,
             metadata: {
                 metaTransaction: params.metaTransaction,
             },
+            affiliateAddress: quote.affiliateAddress,
         };
 
         // this insert will fail if a job has already been created, ensuring

--- a/src/utils/rfq_blockchain_utils.ts
+++ b/src/utils/rfq_blockchain_utils.ts
@@ -12,6 +12,7 @@ import { logger } from '../logger';
 import { ChainId } from '../types';
 
 import { isWorkerReadyAndAbleAsync } from './rfqm_worker_balance_utils';
+import { serviceUtils } from './service_utils';
 import { SubproviderAdapter } from './subprovider_adapter';
 
 // allow a wide range for gas price for flexibility
@@ -152,8 +153,13 @@ export class RfqBlockchainUtils {
         }
     }
 
-    public generateMetaTransactionCallData(metaTx: MetaTransaction, metaTxSig: Signature): string {
-        return this._exchangeProxy.executeMetaTransaction(metaTx, metaTxSig).getABIEncodedTransactionData();
+    public generateMetaTransactionCallData(
+        metaTx: MetaTransaction,
+        metaTxSig: Signature,
+        affiliateAddress?: string,
+    ): string {
+        const callData = this._exchangeProxy.executeMetaTransaction(metaTx, metaTxSig).getABIEncodedTransactionData();
+        return serviceUtils.attributeCallData(callData, affiliateAddress).affiliatedData;
     }
 
     public async getNonceAsync(workerAddress: string): Promise<number> {

--- a/test/rfq_blockchain_utils_test.ts
+++ b/test/rfq_blockchain_utils_test.ts
@@ -11,7 +11,12 @@ import { PROTOCOL_FEE_MULTIPLIER } from '../src/config';
 import { ChainId } from '../src/types';
 import { RfqBlockchainUtils } from '../src/utils/rfq_blockchain_utils';
 
-import { getProvider, TEST_RFQ_ORDER_FILLED_EVENT_LOG, TEST_RFQ_ORDER_FILLED_EVENT_TAKER_AMOUNT } from './constants';
+import {
+    getProvider,
+    MATCHA_AFFILIATE_ADDRESS,
+    TEST_RFQ_ORDER_FILLED_EVENT_LOG,
+    TEST_RFQ_ORDER_FILLED_EVENT_TAKER_AMOUNT,
+} from './constants';
 import { setupDependenciesAsync, teardownDependenciesAsync } from './utils/deployment';
 
 const SUITE_NAME = 'RFQ Blockchain Utils Test';
@@ -167,7 +172,11 @@ describe(SUITE_NAME, () => {
             const metaTx = rfqBlockchainUtils.generateMetaTransaction(rfqOrder, orderSig, taker, takerAmount, CHAIN_ID);
             const metaTxSig = await metaTx.getSignatureWithProviderAsync(provider);
 
-            const callData = rfqBlockchainUtils.generateMetaTransactionCallData(metaTx, metaTxSig);
+            const callData = rfqBlockchainUtils.generateMetaTransactionCallData(
+                metaTx,
+                metaTxSig,
+                MATCHA_AFFILIATE_ADDRESS,
+            );
             expect(
                 await rfqBlockchainUtils.decodeMetaTransactionCallDataAndValidateAsync(callData, txOrigin),
             ).to.deep.eq([takerAmount, makerAmount]);
@@ -176,7 +185,11 @@ describe(SUITE_NAME, () => {
             const metaTx = rfqBlockchainUtils.generateMetaTransaction(rfqOrder, orderSig, taker, takerAmount, CHAIN_ID);
             const invalidMetaTxSig = orderSig;
 
-            const callData = rfqBlockchainUtils.generateMetaTransactionCallData(metaTx, invalidMetaTxSig);
+            const callData = rfqBlockchainUtils.generateMetaTransactionCallData(
+                metaTx,
+                invalidMetaTxSig,
+                MATCHA_AFFILIATE_ADDRESS,
+            );
 
             try {
                 await rfqBlockchainUtils.decodeMetaTransactionCallDataAndValidateAsync(callData, txOrigin);
@@ -195,7 +208,11 @@ describe(SUITE_NAME, () => {
             );
             const metaTxSig = await metaTx.getSignatureWithProviderAsync(provider);
 
-            const callData = rfqBlockchainUtils.generateMetaTransactionCallData(metaTx, metaTxSig);
+            const callData = rfqBlockchainUtils.generateMetaTransactionCallData(
+                metaTx,
+                metaTxSig,
+                MATCHA_AFFILIATE_ADDRESS,
+            );
 
             try {
                 await rfqBlockchainUtils.decodeMetaTransactionCallDataAndValidateAsync(callData, txOrigin);
@@ -240,7 +257,11 @@ describe(SUITE_NAME, () => {
             const metaTx = rfqBlockchainUtils.generateMetaTransaction(rfqOrder, orderSig, taker, takerAmount, CHAIN_ID);
             const metaTxSig = await metaTx.getSignatureWithProviderAsync(provider);
 
-            const callData = rfqBlockchainUtils.generateMetaTransactionCallData(metaTx, metaTxSig);
+            const callData = rfqBlockchainUtils.generateMetaTransactionCallData(
+                metaTx,
+                metaTxSig,
+                MATCHA_AFFILIATE_ADDRESS,
+            );
 
             const txHash = await rfqBlockchainUtils.submitCallDataToExchangeProxyAsync(callData, txOrigin, {
                 gasPrice: 1e9,
@@ -256,7 +277,11 @@ describe(SUITE_NAME, () => {
             const metaTx = rfqBlockchainUtils.generateMetaTransaction(rfqOrder, orderSig, taker, takerAmount, CHAIN_ID);
             const metaTxSig = await metaTx.getSignatureWithProviderAsync(provider);
 
-            const callData = rfqBlockchainUtils.generateMetaTransactionCallData(metaTx, metaTxSig);
+            const callData = rfqBlockchainUtils.generateMetaTransactionCallData(
+                metaTx,
+                metaTxSig,
+                MATCHA_AFFILIATE_ADDRESS,
+            );
 
             const expectedTakerTokenFillAmount = rfqBlockchainUtils.getTakerTokenFillAmountFromMetaTxCallData(callData);
             expect(expectedTakerTokenFillAmount).to.deep.eq(takerAmount);

--- a/test/rfqm_db_test.ts
+++ b/test/rfqm_db_test.ts
@@ -11,6 +11,7 @@ import { RfqmJobStatus } from '../src/entities/RfqmJobEntity';
 import { RfqmTransactionSubmissionStatus } from '../src/entities/RfqmTransactionSubmissionEntity';
 import { feeToStoredFee, RfqmDbUtils, v4RfqOrderToStoredOrder } from '../src/utils/rfqm_db_utils';
 
+import { MATCHA_AFFILIATE_ADDRESS } from './constants';
 import { setupDependenciesAsync, teardownDependenciesAsync } from './utils/deployment';
 
 // Force reload of the app avoid variables being polluted between test suites
@@ -116,6 +117,7 @@ describe(SUITE_NAME, () => {
                 makerUri,
                 fee: feeToStoredFee(fee),
                 order: v4RfqOrderToStoredOrder(order),
+                affiliateAddress: MATCHA_AFFILIATE_ADDRESS,
             });
 
             const quoteRepository = connection.getRepository(RfqmQuoteEntity);
@@ -139,6 +141,7 @@ describe(SUITE_NAME, () => {
                 calldata,
                 fee: feeToStoredFee(fee),
                 order: v4RfqOrderToStoredOrder(order),
+                affiliateAddress: MATCHA_AFFILIATE_ADDRESS,
             };
 
             const testRfqmJobEntity = new RfqmJobEntity(rfqmJobOpts);
@@ -164,6 +167,7 @@ describe(SUITE_NAME, () => {
                 calldata,
                 fee: feeToStoredFee(fee),
                 order: v4RfqOrderToStoredOrder(order),
+                affiliateAddress: MATCHA_AFFILIATE_ADDRESS,
             };
             await dbUtils.writeRfqmJobToDbAsync(rfqmJobOpts);
 

--- a/test/rfqm_test.ts
+++ b/test/rfqm_test.ts
@@ -42,6 +42,7 @@ import {
     CHAIN_ID,
     CONTRACT_ADDRESSES,
     getProvider,
+    MATCHA_AFFILIATE_ADDRESS,
     NULL_ADDRESS,
     TEST_DECODED_RFQ_ORDER_FILLED_EVENT_LOG,
     TEST_RFQ_ORDER_FILLED_EVENT_LOG,
@@ -138,6 +139,7 @@ const MOCK_RFQM_JOB: RfqmJobEntity = {
     isCompleted: false,
     workerAddress: null,
     lastLookResult: null,
+    affiliateAddress: MATCHA_AFFILIATE_ADDRESS,
 };
 
 describe(SUITE_NAME, () => {
@@ -189,10 +191,7 @@ describe(SUITE_NAME, () => {
         when(
             rfqBlockchainUtilsMock.generateMetaTransaction(anything(), anything(), anything(), anything(), anything()),
         ).thenCall((_rfqOrder, _signature, _taker, _takerAmount, chainId) => new MetaTransaction({ chainId }));
-        when(rfqBlockchainUtilsMock.generateMetaTransactionCallData(anything(), anything())).thenReturn(
-            MOCK_META_TX_CALL_DATA,
-        );
-        when(rfqBlockchainUtilsMock.generateMetaTransactionCallData(anything(), anything())).thenReturn(
+        when(rfqBlockchainUtilsMock.generateMetaTransactionCallData(anything(), anything(), anything())).thenReturn(
             MOCK_META_TX_CALL_DATA,
         );
         when(
@@ -694,6 +693,7 @@ describe(SUITE_NAME, () => {
                 takerAddress,
                 intentOnFilling: 'false',
                 skipValidation: 'true',
+                affiliateAddress: MATCHA_AFFILIATE_ADDRESS,
             });
 
             const expectedPrice = '2';
@@ -766,6 +766,7 @@ describe(SUITE_NAME, () => {
                     expect(repositoryResponse).to.not.be.null();
                     expect(repositoryResponse?.orderHash).to.equal(appResponse.body.orderHash);
                     expect(repositoryResponse?.makerUri).to.equal(MARKET_MAKER_1);
+                    expect(repositoryResponse?.affiliateAddress).to.equal(MATCHA_AFFILIATE_ADDRESS);
                 },
                 axiosClient,
             );
@@ -940,6 +941,7 @@ describe(SUITE_NAME, () => {
                 fee: mockStoredFee,
                 order: mockStoredOrder,
                 chainId: 1337,
+                affiliateAddress: MATCHA_AFFILIATE_ADDRESS,
             });
 
             // write a corresponding quote entity to validate against
@@ -961,6 +963,7 @@ describe(SUITE_NAME, () => {
             expect(dbJobEntity).to.not.be.null();
             expect(dbJobEntity?.orderHash).to.equal(mockQuote.orderHash);
             expect(dbJobEntity?.makerUri).to.equal(MARKET_MAKER_1);
+            expect(dbJobEntity?.affiliateAddress).to.equal(MATCHA_AFFILIATE_ADDRESS);
         });
         it('should return status 404 not found if there is not a pre-existing quote', async () => {
             const mockMetaTx = createMockMetaTx();
@@ -1145,6 +1148,7 @@ describe(SUITE_NAME, () => {
                 },
             },
             chainId: 1337,
+            affiliateAddress: MATCHA_AFFILIATE_ADDRESS,
         });
         const mmResponse = {
             fee: mockStoredFee,


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

The goal is to make RFQM calldata consistent with 0x API calldata by encoding 'affiliate data' into the transaction data.

<!--- Describe your changes in detail -->

# Testing Instructions

There are existing tests for RFQ blockchain utils and the serviceUtils.attributeCallData().

Integration tests are modified to test that the affiliate address is properly saved in the database.

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
