### PR TITLE
chore: Bump typescript to 4.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
         "ts-mockito": "^2.6.1",
         "ts-node": "^9.0.0",
         "tslint": "^6.1.3",
-        "typescript": "^4.3.4"
+        "typescript": "^4.4.0"
     },
     "dependencies": {
         "@0x/api-utils": "^0.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
         "noUnusedParameters": false,
         "resolveJsonModule": true,
         "skipLibCheck": true,
-        "allowSyntheticDefaultImports": true
+        "allowSyntheticDefaultImports": true,
+        "useUnknownInCatchVariables": false
     },
     "include": ["src/**/*.ts", "test/**/*.ts", "integration-test/**/*.ts", "migrations/*.ts", "src/schemas/*.json"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10388,10 +10388,15 @@ typescript@^3.8.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
-typescript@^4.2.4, typescript@^4.3.4:
+typescript@^4.2.4:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+
+typescript@^4.4.0:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
+  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Upgrade `typescript` dependency from `4.3.x` to `4.4.x`. With no `tsconfig` change, this minor version breaks the 0x API build by [changing the type of `catch` variables from `any` to `unknown`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html#defaulting-to-the-unknown-type-in-catch-variables---useunknownincatchvariables). While we should consider modifying `catch` blocks to test for `instanceof Error`, the extra safety probably isn't worth the effort.

Modify typescript configuration to restore previous default behavior.
