### PR TITLE
fix: Prevent RFQM from accepting a trade when a trade with the same taker & taker token is pending

### DIFF
--- a/src/services/rfqm_service.ts
+++ b/src/services/rfqm_service.ts
@@ -1,4 +1,5 @@
 // tslint:disable:max-file-line-count
+import { TooManyRequestsError } from '@0x/api-utils';
 import { AssetSwapperContractAddresses, MarketOperation, ProtocolFeeUtils, QuoteRequestor } from '@0x/asset-swapper';
 import { RfqmRequestOptions } from '@0x/asset-swapper/lib/src/types';
 import { MetaTransaction, RfqOrder, Signature } from '@0x/protocol-utils';
@@ -193,7 +194,7 @@ const RFQM_SIGNED_QUOTE_EXPIRY_TOO_SOON = new Counter({
     help: 'A signed quote was not queued because it would expire too soon',
 });
 const RFQM_TAKER_AND_TAKERTOKEN_TRADE_EXISTS = new Counter({
-    name: 'rfqm_taker_and_takertoken_trade_exists',
+    name: 'rfqm_signed_quote_taker_and_takertoken_trade_exists',
     help: 'A trade was submitted when the system already had a pending trade for the same taker and takertoken',
 });
 const RFQM_JOB_FAILED_ETHCALL_VALIDATION = new Counter({
@@ -721,13 +722,7 @@ export class RfqmService {
             )
         ) {
             RFQM_TAKER_AND_TAKERTOKEN_TRADE_EXISTS.inc();
-            throw new ValidationError([
-                {
-                    field: 'n/a',
-                    code: ValidationErrorCodes.InvalidOrder,
-                    reason: 'a trade for this taker and takertoken already exists',
-                },
-            ]);
+            throw new TooManyRequestsError('a pending trade for this taker and takertoken already exists');
         }
         // validate that the firm quote is fillable using the origin registry address (this address is assumed to hold ETH)
         try {

--- a/src/services/rfqm_service.ts
+++ b/src/services/rfqm_service.ts
@@ -714,8 +714,8 @@ export class RfqmService {
         if (
             pendingJobs.some(
                 (job) =>
-                    job.order?.order.taker === quote.order?.order.taker &&
-                    job.order?.order.takerToken === quote.order?.order.takerToken &&
+                    job.order?.order.taker.toLowerCase() === quote.order?.order.taker.toLowerCase() &&
+                    job.order?.order.takerToken.toLowerCase() === quote.order?.order.takerToken.toLowerCase() &&
                     // Other logic handles the case where the same order is submitted twice
                     job.metaTransactionHash !== quote.metaTransactionHash,
             )

--- a/src/services/rfqm_service.ts
+++ b/src/services/rfqm_service.ts
@@ -194,7 +194,7 @@ const RFQM_SIGNED_QUOTE_EXPIRY_TOO_SOON = new Counter({
 });
 const RFQM_TAKER_AND_TAKERTOKEN_TRADE_EXISTS = new Counter({
     name: 'rfqm_taker_and_takertoken_trade_exists',
-    help: 'The rfqm system already has a pending trade for this taker and takertoken',
+    help: 'A trade was submitted when the system already had a pending trade for the same taker and takertoken',
 });
 const RFQM_JOB_FAILED_ETHCALL_VALIDATION = new Counter({
     name: 'rfqm_job_failed_ethcall_validation',

--- a/src/utils/rfqm_db_utils.ts
+++ b/src/utils/rfqm_db_utils.ts
@@ -1,10 +1,17 @@
 import { BigNumber } from '@0x/asset-swapper';
 import { RfqOrder } from '@0x/protocol-utils';
 import { Fee } from '@0x/quote-server/lib/src/types';
+import { In } from 'typeorm';
 import { Connection } from 'typeorm/connection/Connection';
 
 import { RfqmJobEntity, RfqmQuoteEntity, RfqmTransactionSubmissionEntity } from '../entities';
-import { RfqmJobConstructorOpts, RfqmOrderTypes, StoredFee, StoredOrder } from '../entities/RfqmJobEntity';
+import {
+    RfqmJobConstructorOpts,
+    RfqmJobStatus,
+    RfqmOrderTypes,
+    StoredFee,
+    StoredOrder,
+} from '../entities/RfqmJobEntity';
 import { RfqmQuoteConstructorOpts } from '../entities/RfqmQuoteEntity';
 import { RfqmWorkerHeartbeatEntity } from '../entities/RfqmWorkerHeartbeatEntity';
 
@@ -185,5 +192,14 @@ export class RfqmDbUtils {
             .createQueryBuilder()
             .where('worker_address = :workerAddress AND is_completed = FALSE', { workerAddress })
             .getMany();
+    }
+
+    /**
+     * Queries the `rfqm_jobs` table for all jobs with the specified statuses
+     */
+    public async findJobsWithStatusesAsync(statuses: RfqmJobStatus[]): Promise<RfqmJobEntity[]> {
+        return this._connection.getRepository(RfqmJobEntity).find({
+            status: In(statuses),
+        });
     }
 }

--- a/test/services/rfqm_service_test.ts
+++ b/test/services/rfqm_service_test.ts
@@ -2,7 +2,7 @@
 // tslint:disable:no-empty
 // tslint:disable:max-file-line-count
 
-import { ValidationError } from '@0x/api-utils';
+import { TooManyRequestsError } from '@0x/api-utils';
 import {
     FillQuoteTransformerOrderType,
     ProtocolFeeUtils,
@@ -23,7 +23,7 @@ import { ETH_DECIMALS, ONE_MINUTE_MS } from '../../src/constants';
 import { RfqmJobEntity, RfqmTransactionSubmissionEntity } from '../../src/entities';
 import { RfqmJobStatus, RfqmOrderTypes } from '../../src/entities/RfqmJobEntity';
 import { RfqmTransactionSubmissionStatus } from '../../src/entities/RfqmTransactionSubmissionEntity';
-import { RfqmService, RfqmTypes } from '../../src/services/rfqm_service';
+import { MetaTransactionSubmitRfqmSignedQuoteResponse, RfqmService, RfqmTypes } from '../../src/services/rfqm_service';
 import { QuoteServerClient } from '../../src/utils/quote_server_client';
 import { RfqmDbUtils } from '../../src/utils/rfqm_db_utils';
 import { HealthCheckStatus } from '../../src/utils/rfqm_health_check';
@@ -255,7 +255,93 @@ describe('RfqmService', () => {
                     },
                     type: RfqmTypes.MetaTransaction,
                 }),
-            ).to.be.rejectedWith(ValidationError); // tslint:disable-line no-unused-expression
+            ).to.be.rejectedWith(TooManyRequestsError, 'a pending trade for this taker and takertoken already exists'); // tslint:disable-line no-unused-expression
+        });
+
+        it('should allow two trades by the same taker with different taker tokens', async () => {
+            const existingOrder = {
+                chainId: '1',
+                expiry: NEVER_EXPIRES.toString(),
+                maker: '',
+                makerAmount: '',
+                makerToken: '',
+                pool: '',
+                salt: '',
+                taker: '0xtaker',
+                takerAmount: '',
+                takerToken: '0xtakertoken1',
+                txOrigin: '',
+                verifyingContract: '',
+            };
+            const existingJob: RfqmJobEntity = {
+                affiliateAddress: '',
+                calldata: '0x000',
+                chainId: 1,
+                createdAt: new Date(),
+                expiry: NEVER_EXPIRES,
+                fee: {
+                    amount: '0',
+                    token: '',
+                    type: 'fixed',
+                },
+                integratorId: '',
+                isCompleted: false,
+                lastLookResult: null,
+                makerUri: 'http://foo.bar',
+                metadata: null,
+                metaTransactionHash: '',
+                order: {
+                    order: existingOrder,
+                    type: RfqmOrderTypes.V4Rfq,
+                },
+                orderHash: '',
+                status: RfqmJobStatus.PendingEnqueued,
+                updatedAt: new Date(),
+                workerAddress: '',
+            };
+
+            const dbUtilsMock = mock(RfqmDbUtils);
+            when(dbUtilsMock.findJobsWithStatusesAsync(anything())).thenResolve([existingJob]);
+            when(dbUtilsMock.findQuoteByMetaTransactionHashAsync('0xmetatransactionhash')).thenResolve({
+                affiliateAddress: '',
+                chainId: 1,
+                createdAt: new Date(),
+                fee: {
+                    amount: '0',
+                    token: '',
+                    type: 'fixed',
+                },
+                integratorId: '',
+                makerUri: 'http://foo.bar',
+                metaTransactionHash: '0xmetatransactionhash',
+                order: {
+                    order: { ...existingOrder, takerToken: '0xtakertoken2' },
+                    type: RfqmOrderTypes.V4Rfq,
+                },
+                orderHash: '',
+            });
+            const metatransactionMock = mock(MetaTransaction);
+            when(metatransactionMock.getHash()).thenReturn('0xmetatransactionhash');
+            when(metatransactionMock.expirationTimeSeconds).thenReturn(NEVER_EXPIRES);
+            const dbUtils = instance(dbUtilsMock);
+
+            const service = buildRfqmServiceForUnitTest({
+                dbUtils,
+            });
+
+            expect(
+                service.submitMetaTransactionSignedQuoteAsync({
+                    integrator: MOCK_INTEGRATOR,
+                    metaTransaction: instance(metatransactionMock),
+                    signature: {
+                        r: '',
+                        s: '',
+                        signatureType: SignatureType.EthSign,
+                        v: 1,
+                    },
+                    type: RfqmTypes.MetaTransaction,
+                }),
+            ).to.eventually.satisfy((t: MetaTransactionSubmitRfqmSignedQuoteResponse) => t.type === 'metatransaction'); // tslint:disable-line no-unused-expression
         });
     });
 

