### PR TITLE
chore: Enable Prometheus metrics on RPC subprovider

### DIFF
--- a/src/rpc_subprovider.ts
+++ b/src/rpc_subprovider.ts
@@ -6,10 +6,36 @@ import * as http from 'http';
 import * as https from 'https';
 import JsonRpcError = require('json-rpc-error');
 import fetch, { Headers, Response } from 'node-fetch';
+import { Counter, Summary } from 'prom-client';
 
 const httpAgent = new http.Agent({ keepAlive: true });
 const httpsAgent = new https.Agent({ keepAlive: true });
 const agent = (_parsedURL: any) => (_parsedURL.protocol === 'http:' ? httpAgent : httpsAgent);
+
+const ETH_RPC_RESPONSE_TIME = new Summary({
+    name: 'eth_rpc_response_time',
+    help: 'The response time of an RPC request',
+    labelNames: ['method'],
+    percentiles: [0.01, 0.1, 0.5, 0.75, 0.9, 0.95, 0.98, 0.99],
+});
+
+const ETH_RPC_REQUESTS = new Counter({
+    name: 'eth_rpc_requests',
+    help: 'The count of RPC requests',
+    labelNames: ['method'],
+});
+
+const ETH_RPC_REQUEST_SUCCESS = new Counter({
+    name: 'eth_rpc_request_success',
+    help: 'The count of successful RPC requests',
+    labelNames: ['method'],
+});
+
+const ETH_RPC_REQUEST_ERROR = new Counter({
+    name: 'eth_rpc_request_error',
+    help: 'The count of RPC request errors',
+    labelNames: ['method'],
+});
 
 /**
  * This class implements the [web3-provider-engine](https://github.com/MetaMask/provider-engine) subprovider interface.
@@ -47,6 +73,9 @@ export class RPCSubprovider extends Subprovider {
             'Content-Type': 'application/json',
         });
 
+        ETH_RPC_REQUESTS.labels(finalPayload.method!).inc();
+        const begin = Date.now();
+
         let response: Response;
         const rpcUrl = this._rpcUrls[Math.floor(Math.random() * this._rpcUrls.length)];
         try {
@@ -59,12 +88,17 @@ export class RPCSubprovider extends Subprovider {
                 agent,
             });
         } catch (err) {
+            ETH_RPC_REQUEST_ERROR.labels(finalPayload.method!).inc();
             end(new JsonRpcError.InternalError(err));
             return;
+        } finally {
+            const durationMs = (Date.now() - begin) / 1000;
+            ETH_RPC_RESPONSE_TIME.labels(finalPayload.method!).observe(durationMs);
         }
 
         const text = await response.text();
         if (!response.ok) {
+            ETH_RPC_REQUEST_ERROR.labels(finalPayload.method!).inc();
             const statusCode = response.status;
             switch (statusCode) {
                 case StatusCodes.MethodNotAllowed:
@@ -86,14 +120,17 @@ export class RPCSubprovider extends Subprovider {
         try {
             data = JSON.parse(text);
         } catch (err) {
+            ETH_RPC_REQUEST_ERROR.labels(finalPayload.method!).inc();
             end(new JsonRpcError.InternalError(err));
             return;
         }
 
         if (data.error) {
+            ETH_RPC_REQUEST_ERROR.labels(finalPayload.method!).inc();
             end(data.error);
             return;
         }
+        ETH_RPC_REQUEST_SUCCESS.labels(finalPayload.method!).inc();
         end(null, data.result);
     }
 }

--- a/src/rpc_subprovider.ts
+++ b/src/rpc_subprovider.ts
@@ -8,6 +8,8 @@ import JsonRpcError = require('json-rpc-error');
 import fetch, { Headers, Response } from 'node-fetch';
 import { Counter, Summary } from 'prom-client';
 
+import { ONE_SECOND_MS } from './constants';
+
 const httpAgent = new http.Agent({ keepAlive: true });
 const httpsAgent = new https.Agent({ keepAlive: true });
 const agent = (_parsedURL: any) => (_parsedURL.protocol === 'http:' ? httpAgent : httpsAgent);
@@ -16,6 +18,7 @@ const ETH_RPC_RESPONSE_TIME = new Summary({
     name: 'eth_rpc_response_time',
     help: 'The response time of an RPC request',
     labelNames: ['method'],
+    // tslint:disable-next-line:custom-no-magic-numbers
     percentiles: [0.01, 0.1, 0.5, 0.75, 0.9, 0.95, 0.98, 0.99],
 });
 
@@ -92,7 +95,7 @@ export class RPCSubprovider extends Subprovider {
             end(new JsonRpcError.InternalError(err));
             return;
         } finally {
-            const durationMs = (Date.now() - begin) / 1000;
+            const durationMs = (Date.now() - begin) / ONE_SECOND_MS;
             ETH_RPC_RESPONSE_TIME.labels(finalPayload.method!).observe(durationMs);
         }
 


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

Update the deployment config to include

```
ENABLE_PROMETHEUS_METRICS=true
PROMETHEUS_PORT=8080
```

<!--- Describe your changes in detail -->

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
