### PR TITLE
fix: Allow worker error to fall through to process level catches

### DIFF
--- a/src/runners/rfqm_worker_runner.ts
+++ b/src/runners/rfqm_worker_runner.ts
@@ -88,10 +88,7 @@ if (require.main === module) {
 
         // Run the worker
         await runRfqmWorkerAsync(rfqmService, workerAddress);
-    })().catch((error) => {
-        logger.error(error.stack);
-        process.exit(1);
-    });
+    })(); // tslint:disable-line no-floating-promises
 }
 
 /**


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

My hunch is that worker process-level errors were being swallowed here and we were losing the log. This will let the `process.on` clauses catch the error and log it with the `pino.final` logger before exiting.

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
