### PR TITLE
fix: slippage model issues

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -246,6 +246,7 @@ export const SLIPPAGE_MODEL_S3_FILE_NAME: string = `SlippageModel-${CHAIN_ID}.js
 export const SLIPPAGE_MODEL_S3_API_VERSION: string = '2006-03-01';
 export const SLIPPAGE_MODEL_S3_FILE_VALID_INTERVAL_MS: number = ONE_HOUR_MS * 2;
 export const SLIPPAGE_MODEL_REFRESH_INTERVAL_MS: number = ONE_MINUTE_MS * 1;
+export const SLIPPAGE_MODEL_MINIMUM_APPLICABLE_VOLUME_USD: BigNumber = new BigNumber(10000);
 
 export const ORDER_WATCHER_URL = _.isEmpty(process.env.ORDER_WATCHER_URL)
     ? 'http://127.0.0.1:8080'

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -268,8 +268,6 @@ export class SwapHandlers {
             'sellTokenToEthRate',
             'buyTokenToEthRate',
             'expectedSlippage',
-            'expectedBuyAmount',
-            'expectedSellAmount',
         );
 
         if (params.includePriceComparisons && quote.priceComparisonsReport) {

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -523,7 +523,7 @@ export class SwapService {
                 } else {
                     apiSwapQuote.expectedBuyAmount = apiSwapQuote.buyAmount.times(
                         apiSwapQuote.expectedSlippage.plus(1),
-                    );
+                    ).integerValue();
                 }
             } else {
                 if (apiSwapQuote.expectedSlippage === null) {
@@ -531,7 +531,7 @@ export class SwapService {
                 } else {
                     apiSwapQuote.expectedSellAmount = apiSwapQuote.sellAmount.times(
                         apiSwapQuote.expectedSlippage.times(-1).plus(1),
-                    );
+                    ).integerValue();
                 }
             }
         }

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -521,17 +521,17 @@ export class SwapService {
                 if (apiSwapQuote.expectedSlippage === null) {
                     apiSwapQuote.expectedBuyAmount = null;
                 } else {
-                    apiSwapQuote.expectedBuyAmount = apiSwapQuote.buyAmount.times(
-                        apiSwapQuote.expectedSlippage.plus(1),
-                    ).integerValue();
+                    apiSwapQuote.expectedBuyAmount = apiSwapQuote.buyAmount
+                        .times(apiSwapQuote.expectedSlippage.plus(1))
+                        .integerValue();
                 }
             } else {
                 if (apiSwapQuote.expectedSlippage === null) {
                     apiSwapQuote.expectedBuyAmount = null;
                 } else {
-                    apiSwapQuote.expectedSellAmount = apiSwapQuote.sellAmount.times(
-                        apiSwapQuote.expectedSlippage.times(-1).plus(1),
-                    ).integerValue();
+                    apiSwapQuote.expectedSellAmount = apiSwapQuote.sellAmount
+                        .times(apiSwapQuote.expectedSlippage.times(-1).plus(1))
+                        .integerValue();
                 }
             }
         }

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -508,19 +508,29 @@ export class SwapService {
                     sellToken,
                     apiSwapQuote.buyAmount,
                     apiSwapQuote.sellAmount,
-                    slippagePercentage ?? 0,
                     apiSwapQuote.sources,
+                    slippagePercentage ?? 0.0005,
                 );
             } else {
-                apiSwapQuote.expectedSlippage = new BigNumber(0);
+                apiSwapQuote.expectedSlippage = null;
             }
 
             if (marketSide === MarketOperation.Sell) {
-                apiSwapQuote.expectedBuyAmount = apiSwapQuote.buyAmount.times(apiSwapQuote.expectedSlippage.plus(1));
+                if (apiSwapQuote.expectedSlippage === null) {
+                    apiSwapQuote.expectedBuyAmount = null;
+                } else {
+                    apiSwapQuote.expectedBuyAmount = apiSwapQuote.buyAmount.times(
+                        apiSwapQuote.expectedSlippage.times(-1).plus(1),
+                    );
+                }
             } else {
-                apiSwapQuote.expectedSellAmount = apiSwapQuote.sellAmount.times(
-                    apiSwapQuote.expectedSlippage.times(-1).plus(1),
-                );
+                if (apiSwapQuote.expectedSlippage === null) {
+                    apiSwapQuote.expectedBuyAmount = null;
+                } else {
+                    apiSwapQuote.expectedSellAmount = apiSwapQuote.sellAmount.times(
+                        apiSwapQuote.expectedSlippage.plus(1),
+                    );
+                }
             }
         }
 

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -522,7 +522,7 @@ export class SwapService {
                     apiSwapQuote.expectedBuyAmount = null;
                 } else {
                     apiSwapQuote.expectedBuyAmount = apiSwapQuote.buyAmount.times(
-                        apiSwapQuote.expectedSlippage.times(-1).plus(1),
+                        apiSwapQuote.expectedSlippage.plus(1),
                     );
                 }
             } else {
@@ -530,7 +530,7 @@ export class SwapService {
                     apiSwapQuote.expectedBuyAmount = null;
                 } else {
                     apiSwapQuote.expectedSellAmount = apiSwapQuote.sellAmount.times(
-                        apiSwapQuote.expectedSlippage.plus(1),
+                        apiSwapQuote.expectedSlippage.times(-1).plus(1),
                     );
                 }
             }

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -82,6 +82,8 @@ import { serviceUtils } from '../utils/service_utils';
 import { SlippageModelManager } from '../utils/slippage_model_manager';
 import { utils } from '../utils/utils';
 
+const DEFAULT_SLIPPAGE_PERCENTAGE = 0.0005; // Default slippage rate if no `slippagePercentage` is specified by users
+
 export class SwapService {
     private readonly _provider: SupportedProvider;
     private readonly _fakeTaker: FakeTakerContract;
@@ -509,7 +511,7 @@ export class SwapService {
                     apiSwapQuote.buyAmount,
                     apiSwapQuote.sellAmount,
                     apiSwapQuote.sources,
-                    slippagePercentage ?? 0.0005,
+                    slippagePercentage ?? DEFAULT_SLIPPAGE_PERCENTAGE,
                 );
             } else {
                 apiSwapQuote.expectedSlippage = null;

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -82,8 +82,6 @@ import { serviceUtils } from '../utils/service_utils';
 import { SlippageModelManager } from '../utils/slippage_model_manager';
 import { utils } from '../utils/utils';
 
-const DEFAULT_SLIPPAGE_PERCENTAGE = 0.0005; // Default slippage rate if no `slippagePercentage` is specified by users
-
 export class SwapService {
     private readonly _provider: SupportedProvider;
     private readonly _fakeTaker: FakeTakerContract;
@@ -511,28 +509,10 @@ export class SwapService {
                     apiSwapQuote.buyAmount,
                     apiSwapQuote.sellAmount,
                     apiSwapQuote.sources,
-                    slippagePercentage ?? DEFAULT_SLIPPAGE_PERCENTAGE,
+                    slippagePercentage!,
                 );
             } else {
                 apiSwapQuote.expectedSlippage = null;
-            }
-
-            if (marketSide === MarketOperation.Sell) {
-                if (apiSwapQuote.expectedSlippage === null) {
-                    apiSwapQuote.expectedBuyAmount = null;
-                } else {
-                    apiSwapQuote.expectedBuyAmount = apiSwapQuote.buyAmount
-                        .times(apiSwapQuote.expectedSlippage.plus(1))
-                        .integerValue();
-                }
-            } else {
-                if (apiSwapQuote.expectedSlippage === null) {
-                    apiSwapQuote.expectedBuyAmount = null;
-                } else {
-                    apiSwapQuote.expectedSellAmount = apiSwapQuote.sellAmount
-                        .times(apiSwapQuote.expectedSlippage.times(-1).plus(1))
-                        .integerValue();
-                }
             }
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -265,8 +265,6 @@ export interface GetSwapQuoteResponse extends SwapQuoteResponsePartialTransactio
     extendedQuoteReportSources?: ExtendedQuoteReportSources;
     priceComparisonsReport?: PriceComparisonsReport;
     expectedSlippage?: BigNumber | null;
-    expectedBuyAmount?: BigNumber | null;
-    expectedSellAmount?: BigNumber | null;
     blockNumber: number | undefined;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -264,9 +264,9 @@ export interface GetSwapQuoteResponse extends SwapQuoteResponsePartialTransactio
     quoteReport?: QuoteReport;
     extendedQuoteReportSources?: ExtendedQuoteReportSources;
     priceComparisonsReport?: PriceComparisonsReport;
-    expectedSlippage?: BigNumber;
-    expectedBuyAmount?: BigNumber;
-    expectedSellAmount?: BigNumber;
+    expectedSlippage?: BigNumber | null;
+    expectedBuyAmount?: BigNumber | null;
+    expectedSellAmount?: BigNumber | null;
     blockNumber: number | undefined;
 }
 

--- a/src/utils/slippage_model_manager.ts
+++ b/src/utils/slippage_model_manager.ts
@@ -141,7 +141,7 @@ export class SlippageModelManager {
         }
 
         let expectedSlippage: BigNumber = new BigNumber(0);
-        for (let source of sources) {
+        for (const source of sources) {
             if (source.proportion.isGreaterThan(0)) {
                 const slippageModel = slippageModelCacheForPair.get(source.name) || null;
                 if (slippageModel === null) {

--- a/src/utils/slippage_model_manager.ts
+++ b/src/utils/slippage_model_manager.ts
@@ -79,7 +79,7 @@ const createSlippageModelCache = (slippageModelFileContent: string, logLabels: {
  */
 const calculateExpectedSlippageForModel = (
     token0Amount: BigNumber,
-    maxSlippageRate: number,
+    maxSlippageRate: BigNumber,
     slippageModel: SlippageModel,
 ): BigNumber | null => {
     const volumeUsd = token0Amount.times(slippageModel.token0PriceInUsd);
@@ -90,9 +90,9 @@ const calculateExpectedSlippageForModel = (
     }
 
     const volumeTerm = volumeUsd.times(slippageModel.volumeCoefficient);
-    const slippageTerm = new BigNumber(maxSlippageRate * ONE_IN_BASE_POINTS).times(slippageModel.slippageCoefficient);
+    const slippageTerm = maxSlippageRate.times(ONE_IN_BASE_POINTS).times(slippageModel.slippageCoefficient);
     const expectedSlippage = slippageTerm.plus(volumeTerm).plus(slippageModel.intercept).times(-1);
-    return expectedSlippage.gt(maxSlippageRate) ? new BigNumber(maxSlippageRate) : expectedSlippage;
+    return expectedSlippage.gt(maxSlippageRate) ? maxSlippageRate : expectedSlippage;
 };
 
 /**
@@ -153,7 +153,7 @@ export class SlippageModelManager {
 
                     const expectedSlippageOfSource = calculateExpectedSlippageForModel(
                         token0Amount.times(source.proportion),
-                        maxSlippageRate,
+                        new BigNumber(maxSlippageRate),
                         slippageModel,
                     );
 

--- a/src/utils/slippage_model_manager.ts
+++ b/src/utils/slippage_model_manager.ts
@@ -23,7 +23,7 @@ const SLIPPAGE_MODEL_FILE_STALE = new Counter({
     labelNames: ['bucket', 'fileName'],
 });
 
-interface SlippageModel {
+export interface SlippageModel {
     token0: string;
     token1: string;
     source: string;
@@ -141,7 +141,7 @@ export class SlippageModelManager {
         }
 
         let expectedSlippage: BigNumber = new BigNumber(0);
-        sources.forEach((source) => {
+        for (let source of sources) {
             if (source.proportion.isGreaterThan(0)) {
                 const slippageModel = slippageModelCacheForPair.get(source.name) || null;
                 if (slippageModel === null) {
@@ -166,7 +166,7 @@ export class SlippageModelManager {
                     expectedSlippage = expectedSlippage.plus(source.proportion.times(expectedSlippageOfSource));
                 }
             }
-        });
+        }
         return expectedSlippage;
     }
 

--- a/src/utils/slippage_model_manager.ts
+++ b/src/utils/slippage_model_manager.ts
@@ -2,6 +2,7 @@ import { BigNumber } from '@0x/utils';
 import { Counter } from 'prom-client';
 
 import {
+    SLIPPAGE_MODEL_MINIMUM_APPLICABLE_VOLUME_USD,
     SLIPPAGE_MODEL_REFRESH_INTERVAL_MS,
     SLIPPAGE_MODEL_S3_BUCKET_NAME,
     SLIPPAGE_MODEL_S3_FILE_NAME,
@@ -78,12 +79,20 @@ const createSlippageModelCache = (slippageModelFileContent: string, logLabels: {
  */
 const calculateExpectedSlippageForModel = (
     token0Amount: BigNumber,
-    maxSlippageInBps: BigNumber,
+    maxSlippageRate: number,
     slippageModel: SlippageModel,
-): BigNumber => {
-    const slippageTerm = maxSlippageInBps.times(slippageModel.slippageCoefficient);
-    const volumeTerm = token0Amount.times(slippageModel.token0PriceInUsd).times(slippageModel.volumeCoefficient);
-    return slippageTerm.plus(volumeTerm).plus(slippageModel.intercept);
+): BigNumber | null => {
+    const volumeUsd = token0Amount.times(slippageModel.token0PriceInUsd);
+
+    // Volume is too small for a reasonable prediction
+    if (volumeUsd.lte(SLIPPAGE_MODEL_MINIMUM_APPLICABLE_VOLUME_USD)) {
+        return null;
+    }
+
+    const volumeTerm = volumeUsd.times(slippageModel.volumeCoefficient);
+    const slippageTerm = new BigNumber(maxSlippageRate * ONE_IN_BASE_POINTS).times(slippageModel.slippageCoefficient);
+    const expectedSlippage = slippageTerm.plus(volumeTerm).plus(slippageModel.intercept).times(-1);
+    return expectedSlippage.gt(maxSlippageRate) ? new BigNumber(maxSlippageRate) : expectedSlippage;
 };
 
 /**
@@ -120,44 +129,44 @@ export class SlippageModelManager {
         sellToken: string,
         buyAmount: BigNumber,
         sellAmount: BigNumber,
-        maxSlippageRate: number,
         sources: GetSwapQuoteResponseLiquiditySource[],
-    ): BigNumber {
-        const maxSlippageInBps = new BigNumber(maxSlippageRate * ONE_IN_BASE_POINTS);
+        maxSlippageRate: number,
+    ): BigNumber | null {
+        const slippageModelCacheForPair = this._cachedSlippageModel.get(pairUtils.toKey(buyToken, sellToken)) || null;
+
+        // Slippage models for given pair is not available
+        if (slippageModelCacheForPair === null) {
+            return null;
+        }
+
         let expectedSlippage: BigNumber = new BigNumber(0);
         sources.forEach((source) => {
             if (source.proportion.isGreaterThan(0)) {
-                const slippageModel = this._getCachedModel(buyToken, sellToken, source.name);
-                if (slippageModel !== undefined) {
+                const slippageModel = slippageModelCacheForPair.get(source.name) || null;
+                if (slippageModel === null) {
+                    // Slippage model for given source is not available
+                    return null;
+                } else {
                     const token0Amount = source.proportion.times(
                         slippageModel.token0 === buyToken.toLowerCase() ? buyAmount : sellAmount,
                     );
 
                     const expectedSlippageOfSource = calculateExpectedSlippageForModel(
-                        token0Amount,
-                        maxSlippageInBps,
+                        token0Amount.times(source.proportion),
+                        maxSlippageRate,
                         slippageModel,
                     );
+
+                    // Volume for given source is too small for a reasonable prediction
+                    if (expectedSlippageOfSource === null) {
+                        return null;
+                    }
+
                     expectedSlippage = expectedSlippage.plus(source.proportion.times(expectedSlippageOfSource));
                 }
             }
         });
         return expectedSlippage;
-    }
-
-    /**
-     * Get the cached slippage model data for a specific pair and source
-     * @param tokenA Address of one token
-     * @param tokenB Address of another token
-     * @param source Name of AMM source
-     * @returns Slippage model
-     */
-    private _getCachedModel(tokenA: string, tokenB: string, sourceName: string): SlippageModel | undefined {
-        const pairKey = pairUtils.toKey(tokenA, tokenB);
-        if (this._cachedSlippageModel.has(pairKey)) {
-            return this._cachedSlippageModel.get(pairKey)!.get(sourceName);
-        }
-        return undefined;
     }
 
     /**

--- a/src/utils/slippage_model_manager.ts
+++ b/src/utils/slippage_model_manager.ts
@@ -153,7 +153,7 @@ export class SlippageModelManager {
                     );
 
                     const expectedSlippageOfSource = calculateExpectedSlippageForModel(
-                        token0Amount.times(source.proportion),
+                        token0Amount,
                         new BigNumber(maxSlippageRate),
                         slippageModel,
                     );

--- a/src/utils/slippage_model_manager.ts
+++ b/src/utils/slippage_model_manager.ts
@@ -91,8 +91,9 @@ const calculateExpectedSlippageForModel = (
 
     const volumeTerm = volumeUsd.times(slippageModel.volumeCoefficient);
     const slippageTerm = maxSlippageRate.times(ONE_IN_BASE_POINTS).times(slippageModel.slippageCoefficient);
-    const expectedSlippage = slippageTerm.plus(volumeTerm).plus(slippageModel.intercept).times(-1);
-    return expectedSlippage.gt(maxSlippageRate) ? maxSlippageRate : expectedSlippage;
+    const expectedSlippage = slippageTerm.plus(volumeTerm).plus(slippageModel.intercept);
+    const expectedSlippageCap = maxSlippageRate.times(-1); // `maxSlippageRate` is specified with a postive number while `expectedSlippage` is normally negative.
+    return expectedSlippage.lt(expectedSlippageCap) ? expectedSlippageCap : expectedSlippage;
 };
 
 /**

--- a/test/test_env
+++ b/test/test_env
@@ -13,3 +13,4 @@ ALT_RFQ_MM_API_KEY=averysecurekey
 ALT_RFQ_MM_PROFILE=acoolprofile
 ETH_GAS_STATION_API_URL=https://gas.api.0x.org/source/median?output=eth_gas_station
 INTEGRATORS_ACL='[{"integratorId":"test-integrator-id-1","label":"Test Integrator 1","rfqt":true,"rfqm":true,"plp":false,"apiKeys":["test-api-key-1","test-api-key-2"], "whitelistIntegratorUrls":["http://foo.bar"]},{"integratorId":"test-integrator-id-2","label":"Test Integrator 2","rfqt":false,"rfqm":true,"plp":false,"apiKeys":["test-api-key-3"]}]'
+SLIPPAGE_MODEL_S3_BUCKET_NAME='TestBucket'

--- a/test/utils/slippage_model_manager_test.ts
+++ b/test/utils/slippage_model_manager_test.ts
@@ -40,8 +40,8 @@ describe('SlippageModelManager', () => {
             token1: weth,
             source: 'source 2',
             slippageCoefficient: -0.0000004,
-            volumeCoefficient: -0.000000003,
-            intercept: -0.0001,
+            volumeCoefficient: -0.000000002,
+            intercept: -0.00001,
             token0PriceInUsd: 0.000001,
         },
     ];
@@ -145,7 +145,7 @@ describe('SlippageModelManager', () => {
             );
 
             // Then
-            expect(expectedSlippage).to.deep.equal(new BigNumber(-0.000205));
+            expect(expectedSlippage).to.deep.equal(new BigNumber(-0.000185));
         });
         it('should return null if pair is not supported', async () => {
             // Given

--- a/test/utils/slippage_model_manager_test.ts
+++ b/test/utils/slippage_model_manager_test.ts
@@ -1,0 +1,208 @@
+// tslint:disable:custom-no-magic-numbers
+// tslint:disable:no-empty
+// tslint:disable:max-file-line-count
+
+import { BigNumber } from '@0x/utils';
+import { expect } from 'chai';
+import { anything, instance, mock, when } from 'ts-mockito';
+
+import { S3Client } from '../../src/utils/s3_client';
+import { SlippageModel, SlippageModelManager } from '../../src/utils/slippage_model_manager';
+
+// const createMockConfigManager = (
+//     rfqmMakers: MakerIdSet,
+//     rfqmRfqMakers: MakerIdSet,
+//     rfqmOtcMakers: MakerIdSet,
+//     rfqtRfqMakers: MakerIdSet = new Set(),
+// ): ConfigManager => {
+//     const configManagerMock = mock(ConfigManager);
+//     when(configManagerMock.getRfqmMakerIdSet()).thenReturn(rfqmMakers);
+//     when(configManagerMock.getRfqmMakerIdSetForRfqOrder()).thenReturn(rfqmRfqMakers);
+//     when(configManagerMock.getRfqmMakerIdSetForOtcOrder()).thenReturn(rfqmOtcMakers);
+//     when(configManagerMock.getRfqtMakerIdSetForRfqOrder()).thenReturn(rfqtRfqMakers);
+
+//     return instance(configManagerMock);
+// };
+
+const createMockS3Client = (slippageModels: SlippageModel[]): S3Client => {
+    const s3ClientMock = mock(S3Client);
+    when(s3ClientMock.hasFileAsync(anything(), anything())).thenResolve({
+        exists: true,
+        lastModified: new Date(),
+    });
+    when(s3ClientMock.getFileContentAsync(anything(), anything())).thenResolve({
+        content: JSON.stringify(slippageModels),
+        lastModified: new Date(),
+    });
+
+    return instance(s3ClientMock)
+};
+
+describe('SlippageModelManager', () => {
+    // Tokens in Checksum representation
+    const usdc = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+    const weth = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
+    const otherToken = '0xeAC17F958D2ee523a2206206994597C13D831ec7';
+    const slippageModels = [
+        {
+            token0: usdc,
+            token1: weth,
+            source: 'source 1',
+            slippageCoefficient: -0.0000003,
+            volumeCoefficient: -0.000000001,
+            intercept: 0,
+            token0PriceInUsd: 0.000001,
+        },
+    ];
+
+    describe('calculateExpectedSlippage', () => {
+        it('should return correct expected slippage if buying USDC', async () => {
+            // Given
+            const s3Client = createMockS3Client(slippageModels);
+            const slippageModelManager = new SlippageModelManager(s3Client);
+            await slippageModelManager.initializeAsync();
+
+            // When
+            const expectedSlippage = slippageModelManager.calculateExpectedSlippage(
+                usdc,
+                weth,
+                new BigNumber('100000000000'),
+                new BigNumber('1000000'),
+                [
+                    {
+                        name: 'source 1',
+                        proportion: new BigNumber(1),
+                    },
+                ],
+                0.03,
+            );
+
+            // Then
+            expect(expectedSlippage).to.deep.equal(new BigNumber(-0.00019));
+        });
+        it('should return correct expected slippage if selling USDC', async () => {
+            // Given
+            const s3Client = createMockS3Client(slippageModels);
+            const slippageModelManager = new SlippageModelManager(s3Client);
+            await slippageModelManager.initializeAsync();
+
+            // When
+            const expectedSlippage = slippageModelManager.calculateExpectedSlippage(
+                weth,
+                usdc,
+                new BigNumber('1000000'),
+                new BigNumber('100000000000'),
+                [
+                    {
+                        name: 'source 1',
+                        proportion: new BigNumber(1),
+                    },
+                ],
+                0.03,
+            );
+
+            // Then
+            expect(expectedSlippage).to.deep.equal(new BigNumber(-0.00019));
+        });
+        it('should return capped expected slippage if volume is huge', async () => {
+            // Given
+            const s3Client = createMockS3Client(slippageModels);
+            const slippageModelManager = new SlippageModelManager(s3Client);
+            await slippageModelManager.initializeAsync();
+
+            // When
+            const expectedSlippage = slippageModelManager.calculateExpectedSlippage(
+                usdc,
+                weth,
+                new BigNumber('100000000000000'),
+                new BigNumber('1000000'),
+                [
+                    {
+                        name: 'source 1',
+                        proportion: new BigNumber(1),
+                    },
+                ],
+                0.03,
+            );
+
+            // Then
+            expect(expectedSlippage).to.deep.equal(new BigNumber(-0.03));
+        });
+        it('should return null if pair is not supported', async () => {
+            // Given
+            const s3Client = createMockS3Client(slippageModels);
+            const slippageModelManager = new SlippageModelManager(s3Client);
+            await slippageModelManager.initializeAsync();
+
+            // When
+            const expectedSlippage = slippageModelManager.calculateExpectedSlippage(
+                usdc,
+                otherToken,
+                new BigNumber('100000000000'),
+                new BigNumber('1000000'),
+                [
+                    {
+                        name: 'source 1',
+                        proportion: new BigNumber(1),
+                    },
+                ],
+                0.03,
+            );
+
+            // Then
+            expect(expectedSlippage).to.deep.equal(null);
+        });
+        it('should return null if any source is not supported', async () => {
+            // Given
+            const s3Client = createMockS3Client(slippageModels);
+            const slippageModelManager = new SlippageModelManager(s3Client);
+            await slippageModelManager.initializeAsync();
+
+            // When
+            const expectedSlippage = slippageModelManager.calculateExpectedSlippage(
+                usdc,
+                weth,
+                new BigNumber('100000000000'),
+                new BigNumber('1000000'),
+                [
+                    {
+                        name: 'source 1',
+                        proportion: new BigNumber(0.9),
+                    },
+                    {
+                        name: 'source 2',
+                        proportion: new BigNumber(0.1),
+                    },
+                ],
+                0.03,
+            );
+
+            // Then
+            expect(expectedSlippage).to.deep.equal(null);
+        });
+        it('should return null if trade size is less than 10k USD', async () => {
+            // Given
+            const s3Client = createMockS3Client(slippageModels);
+            const slippageModelManager = new SlippageModelManager(s3Client);
+            await slippageModelManager.initializeAsync();
+
+            // When
+            const expectedSlippage = slippageModelManager.calculateExpectedSlippage(
+                usdc,
+                weth,
+                new BigNumber('999000000'),
+                new BigNumber('1000000'),
+                [
+                    {
+                        name: 'source 1',
+                        proportion: new BigNumber(1),
+                    },
+                ],
+                0.03,
+            );
+
+            // Then
+            expect(expectedSlippage).to.deep.equal(null);
+        });
+    });
+});

--- a/test/utils/slippage_model_manager_test.ts
+++ b/test/utils/slippage_model_manager_test.ts
@@ -1,28 +1,11 @@
 // tslint:disable:custom-no-magic-numbers
-// tslint:disable:no-empty
-// tslint:disable:max-file-line-count
 
+import { expect } from '@0x/contracts-test-utils';
 import { BigNumber } from '@0x/utils';
-import { expect } from 'chai';
 import { anything, instance, mock, when } from 'ts-mockito';
 
 import { S3Client } from '../../src/utils/s3_client';
 import { SlippageModel, SlippageModelManager } from '../../src/utils/slippage_model_manager';
-
-// const createMockConfigManager = (
-//     rfqmMakers: MakerIdSet,
-//     rfqmRfqMakers: MakerIdSet,
-//     rfqmOtcMakers: MakerIdSet,
-//     rfqtRfqMakers: MakerIdSet = new Set(),
-// ): ConfigManager => {
-//     const configManagerMock = mock(ConfigManager);
-//     when(configManagerMock.getRfqmMakerIdSet()).thenReturn(rfqmMakers);
-//     when(configManagerMock.getRfqmMakerIdSetForRfqOrder()).thenReturn(rfqmRfqMakers);
-//     when(configManagerMock.getRfqmMakerIdSetForOtcOrder()).thenReturn(rfqmOtcMakers);
-//     when(configManagerMock.getRfqtMakerIdSetForRfqOrder()).thenReturn(rfqtRfqMakers);
-
-//     return instance(configManagerMock);
-// };
 
 const createMockS3Client = (slippageModels: SlippageModel[]): S3Client => {
     const s3ClientMock = mock(S3Client);
@@ -35,11 +18,10 @@ const createMockS3Client = (slippageModels: SlippageModel[]): S3Client => {
         lastModified: new Date(),
     });
 
-    return instance(s3ClientMock)
+    return instance(s3ClientMock);
 };
 
 describe('SlippageModelManager', () => {
-    // Tokens in Checksum representation
     const usdc = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
     const weth = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
     const otherToken = '0xeAC17F958D2ee523a2206206994597C13D831ec7';
@@ -51,6 +33,15 @@ describe('SlippageModelManager', () => {
             slippageCoefficient: -0.0000003,
             volumeCoefficient: -0.000000001,
             intercept: 0,
+            token0PriceInUsd: 0.000001,
+        },
+        {
+            token0: usdc,
+            token1: weth,
+            source: 'source 2',
+            slippageCoefficient: -0.0000004,
+            volumeCoefficient: -0.000000003,
+            intercept: -0.0001,
             token0PriceInUsd: 0.000001,
         },
     ];
@@ -128,6 +119,34 @@ describe('SlippageModelManager', () => {
             // Then
             expect(expectedSlippage).to.deep.equal(new BigNumber(-0.03));
         });
+        it('should return aggregated slippage if there are multiple sources', async () => {
+            // Given
+            const s3Client = createMockS3Client(slippageModels);
+            const slippageModelManager = new SlippageModelManager(s3Client);
+            await slippageModelManager.initializeAsync();
+
+            // When
+            const expectedSlippage = slippageModelManager.calculateExpectedSlippage(
+                usdc,
+                weth,
+                new BigNumber('100000000000'),
+                new BigNumber('1000000'),
+                [
+                    {
+                        name: 'source 1',
+                        proportion: new BigNumber(0.5),
+                    },
+                    {
+                        name: 'source 2',
+                        proportion: new BigNumber(0.5),
+                    },
+                ],
+                0.03,
+            );
+
+            // Then
+            expect(expectedSlippage).to.deep.equal(new BigNumber(-0.000205));
+        });
         it('should return null if pair is not supported', async () => {
             // Given
             const s3Client = createMockS3Client(slippageModels);
@@ -167,11 +186,11 @@ describe('SlippageModelManager', () => {
                 [
                     {
                         name: 'source 1',
-                        proportion: new BigNumber(0.9),
+                        proportion: new BigNumber(0.5),
                     },
                     {
-                        name: 'source 2',
-                        proportion: new BigNumber(0.1),
+                        name: 'source 3',
+                        proportion: new BigNumber(0.5),
                     },
                 ],
                 0.03,


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

<!--- Describe your changes in detail -->
Fix a few issues of `SlippageModelManager` according to recent discussion:
* `expectedSlippage` shall be `null` for trades below $10k in volume
* `expectedSlippage` shall not exceed the max slippage threshold set by the end-user
* `expectedSlippage` shall be `null` for unsupported pairs
* `expectedSlippage` shall be `null` for unsupported sources
* for trades spanning across multiple sources, the overall `expectedSlippage` shall be `null` if `expectedSlippage` of any individual source is `null`.

Also according to Jacob's comment, remove derived fields `expectedBuyAmount` and `expectedSellAmount`.
# Testing Instructions

<!--- Please describe how reviewers can test your changes -->
Unit test added to cover `SlippageModelManager`.

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
