### PR TITLE
fix: get better gas estimates on /price

### DIFF
--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -228,7 +228,7 @@ export class SwapHandlers {
     // tslint:disable-next-line:prefer-function-over-method
     public async getQuotePriceAsync(req: express.Request, res: express.Response): Promise<void> {
         const params = parseSwapQuoteRequestParams(req, 'price');
-        const quote = await this._getSwapQuoteAsync({ ...params, skipValidation: true }, req);
+        const quote = await this._getSwapQuoteAsync({ ...params }, req);
         req.log.info({
             indicativeQuoteServed: {
                 taker: params.takerAddress,
@@ -399,6 +399,7 @@ const parseSwapQuoteRequestParams = (req: express.Request, endpoint: 'price' | '
     // tslint:disable:boolean-naming
     let skipValidation: boolean;
     skipValidation = req.query.skipValidation === undefined ? false : req.query.skipValidation === 'true';
+
     if (endpoint === 'quote' && integratorId !== undefined && integratorId === MATCHA_INTEGRATOR_ID) {
         // NOTE: force skip validation to false if the quote comes from Matcha
         // NOTE: allow skip validation param if the quote comes from unknown integrators (without API keys or Simbot)

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -315,10 +315,15 @@ export class SwapService {
             .plus(isETHSell ? WRAP_ETH_GAS : 0)
             .plus(isETHBuy ? UNWRAP_WETH_GAS : 0);
 
+        // Cannot eth_gasEstimate for indicative quotes when RFQ Native liquidity is included
+        const isNativeIncluded = swapQuote.sourceBreakdown.Native !== undefined;
+        const isFirmQuote = !_rfqt?.isIndicative;
+        const canEstimateGas = isFirmQuote || !isNativeIncluded;
+
         // If the taker address is provided we can provide a more accurate gas estimate
         // using eth_gasEstimate
         // If an error occurs we attempt to provide a better message then "Transaction Reverted"
-        if (takerAddress && !skipValidation) {
+        if (takerAddress && !skipValidation && canEstimateGas) {
             let estimateGasCallResult = await this._estimateGasOrThrowRevertErrorAsync({
                 to,
                 data,


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

Presently, we hardcode `skipValidation: true`  in every `/price` request. This means we do not have accurate gas estimates on /price. As we will be using the gasEstimate to compare the all-in price of gasless swaps vs traditional swaps, it's important we get the gas estimate as close to correct as possible.

After speaking w/ @dekz - the reason we do not produce high fidelity gas estimates on `/price` is that we cannot call `eth_estimateGas` when RFQ indicative quotes are present. Thus, a large percentage of `/price` requests would fail when we estimate gas.

However, when RFQ is not present, we _do_ have the ability to estimate.

This change removes the hardcoding of skipValidation on price, and uses the sources to determine if we can estimate gas. It should do the following:
- Firm quotes should always be able to estimate gas
- Indicative quotes without Native liquidity should always be able to estimate gas
- Indicative quotes with Native liquidity should NOT be able to estimate gas

Of course, it will also skip validation if `skipValidation=true` is passed in from the API.

<!--- Describe your changes in detail -->

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

We can test this on staging, and try to trigger the above scenarios:
- Firm quote
- Indicative quote without RFQ
- Indicative quote with RFQ (by disabling all other sources)

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
