### PR TITLE
feat: Add prometheus counters to RFQM health check

### DIFF
--- a/src/utils/rfqm_health_check.ts
+++ b/src/utils/rfqm_health_check.ts
@@ -93,7 +93,7 @@ export async function computeHealthCheckAsync(
     const workersStatus = getWorstStatus(workersIssues.map((issue) => issue.status));
 
     // Prometheus counters
-    [...httpIssues, ...queueIssues, ...workersIssues].forEach((issue) =>
+    [...httpIssues, ...workersIssues].forEach((issue) =>
         RFQM_HEALTH_CHECK_ISSUE_COUNTER.labels(issue.status, issue.label).inc(),
     );
 
@@ -149,12 +149,15 @@ export function getHttpIssues(isMaintainenceMode: boolean, registryBalance: BigN
         });
     }
 
-    if (registryBalance.isLessThan(BALANCE_DEGRADED_THRESHOLD_WEI)) {
+    if (
+        registryBalance.isLessThan(BALANCE_DEGRADED_THRESHOLD_WEI) &&
+        registryBalance.isGreaterThanOrEqualTo(BALANCE_FAILED_THRESHOLD_WEI)
+    ) {
         issues.push({
             status: HealthCheckStatus.Degraded,
             description: `Registry balance is ${registryBalance
                 .shiftedBy(ETH_DECIMALS * -1)
-                .toFixed(2)} (threshold is ${BALANCE_DEGRADED_THRESHOLD_WEI})`,
+                .toFixed(2)} (threshold is ${BALANCE_DEGRADED_THRESHOLD})`,
             label: 'registry balance',
         });
     }

--- a/src/utils/rfqm_health_check.ts
+++ b/src/utils/rfqm_health_check.ts
@@ -1,5 +1,6 @@
 import { RfqMakerAssetOfferings } from '@0x/asset-swapper';
 import { BigNumber } from '@0x/utils';
+import { Counter } from 'prom-client';
 import { Producer } from 'sqs-producer';
 
 import { ETH_DECIMALS } from '../constants';
@@ -19,6 +20,12 @@ const MS_IN_MINUTE = 60000;
 const BALANCE_DEGRADED_THRESHOLD_WEI = new BigNumber(BALANCE_DEGRADED_THRESHOLD).shiftedBy(ETH_DECIMALS);
 const BALANCE_FAILED_THRESHOLD_WEI = new BigNumber(BALANCE_FAILED_THRESHOLD).shiftedBy(ETH_DECIMALS);
 
+const RFQM_HEALTH_CHECK_ISSUE_COUNTER = new Counter({
+    name: 'rfqm_health_check_issue',
+    labelNames: ['status' /* :HealthCheckStatus, except for Operational */, 'label' /* :HealthCheckLabel */],
+    help: 'RFQM health system has detected a problem with the system',
+});
+
 export enum HealthCheckStatus {
     Operational = 'operational',
     Maintenance = 'maintenance',
@@ -26,9 +33,17 @@ export enum HealthCheckStatus {
     Failed = 'failed',
 }
 
+type HealthCheckLabel =
+    | 'registry balance'
+    | 'RFQM_MAINTENANCE_MODE config `true`'
+    | 'queue size'
+    | 'worker balance'
+    | 'worker heartbeat';
+
 interface HealthCheckIssue {
     status: HealthCheckStatus;
     description: string;
+    label: HealthCheckLabel;
 }
 
 /**
@@ -77,6 +92,11 @@ export async function computeHealthCheckAsync(
     const workersIssues = [...queueIssues, ...heartbeatIssues];
     const workersStatus = getWorstStatus(workersIssues.map((issue) => issue.status));
 
+    // Prometheus counters
+    [...httpIssues, ...queueIssues, ...workersIssues].forEach((issue) =>
+        RFQM_HEALTH_CHECK_ISSUE_COUNTER.labels(issue.status, issue.label).inc(),
+    );
+
     return {
         status: getWorstStatus([httpStatus, workersStatus]),
         pairs,
@@ -120,11 +140,22 @@ function transformPairs(offerings: RfqMakerAssetOfferings): { [pair: string]: He
  * Creates issues related to the server/API not specific to the worker farm.
  */
 export function getHttpIssues(isMaintainenceMode: boolean, registryBalance: BigNumber): HealthCheckIssue[] {
-    const issues = [];
+    const issues: HealthCheckIssue[] = [];
     if (isMaintainenceMode) {
         issues.push({
             status: HealthCheckStatus.Maintenance,
             description: 'RFQM is set to maintainence mode via the 0x API configuration',
+            label: 'RFQM_MAINTENANCE_MODE config `true`',
+        });
+    }
+
+    if (registryBalance.isLessThan(BALANCE_DEGRADED_THRESHOLD_WEI)) {
+        issues.push({
+            status: HealthCheckStatus.Degraded,
+            description: `Registry balance is ${registryBalance
+                .shiftedBy(ETH_DECIMALS * -1)
+                .toFixed(2)} (threshold is ${BALANCE_DEGRADED_THRESHOLD_WEI})`,
+            label: 'registry balance',
         });
     }
 
@@ -134,6 +165,7 @@ export function getHttpIssues(isMaintainenceMode: boolean, registryBalance: BigN
             description: `Registry balance is ${registryBalance
                 .shiftedBy(ETH_DECIMALS * -1)
                 .toFixed(2)} (threshold is ${BALANCE_FAILED_THRESHOLD})`,
+            label: 'registry balance',
         });
     }
     return issues;
@@ -152,11 +184,13 @@ export async function checkSqsQueueAsync(producer: Producer): Promise<HealthChec
         results.push({
             status: HealthCheckStatus.Failed,
             description: `SQS queue contains ${messagesInQueue} messages (threshold is ${SQS_QUEUE_SIZE_FAILED_THRESHOLD})`,
+            label: 'queue size',
         });
     } else if (messagesInQueue > SQS_QUEUE_SIZE_DEGRADED_THRESHOLD) {
         results.push({
             status: HealthCheckStatus.Degraded,
             description: `SQS queue contains ${messagesInQueue} messages (threshold is ${SQS_QUEUE_SIZE_DEGRADED_THRESHOLD})`,
+            label: 'queue size',
         });
     }
     return results;
@@ -216,7 +250,13 @@ export async function checkWorkerHeartbeatsAsync(
 ): Promise<HealthCheckIssue[]> {
     const results: HealthCheckIssue[] = [];
     if (!heartbeats.length) {
-        return [{ status: HealthCheckStatus.Failed, description: 'No worker heartbeats were found' }];
+        return [
+            {
+                status: HealthCheckStatus.Failed,
+                description: 'No worker heartbeats were found',
+                label: 'worker heartbeat',
+            },
+        ];
     }
 
     // Heartbeat Age
@@ -227,6 +267,7 @@ export async function checkWorkerHeartbeatsAsync(
         results.push({
             status: HealthCheckStatus.Failed,
             description: `No worker has published a heartbeat in the last ${RECENT_HEARTBEAT_AGE_THRESHOLD} minutes`,
+            label: 'worker heartbeat',
         });
     }
     // TODO (rhinodavid): Think about how this will work when we downscale and a worker isn't producing new
@@ -237,6 +278,7 @@ export async function checkWorkerHeartbeatsAsync(
             results.push({
                 status: HealthCheckStatus.Degraded,
                 description: `Worker ${index} (${address}) last heartbeat was ${heartbeatAgeMinutes} ago`,
+                label: 'worker heartbeat',
             });
         }
     });
@@ -249,6 +291,7 @@ export async function checkWorkerHeartbeatsAsync(
         results.push({
             status: HealthCheckStatus.Failed,
             description: `No worker has a balance greater than the failed threshold (${BALANCE_FAILED_THRESHOLD})`,
+            label: 'worker heartbeat',
         });
     }
 
@@ -259,6 +302,7 @@ export async function checkWorkerHeartbeatsAsync(
                 description: `Worker ${index} (${address}) has a low balance: ${balance
                     .shiftedBy(ETH_DECIMALS * -1)
                     .toFixed(3)}`, // tslint:disable-line: custom-no-magic-numbers
+                label: 'worker balance',
             });
         }
     });


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

Closes MKR-163

Add Prometheus counters to the RFQM health check.

After the health check runs, look at each issue and increment a Prometheus counter with the lablels `<status>, <label>`, for instance `degraded, worker balance`.

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
