### PR TITLE
fix: Send integrator IDs for /swap/rfq/registry

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -242,6 +242,7 @@ export const RFQT_REGISTRY_PASSWORDS: string[] = _.isEmpty(process.env.RFQT_REGI
     ? []
     : assertEnvVarType('RFQT_REGISTRY_PASSWORDS', process.env.RFQT_REGISTRY_PASSWORDS, EnvVarType.JsonStringList);
 
+export const RFQT_INTEGRATOR_IDS: string[] = INTEGRATORS_ACL.filter((i) => i.rfqt).map((i) => i.integratorId);
 export const RFQT_API_KEY_WHITELIST: string[] = getApiKeyWhitelistFromIntegratorsAcl('rfqt');
 export const RFQM_API_KEY_WHITELIST: Set<string> = new Set(getApiKeyWhitelistFromIntegratorsAcl('rfqm'));
 export const PLP_API_KEY_WHITELIST: string[] = getApiKeyWhitelistFromIntegratorsAcl('plp');

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -26,6 +26,7 @@ import {
     NATIVE_WRAPPED_TOKEN_SYMBOL,
     PLP_API_KEY_WHITELIST,
     RFQT_API_KEY_WHITELIST,
+    RFQT_INTEGRATOR_IDS,
     RFQT_REGISTRY_PASSWORDS,
 } from '../config';
 import {
@@ -99,7 +100,7 @@ export class SwapHandlers {
         if (!REGISTRY_SET.has(authToken)) {
             return res.status(HttpStatus.UNAUTHORIZED).end();
         }
-        res.status(HttpStatus.OK).send(RFQT_API_KEY_WHITELIST).end();
+        res.status(HttpStatus.OK).send(RFQT_INTEGRATOR_IDS).end();
     }
 
     constructor(swapService: SwapService) {

--- a/test/config_test.ts
+++ b/test/config_test.ts
@@ -1,7 +1,7 @@
 import { expect } from '@0x/contracts-test-utils';
 import 'mocha';
 
-import { getApiKeyWhitelistFromIntegratorsAcl, getIntegratorIdForApiKey } from '../src/config';
+import { getApiKeyWhitelistFromIntegratorsAcl, getIntegratorIdForApiKey, RFQT_INTEGRATOR_IDS } from '../src/config';
 
 /**
  * Configuration tests which run against the config in `test_env` file.
@@ -11,7 +11,7 @@ describe('Config', () => {
         it('gets the integrator ID for an api key', () => {
             const id = getIntegratorIdForApiKey('test-api-key-1');
 
-            expect(id).to.equal('test-integrator-id');
+            expect(id).to.equal('test-integrator-id-1');
         });
 
         it('returns `undefined` for non-existent api keys', () => {
@@ -30,13 +30,18 @@ describe('Config', () => {
             expect(rfqtKeys[1]).to.eql('test-api-key-2');
 
             const rfqmKeys = getApiKeyWhitelistFromIntegratorsAcl('rfqm');
-            expect(rfqmKeys.length).to.eql(2);
+            expect(rfqmKeys.length).to.eql(3); // tslint:disable-line: custom-no-magic-numbers
             expect(rfqmKeys[0]).to.eql('test-api-key-1');
             expect(rfqmKeys[1]).to.eql('test-api-key-2');
+            expect(rfqmKeys[2]).to.eql('test-api-key-3');
         });
-        it("doesn't add disallowed liquidity sources", () => {
+        it("doesn't add disallowed liquidity sources to allowed API keys", () => {
             const plpKeys = getApiKeyWhitelistFromIntegratorsAcl('plp');
             expect(plpKeys.length).to.equal(0);
+        });
+        it('creates the RFQt Integrator ID list (used in swap/rfq/registry)', () => {
+            expect(RFQT_INTEGRATOR_IDS.length).to.equal(1);
+            expect(RFQT_INTEGRATOR_IDS[0]).to.equal('test-integrator-id-1');
         });
     });
 });

--- a/test/test_env
+++ b/test/test_env
@@ -14,4 +14,4 @@ ALT_RFQ_MM_PROFILE=acoolprofile
 MESH_WEBSOCKET_URI=ws://localhost:60557
 MESH_HTTP_URI=ws://localhost:60557
 ETH_GAS_STATION_API_URL=https://gas.api.0x.org/source/median?output=eth_gas_station
-INTEGRATORS_ACL='[{"integratorId":"test-integrator-id","label":"Test Integrator","rfqt":true,"rfqm":true,"plp":false,"apiKeys":["test-api-key-1","test-api-key-2"]}]'
+INTEGRATORS_ACL='[{"integratorId":"test-integrator-id-1","label":"Test Integrator 1","rfqt":true,"rfqm":true,"plp":false,"apiKeys":["test-api-key-1","test-api-key-2"]},{"integratorId":"test-integrator-id-2","label":"Test Integrator 2","rfqt":false,"rfqm":true,"plp":false,"apiKeys":["test-api-key-3"]}]'


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description
Send the integrator IDs instead of API keys when `/swap/rfq/registry` is queried.

<!--- Describe your changes in detail -->

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->
`yarn test` it out

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
