### PR TITLE
fix: Fix pino useLevelLabels warning

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -6,8 +6,12 @@ import { ExpiredOrderError } from './errors';
 import { SRAOrder } from './types';
 
 export const logger = pino({
+    formatters: {
+        level: (label) => ({
+            level: label,
+        }),
+    },
     level: LOG_LEVEL,
-    useLevelLabels: true,
     timestamp: LOGGER_INCLUDE_TIMESTAMP,
 });
 


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description
Have you noticed that annoying message throughout the API outputs: `[PINODEP001] Warning: useLevelLabels is deprecated, use the formatters.level option instead`? Time to fix it.

Update `pino` logger with the new formatting. This shouldn't change the output at all, just get rid of the warning. See https://github.com/pinojs/pino/issues/848#issuecomment-642768553.

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
