### PR TITLE
fix: avoid creating a PairsManager for layer2 chains

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -120,7 +120,6 @@ async function createAndInitializePairsManagerAsync(
     configManager: ConfigManager,
     rfqMakerDbUtils: RfqMakerDbUtils,
 ): Promise<PairsManager | undefined> {
-
     if (configManager.getChainId() !== ChainId.Mainnet) {
         return undefined;
     }

--- a/src/app.ts
+++ b/src/app.ts
@@ -119,7 +119,12 @@ export async function getContractAddressesForNetworkOrThrowAsync(
 async function createAndInitializePairsManagerAsync(
     configManager: ConfigManager,
     rfqMakerDbUtils: RfqMakerDbUtils,
-): Promise<PairsManager> {
+): Promise<PairsManager | undefined> {
+
+    if (configManager.getChainId() !== ChainId.Mainnet) {
+        return undefined;
+    }
+
     const pairsManager = new PairsManager(configManager, rfqMakerDbUtils);
     await pairsManager.initializeAsync();
     return pairsManager;

--- a/src/app.ts
+++ b/src/app.ts
@@ -120,7 +120,8 @@ async function createAndInitializePairsManagerAsync(
     configManager: ConfigManager,
     rfqMakerDbUtils: RfqMakerDbUtils,
 ): Promise<PairsManager | undefined> {
-    if (configManager.getChainId() !== ChainId.Mainnet) {
+    const chainId = configManager.getChainId();
+    if (chainId !== ChainId.Mainnet && chainId !== ChainId.Ropsten) {
         return undefined;
     }
 


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description
Currently RFQt only support Mainnet so the PairsManger, which queries DB to refresh in memory pairs, should only be initialized and used in Mainnet pods.

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