--- a/test/services/rfqm_service_test.ts
+++ b/test/services/rfqm_service_test.ts
@@ -175,57 +175,64 @@ describe('RfqmService', () => {
         it('should fail if there is already a pending trade for the taker and taker token', async () => {
             const existingOrder = {
                 chainId: '1',
+                expiry: NEVER_EXPIRES.toString(),
                 maker: '',
                 makerAmount: '',
-                taker: '0xtaker',
-                takerAmount: '',
                 makerToken: '',
                 pool: '',
                 salt: '',
+                taker: '0xtaker',
+                takerAmount: '',
                 takerToken: '0xtakertoken',
                 txOrigin: '',
-                verifyingContract: '',
-                expiry: NEVER_EXPIRES.toString(),
+                verifyingContract: ''
             };
             const existingJob: RfqmJobEntity = {
-                chainId: 1,
                 affiliateAddress: '',
+                calldata: '0x000',
+                chainId: 1,
                 createdAt: new Date(),
                 expiry: NEVER_EXPIRES,
+                fee: {
+                    amount: '0',
+                    token: '',
+                    type: 'fixed'
+                },
                 integratorId: '',
                 isCompleted: false,
                 lastLookResult: null,
-                fee: {
-                    type: 'fixed',
-                    amount: '0',
-                    token: '',
-                },
-                order: {
-                    type: RfqmOrderTypes.V4Rfq,
-                    order: existingOrder,
-                },
+                makerUri: 'http://foo.bar',
                 metadata: null,
+                metaTransactionHash: '',
+                order: {
+                    order: existingOrder,
+                    type: RfqmOrderTypes.V4Rfq
+                },
+                orderHash: '',
                 status: RfqmJobStatus.PendingEnqueued,
                 updatedAt: new Date(),
-                workerAddress: '',
-                orderHash: '',
-                metaTransactionHash: '',
-                calldata: '0x000',
-                makerUri: 'http://foo.bar',
+                workerAddress: ''
             };
 
             const dbUtilsMock = mock(RfqmDbUtils);
             when(dbUtilsMock.findJobsWithStatusesAsync(anything())).thenResolve([existingJob]);
             when(dbUtilsMock.findQuoteByMetaTransactionHashAsync('0xmetatransactionhash')).thenResolve({
-                orderHash: '',
-                metaTransactionHash: '0xmetatransactionhash',
-                createdAt: new Date(),
+                affiliateAddress: '',
                 chainId: 1,
+                createdAt: new Date(),
+                fee: {
+                    amount: '0',
+                    token: '',
+                    type: 'fixed'
+                },
                 integratorId: '',
                 makerUri: 'http://foo.bar',
-                fee: { type: 'fixed', amount: '0', token: '' },
-                order: { type: RfqmOrderTypes.V4Rfq, order: existingOrder },
-                affiliateAddress: '',
+                metaTransactionHash: '0xmetatransactionhash',
+                order: {
+                    order: existingOrder,
+                    type: RfqmOrderTypes.V4Rfq
+                },
+                orderHash: ''
             });
             const metatransactionMock = mock(MetaTransaction);
             when(metatransactionMock.getHash()).thenReturn('0xmetatransactionhash');
@@ -241,12 +248,12 @@ describe('RfqmService', () => {
                     integrator: MOCK_INTEGRATOR,
                     metaTransaction: instance(metatransactionMock),
                     signature: {
-                        signatureType: SignatureType.EthSign,
-                        v: 1,
                         r: '',
                         s: '',
+                        signatureType: SignatureType.EthSign,
+                        v: 1
                     },
-                    type: RfqmTypes.MetaTransaction,
+                    type: RfqmTypes.MetaTransaction
                 }),
             ).to.be.rejectedWith(ValidationError); // tslint:disable-line no-unused-expression
         });

--- a/test/services/rfqm_service_test.ts
+++ b/test/services/rfqm_service_test.ts
@@ -185,7 +185,7 @@ describe('RfqmService', () => {
                 takerAmount: '',
                 takerToken: '0xtakertoken',
                 txOrigin: '',
-                verifyingContract: ''
+                verifyingContract: '',
             };
             const existingJob: RfqmJobEntity = {
                 affiliateAddress: '',
@@ -196,7 +196,7 @@ describe('RfqmService', () => {
                 fee: {
                     amount: '0',
                     token: '',
-                    type: 'fixed'
+                    type: 'fixed',
                 },
                 integratorId: '',
                 isCompleted: false,
@@ -206,12 +206,12 @@ describe('RfqmService', () => {
                 metaTransactionHash: '',
                 order: {
                     order: existingOrder,
-                    type: RfqmOrderTypes.V4Rfq
+                    type: RfqmOrderTypes.V4Rfq,
                 },
                 orderHash: '',
                 status: RfqmJobStatus.PendingEnqueued,
                 updatedAt: new Date(),
-                workerAddress: ''
+                workerAddress: '',
             };
 
             const dbUtilsMock = mock(RfqmDbUtils);
@@ -223,16 +223,16 @@ describe('RfqmService', () => {
                 fee: {
                     amount: '0',
                     token: '',
-                    type: 'fixed'
+                    type: 'fixed',
                 },
                 integratorId: '',
                 makerUri: 'http://foo.bar',
                 metaTransactionHash: '0xmetatransactionhash',
                 order: {
                     order: existingOrder,
-                    type: RfqmOrderTypes.V4Rfq
+                    type: RfqmOrderTypes.V4Rfq,
                 },
-                orderHash: ''
+                orderHash: '',
             });
             const metatransactionMock = mock(MetaTransaction);
             when(metatransactionMock.getHash()).thenReturn('0xmetatransactionhash');
@@ -251,9 +251,9 @@ describe('RfqmService', () => {
                         r: '',
                         s: '',
                         signatureType: SignatureType.EthSign,
-                        v: 1
+                        v: 1,
                     },
-                    type: RfqmTypes.MetaTransaction
+                    type: RfqmTypes.MetaTransaction,
                 }),
             ).to.be.rejectedWith(ValidationError); // tslint:disable-line no-unused-expression
         });


### PR DESCRIPTION
# Description

Closes MKR-185

We've seen issues where a taker submits multiple trades for the same token in rapid sequence, likely because they don't understand the first trade is being processed.

Update the submit logic to make sure that the RFQM system isn't currently processing a trade for the taker with the same token as a new trade.
