### PR TITLE
feat: Update rfqm balance degraded threshold to align with current alerting

### DIFF
--- a/test/utils/rfqm_health_check_test.ts
+++ b/test/utils/rfqm_health_check_test.ts
@@ -141,7 +141,9 @@ describe('RFQm Health Check', () => {
                 const degradedIssues = issues.filter(({ status }) => status === HealthCheckStatus.Degraded);
 
                 expect(degradedIssues).to.have.length(1);
-                expect(degradedIssues[0].description).to.contain('0x00');
+                expect(degradedIssues[0].description).to.contain(
+                    'Less than two workers have a balance above the degraded threshold (0.1)',
+                );
             });
         });
     });

--- a/test/utils/rfqm_health_check_test.ts
+++ b/test/utils/rfqm_health_check_test.ts
@@ -142,7 +142,7 @@ describe('RFQm Health Check', () => {
 
                 expect(degradedIssues).to.have.length(1);
                 expect(degradedIssues[0].description).to.contain(
-                    'Less than two workers have a balance above the degraded threshold (0.1)',
+                    'Less than two workers have a balance above the degraded threshold',
                 );
             });
         });


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

Aligns the health check with the < 2 workers with 0.1 ETH balance alert.

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
