### PR TITLE
fix: /price endpoint does not fail on eth_gasEstimate error

### DIFF
--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -539,6 +539,7 @@ const parseSwapQuoteRequestParams = (req: express.Request, endpoint: 'price' | '
     const integrator = integratorId ? getIntegratorByIdOrThrow(integratorId) : undefined;
 
     return {
+        endpoint,
         takerAddress: takerAddress as string,
         sellToken,
         buyToken,

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -228,7 +228,7 @@ export class SwapHandlers {
     // tslint:disable-next-line:prefer-function-over-method
     public async getQuotePriceAsync(req: express.Request, res: express.Response): Promise<void> {
         const params = parseSwapQuoteRequestParams(req, 'price');
-        const quote = await this._getSwapQuoteAsync({ ...params, skipValidation: true }, req);
+        const quote = await this._getSwapQuoteAsync({ ...params }, req);
         req.log.info({
             indicativeQuoteServed: {
                 taker: params.takerAddress,

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -396,14 +396,20 @@ const parseSwapQuoteRequestParams = (req: express.Request, endpoint: 'price' | '
 
     // Parse boolean params and defaults
     // tslint:disable:boolean-naming
-    let skipValidation: boolean;
-    skipValidation = req.query.skipValidation === undefined ? false : req.query.skipValidation === 'true';
+
+    // The /quote and /price endpoints should have different default behavior on skip validation
+    const defaultSkipValidation = endpoint === 'quote' ? false : true;
+
+    // Allow the query parameter skipValidation to override the default
+    let skipValidation =
+        req.query.skipValidation === undefined ? defaultSkipValidation : req.query.skipValidation === 'true';
 
     if (endpoint === 'quote' && integratorId !== undefined && integratorId === MATCHA_INTEGRATOR_ID) {
         // NOTE: force skip validation to false if the quote comes from Matcha
         // NOTE: allow skip validation param if the quote comes from unknown integrators (without API keys or Simbot)
         skipValidation = false;
     }
+
     const includePriceComparisons = req.query.includePriceComparisons === 'true' ? true : false;
     // Whether the entire callers balance should be sold, used for contracts where the
     // amount available is non-deterministic

--- a/src/services/meta_transaction_service.ts
+++ b/src/services/meta_transaction_service.ts
@@ -103,13 +103,13 @@ export class MetaTransactionService {
     public async calculateMetaTransactionPriceAsync(
         params: CalculateMetaTransactionQuoteParams,
     ): Promise<CalculateMetaTransactionQuoteResponse> {
-        return this._calculateMetaTransactionQuoteAsync(params, false);
+        return this._calculateMetaTransactionQuoteAsync(params, 'price');
     }
 
     public async calculateMetaTransactionQuoteAsync(
         params: CalculateMetaTransactionQuoteParams,
     ): Promise<GetMetaTransactionQuoteResponse & { quoteReport?: QuoteReport }> {
-        const quote = await this._calculateMetaTransactionQuoteAsync(params, true);
+        const quote = await this._calculateMetaTransactionQuoteAsync(params, 'quote');
         const { sellTokenToEthRate, buyTokenToEthRate } = quote;
         const commonQuoteFields = {
             chainId: quote.chainId,
@@ -343,9 +343,11 @@ export class MetaTransactionService {
 
     private async _calculateMetaTransactionQuoteAsync(
         params: CalculateMetaTransactionQuoteParams,
-        isQuote: boolean = true,
+        endpoint: 'price' | 'quote',
     ): Promise<CalculateMetaTransactionQuoteResponse> {
+        const isQuote = endpoint === 'quote';
         const quoteParams = {
+            endpoint,
             skipValidation: true,
             rfqt: {
                 apiKey: params.apiKey,

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -349,6 +349,10 @@ export class SwapService {
                     conservativeBestCaseGasEstimate,
                 );
             } catch (error) {
+                if (isFirmQuote) {
+                    // On firm quotes, when skipValidation=false, we want to raise an error
+                    throw error;
+                }
                 logger.warn(
                     { takerAddress, data, value, gasPrice, error: error?.message },
                     'Unable to use eth_estimateGas. Falling back to faux estimate',

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -325,7 +325,7 @@ export class SwapService {
 
         // Cannot eth_gasEstimate for indicative quotes when RFQ Native liquidity is included
         const isNativeIncluded = swapQuote.sourceBreakdown.Native !== undefined;
-        const isFirmQuote = !_rfqt?.isIndicative;
+        const isFirmQuote = _rfqt !== undefined && !_rfqt.isIndicative;
         const canEstimateGas = isFirmQuote || !isNativeIncluded;
 
         // If the taker address is provided we can provide a more accurate gas estimate

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -194,6 +194,7 @@ export class SwapService {
 
     public async calculateSwapQuoteAsync(params: GetSwapQuoteParams): Promise<GetSwapQuoteResponse> {
         const {
+            endpoint,
             takerAddress,
             sellAmount,
             buyAmount,
@@ -323,10 +324,10 @@ export class SwapService {
             .plus(isETHSell ? WRAP_ETH_GAS : 0)
             .plus(isETHBuy ? UNWRAP_WETH_GAS : 0);
 
-        // Cannot eth_gasEstimate for indicative quotes when RFQ Native liquidity is included
+        // Cannot eth_gasEstimate for /price when RFQ Native liquidity is included
         const isNativeIncluded = swapQuote.sourceBreakdown.Native !== undefined;
-        const isFirmQuote = _rfqt !== undefined && !_rfqt.isIndicative;
-        const canEstimateGas = isFirmQuote || !isNativeIncluded;
+        const isQuote = endpoint === 'quote';
+        const canEstimateGas = isQuote || !isNativeIncluded;
 
         // If the taker address is provided we can provide a more accurate gas estimate
         // using eth_gasEstimate
@@ -349,8 +350,8 @@ export class SwapService {
                     conservativeBestCaseGasEstimate,
                 );
             } catch (error) {
-                if (isFirmQuote) {
-                    // On firm quotes, when skipValidation=false, we want to raise an error
+                if (isQuote) {
+                    // On /quote, when skipValidation=false, we want to raise an error
                     throw error;
                 }
                 logger.warn(

--- a/src/types.ts
+++ b/src/types.ts
@@ -272,6 +272,7 @@ export interface SwapQuoteResponsePartialTransaction {
 
 // Request params
 export interface GetSwapQuoteParams extends SwapQuoteParamsBase {
+    endpoint: 'price' | 'quote';
     sellToken: string;
     buyToken: string;
     takerAddress?: string;


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

Previously, in #804 - a change was introduced to call `eth_estimateGas` when we had the appropriate calldata to do so. However, this change did not take into account that sometimes this rpc call could fail for balance and allowance reasons. 

If the taker did not have enough balance, they would get an error that looks like this:

```
{
  "code": 105,
  "reason": "Error",
  "values": {
    "message": "ERC20: transfer amount exceeds allowance"
  }
}
```

This effectively broke any integrations that were relying on the `/price` to always work (even if the taker could not fill the order)

This change provides error handling around such a scenario.

However, we want to preserve this behavior on the `/quote` endpoint, and hence, bubble the error up if seen on a firm quote

<!--- Describe your changes in detail -->

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

Added a new test for `/price` endpoint in `swap_test.ts` to automate the checking of this case. Previous `/quote` endpoints also give as some coverage.


# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
