### PR TITLE
feat: Add prometheus gauge for total rfqm trade capacity

### DIFF
--- a/src/services/rfqm_service.ts
+++ b/src/services/rfqm_service.ts
@@ -671,12 +671,19 @@ export class RfqmService {
     public async runHealthCheckAsync(): Promise<HealthCheckResult> {
         const heartbeats = await this._dbUtils.findRfqmWorkerHeartbeatsAsync();
         const registryBalance = await this._blockchainUtils.getAccountBalanceAsync(this._registryAddress);
+        let gasPrice: BigNumber | undefined;
+        try {
+            const gasPrice = await this._protocolFeeUtils.getGasPriceEstimationOrThrowAsync();
+        } catch (error) {
+            logger.warn({ error }, 'Failed to get gas price for health check');
+        }
         return computeHealthCheckAsync(
             RFQM_MAINTENANCE_MODE,
             registryBalance,
             RFQM_MAKER_ASSET_OFFERINGS,
             this._sqsProducer,
             heartbeats,
+            
         );
     }
 

--- a/src/utils/rfqm_health_check.ts
+++ b/src/utils/rfqm_health_check.ts
@@ -1,6 +1,6 @@
 import { RfqMakerAssetOfferings } from '@0x/asset-swapper';
 import { BigNumber } from '@0x/utils';
-import { Counter } from 'prom-client';
+import { Counter, Gauge } from 'prom-client';
 import { Producer } from 'sqs-producer';
 
 import { ETH_DECIMALS } from '../constants';
@@ -24,6 +24,11 @@ const RFQM_HEALTH_CHECK_ISSUE_COUNTER = new Counter({
     name: 'rfqm_health_check_issue',
     labelNames: ['status' /* :HealthCheckStatus, except for Operational */, 'label' /* :HealthCheckLabel */],
     help: 'RFQM health system has detected a problem with the system',
+});
+
+const RFQM_TOTAL_SYSTEM_TRADE_CAPACITY_GAUGE = new Gauge({
+    name: 'rfqm_total_system_trade_capacity',
+    help: 'Total amount of ETH in the worker pool divided by the current expected gas of a trade',
 });
 
 export enum HealthCheckStatus {
@@ -81,6 +86,7 @@ export async function computeHealthCheckAsync(
     offerings: RfqMakerAssetOfferings,
     producer: Producer,
     heartbeats: RfqmWorkerHeartbeatEntity[],
+    gasPrice?: BigNumber,
 ): Promise<HealthCheckResult> {
     const pairs = transformPairs(offerings);
 
@@ -96,6 +102,12 @@ export async function computeHealthCheckAsync(
     [...httpIssues, ...workersIssues].forEach((issue) =>
         RFQM_HEALTH_CHECK_ISSUE_COUNTER.labels(issue.status, issue.label).inc(),
     );
+
+    if (gasPrice) {
+        const totalWorkerBalance = heartbeats.reduce((total, { balance }) => total.plus(balance), new BigNumber(0));
+        const totalSystemTradeCapacity = totalWorkerBalance.div(gasPrice);
+        RFQM_TOTAL_SYSTEM_TRADE_CAPACITY_GAUGE.set(totalSystemTradeCapacity.toNumber());
+    }
 
     return {
         status: getWorstStatus([httpStatus, workersStatus]),


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

Lil' PR to create a prom gauge which shows how many trades the RFQM system can do as a whole.

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
