### PR TITLE
[WIP] fix: change native buy/sell addresses to return 0xeeee... 

### DIFF
--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -1,10 +1,8 @@
 // tslint:disable:max-file-line-count
 import { isAPIError, isRevertError } from '@0x/api-utils';
 import { ERC20BridgeSource, RfqRequestOpts, SwapQuoterError } from '@0x/asset-swapper';
-import {
-    NATIVE_FEE_TOKEN_BY_CHAIN_ID,
-    SELL_SOURCE_FILTER_BY_CHAIN_ID,
-} from '@0x/asset-swapper/lib/src/utils/market_operation_utils/constants';
+import { SELL_SOURCE_FILTER_BY_CHAIN_ID } from '@0x/asset-swapper/lib/src/utils/market_operation_utils/constants';
+import { ETH_TOKEN_ADDRESS } from '@0x/protocol-utils';
 import {
     findTokenAddressOrThrow,
     getTokenMetadataIfExists,
@@ -427,12 +425,12 @@ const parseSwapQuoteRequestParams = (req: express.Request, endpoint: 'price' | '
     const isNativeBuy = isNativeSymbolOrAddress(buyTokenRaw, CHAIN_ID);
     // NOTE: Internally all Native token (like ETH) trades are for their wrapped equivalent (ie WETH), we just wrap/unwrap automatically
     const sellToken = findTokenAddressOrThrowApiError(
-        isNativeSell ? NATIVE_FEE_TOKEN_BY_CHAIN_ID[CHAIN_ID] : sellTokenRaw,
+        isNativeSell ? ETH_TOKEN_ADDRESS : sellTokenRaw,
         'sellToken',
         CHAIN_ID,
     ).toLowerCase();
     const buyToken = findTokenAddressOrThrowApiError(
-        isNativeBuy ? NATIVE_FEE_TOKEN_BY_CHAIN_ID[CHAIN_ID] : buyTokenRaw,
+        isNativeBuy ? ETH_TOKEN_ADDRESS : buyTokenRaw,
         'buyToken',
         CHAIN_ID,
     ).toLowerCase();


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

Currently the API returns the address of the wrapped native token (e.g. WETH on mainnet) as the value of both the `buyTokenAddress` and `sellTokenAddress` whenever a quote is requested for swapping either ETH/WETH or ETH/ETH.

<img width="754" alt="Captura de pantalla 2022-03-17 a las 18 42 40" src="https://user-images.githubusercontent.com/77161947/158863015-cff3579b-1b03-4883-bdb5-4495459da21b.png">

This PR replaces the WETH address for the native token address `0xeeee...` when either the buy or sell token is ETH, and the API will throw an error when requesting an ETH/ETH quote.

<img width="800" alt="Captura de pantalla 2022-03-17 a las 18 40 03" src="https://user-images.githubusercontent.com/77161947/158865007-1fad5ec7-45d1-4688-9c40-9ceadbebb1e1.png">

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
