### PR TITLE
feat: Modify `SlippageModelManager` to handle native source and remove $10k usd threshold [TKR-461, MKR-513]

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -250,7 +250,6 @@ export const SLIPPAGE_MODEL_S3_FILE_NAME: string = `SlippageModel-${CHAIN_ID}.js
 export const SLIPPAGE_MODEL_S3_API_VERSION: string = '2006-03-01';
 export const SLIPPAGE_MODEL_S3_FILE_VALID_INTERVAL_MS: number = ONE_HOUR_MS * 2;
 export const SLIPPAGE_MODEL_REFRESH_INTERVAL_MS: number = ONE_MINUTE_MS * 1;
-export const SLIPPAGE_MODEL_MINIMUM_APPLICABLE_VOLUME_USD: BigNumber = new BigNumber(10000);
 
 export const ORDER_WATCHER_URL = _.isEmpty(process.env.ORDER_WATCHER_URL)
     ? 'http://127.0.0.1:8080'

--- a/src/utils/slippage_model_manager.ts
+++ b/src/utils/slippage_model_manager.ts
@@ -3,7 +3,6 @@ import { BigNumber } from '@0x/utils';
 import { Counter } from 'prom-client';
 
 import {
-    SLIPPAGE_MODEL_MINIMUM_APPLICABLE_VOLUME_USD,
     SLIPPAGE_MODEL_REFRESH_INTERVAL_MS,
     SLIPPAGE_MODEL_S3_BUCKET_NAME,
     SLIPPAGE_MODEL_S3_FILE_NAME,
@@ -84,12 +83,6 @@ const calculateExpectedSlippageForModel = (
     slippageModel: SlippageModel,
 ): BigNumber | null => {
     const volumeUsd = token0Amount.times(slippageModel.token0PriceInUsd);
-
-    // Volume is too small for a reasonable prediction
-    if (volumeUsd.lte(SLIPPAGE_MODEL_MINIMUM_APPLICABLE_VOLUME_USD)) {
-        return null;
-    }
-
     const volumeTerm = volumeUsd.times(slippageModel.volumeCoefficient);
     const slippageTerm = maxSlippageRate.times(ONE_IN_BASE_POINTS).times(slippageModel.slippageCoefficient);
     const expectedSlippage = BigNumber.sum(slippageTerm, volumeTerm, slippageModel.intercept);

--- a/src/utils/slippage_model_manager.ts
+++ b/src/utils/slippage_model_manager.ts
@@ -92,9 +92,9 @@ const calculateExpectedSlippageForModel = (
 
     const volumeTerm = volumeUsd.times(slippageModel.volumeCoefficient);
     const slippageTerm = maxSlippageRate.times(ONE_IN_BASE_POINTS).times(slippageModel.slippageCoefficient);
-    const expectedSlippage = slippageTerm.plus(volumeTerm).plus(slippageModel.intercept);
+    const expectedSlippage = BigNumber.sum(slippageTerm, volumeTerm, slippageModel.intercept);
     const expectedSlippageCap = maxSlippageRate.times(-1); // `maxSlippageRate` is specified with a positive number while `expectedSlippage` is normally negative.
-    return expectedSlippage.lt(expectedSlippageCap) ? expectedSlippageCap : expectedSlippage;
+    return BigNumber.max(expectedSlippage, expectedSlippageCap);
 };
 
 /**

--- a/src/utils/slippage_model_manager.ts
+++ b/src/utils/slippage_model_manager.ts
@@ -87,7 +87,9 @@ const calculateExpectedSlippageForModel = (
     const slippageTerm = maxSlippageRate.times(ONE_IN_BASE_POINTS).times(slippageModel.slippageCoefficient);
     const expectedSlippage = BigNumber.sum(slippageTerm, volumeTerm, slippageModel.intercept);
     const expectedSlippageCap = maxSlippageRate.times(-1); // `maxSlippageRate` is specified with a positive number while `expectedSlippage` is normally negative.
-    return BigNumber.max(expectedSlippage, expectedSlippageCap);
+
+    // Return 0 if the expected slippage is positive since the model shouldn't predict a positive slippage.
+    return BigNumber.min(new BigNumber(0), BigNumber.max(expectedSlippage, expectedSlippageCap));
 };
 
 /**

--- a/src/utils/slippage_model_manager.ts
+++ b/src/utils/slippage_model_manager.ts
@@ -1,3 +1,4 @@
+import { ERC20BridgeSource } from '@0x/asset-swapper';
 import { BigNumber } from '@0x/utils';
 import { Counter } from 'prom-client';
 
@@ -92,7 +93,7 @@ const calculateExpectedSlippageForModel = (
     const volumeTerm = volumeUsd.times(slippageModel.volumeCoefficient);
     const slippageTerm = maxSlippageRate.times(ONE_IN_BASE_POINTS).times(slippageModel.slippageCoefficient);
     const expectedSlippage = slippageTerm.plus(volumeTerm).plus(slippageModel.intercept);
-    const expectedSlippageCap = maxSlippageRate.times(-1); // `maxSlippageRate` is specified with a postive number while `expectedSlippage` is normally negative.
+    const expectedSlippageCap = maxSlippageRate.times(-1); // `maxSlippageRate` is specified with a positive number while `expectedSlippage` is normally negative.
     return expectedSlippage.lt(expectedSlippageCap) ? expectedSlippageCap : expectedSlippage;
 };
 
@@ -133,41 +134,69 @@ export class SlippageModelManager {
         sources: GetSwapQuoteResponseLiquiditySource[],
         maxSlippageRate: number,
     ): BigNumber | null {
-        const slippageModelCacheForPair = this._cachedSlippageModel.get(pairUtils.toKey(buyToken, sellToken)) || null;
+        let expectedSlippage = new BigNumber(0);
+        for (const source of sources) {
+            if (source.proportion.isEqualTo(0)) {
+                continue;
+            }
 
+            const singleSourceSlippage = this.calculateSingleSourceExpectedSlippage(
+                buyToken,
+                sellToken,
+                buyAmount,
+                sellAmount,
+                source,
+                maxSlippageRate,
+            );
+
+            if (singleSourceSlippage === null) {
+                return null;
+            }
+            expectedSlippage = expectedSlippage.plus(singleSourceSlippage);
+        }
+        return expectedSlippage;
+    }
+
+    private calculateSingleSourceExpectedSlippage(
+        buyToken: string,
+        sellToken: string,
+        buyAmount: BigNumber,
+        sellAmount: BigNumber,
+        source: GetSwapQuoteResponseLiquiditySource,
+        maxSlippageRate: number,
+    ): BigNumber | null {
+        // For 0x native source, the source name should be '0x' instead of 'Native', but check both to be future proof.
+        if (source.name === '0x' || source.name === ERC20BridgeSource.Native) {
+            return new BigNumber(0);
+        }
+
+        const slippageModelCacheForPair = this._cachedSlippageModel.get(pairUtils.toKey(buyToken, sellToken));
         // Slippage models for given pair is not available
-        if (slippageModelCacheForPair === null) {
+        if (slippageModelCacheForPair === undefined) {
             return null;
         }
 
-        let expectedSlippage: BigNumber = new BigNumber(0);
-        for (const source of sources) {
-            if (source.proportion.isGreaterThan(0)) {
-                const slippageModel = slippageModelCacheForPair.get(source.name) || null;
-                if (slippageModel === null) {
-                    // Slippage model for given source is not available
-                    return null;
-                } else {
-                    const token0Amount = source.proportion.times(
-                        slippageModel.token0 === buyToken.toLowerCase() ? buyAmount : sellAmount,
-                    );
-
-                    const expectedSlippageOfSource = calculateExpectedSlippageForModel(
-                        token0Amount,
-                        new BigNumber(maxSlippageRate),
-                        slippageModel,
-                    );
-
-                    // Volume for given source is too small for a reasonable prediction
-                    if (expectedSlippageOfSource === null) {
-                        return null;
-                    }
-
-                    expectedSlippage = expectedSlippage.plus(source.proportion.times(expectedSlippageOfSource));
-                }
-            }
+        const slippageModel = slippageModelCacheForPair.get(source.name);
+        if (slippageModel == undefined) {
+            return null;
         }
-        return expectedSlippage;
+
+        const token0Amount = source.proportion.times(
+            slippageModel.token0 === buyToken.toLowerCase() ? buyAmount : sellAmount,
+        );
+
+        const expectedSlippageOfSource = calculateExpectedSlippageForModel(
+            token0Amount,
+            new BigNumber(maxSlippageRate),
+            slippageModel,
+        );
+
+        // Volume for given source is too small for a reasonable prediction
+        if (expectedSlippageOfSource === null) {
+            return null;
+        }
+
+        return source.proportion.times(expectedSlippageOfSource);
     }
 
     /**

--- a/src/utils/slippage_model_manager.ts
+++ b/src/utils/slippage_model_manager.ts
@@ -140,7 +140,7 @@ export class SlippageModelManager {
                 continue;
             }
 
-            const singleSourceSlippage = this.calculateSingleSourceExpectedSlippage(
+            const singleSourceSlippage = this._calculateSingleSourceExpectedSlippage(
                 buyToken,
                 sellToken,
                 buyAmount,
@@ -157,7 +157,7 @@ export class SlippageModelManager {
         return expectedSlippage;
     }
 
-    private calculateSingleSourceExpectedSlippage(
+    private _calculateSingleSourceExpectedSlippage(
         buyToken: string,
         sellToken: string,
         buyAmount: BigNumber,
@@ -177,7 +177,7 @@ export class SlippageModelManager {
         }
 
         const slippageModel = slippageModelCacheForPair.get(source.name);
-        if (slippageModel == undefined) {
+        if (slippageModel === undefined) {
             return null;
         }
 

--- a/test/utils/slippage_model_manager_test.ts
+++ b/test/utils/slippage_model_manager_test.ts
@@ -71,6 +71,7 @@ describe('SlippageModelManager', () => {
             // Then
             expect(expectedSlippage).to.deep.equal(new BigNumber(-0.00019));
         });
+
         it('should return correct expected slippage if selling USDC', async () => {
             // Given
             const s3Client = createMockS3Client(slippageModels);
@@ -95,6 +96,32 @@ describe('SlippageModelManager', () => {
             // Then
             expect(expectedSlippage).to.deep.equal(new BigNumber(-0.00019));
         });
+
+        it('should return expected slippage for small trades', async () => {
+            // Given
+            const s3Client = createMockS3Client(slippageModels);
+            const slippageModelManager = new SlippageModelManager(s3Client);
+            await slippageModelManager.initializeAsync();
+
+            // When
+            const expectedSlippage = slippageModelManager.calculateExpectedSlippage(
+                usdc,
+                weth,
+                new BigNumber('250000000'), // $250
+                new BigNumber('250000'),
+                [
+                    {
+                        name: 'source 1',
+                        proportion: new BigNumber(1),
+                    },
+                ],
+                0.03,
+            );
+
+            // Then
+            expect(expectedSlippage).to.deep.equal(new BigNumber(-0.00009025));
+        });
+
         it('should return capped expected slippage if volume is huge', async () => {
             // Given
             const s3Client = createMockS3Client(slippageModels);
@@ -119,6 +146,7 @@ describe('SlippageModelManager', () => {
             // Then
             expect(expectedSlippage).to.deep.equal(new BigNumber(-0.03));
         });
+
         it('should return 0 slippage when source is 0x (Native)', async () => {
             // Given
             const s3Client = createMockS3Client(slippageModels);
@@ -143,6 +171,7 @@ describe('SlippageModelManager', () => {
             // Then
             expect(expectedSlippage).to.deep.equal(new BigNumber(0));
         });
+
         it('should return 0 slippage when source is "Native"', async () => {
             // Given
             const s3Client = createMockS3Client(slippageModels);
@@ -167,6 +196,7 @@ describe('SlippageModelManager', () => {
             // Then
             expect(expectedSlippage).to.deep.equal(new BigNumber(0));
         });
+
         it('should return 0 slippage when sole source is 0x (Native) even when the pair is not supported', async () => {
             // Given
             const s3Client = createMockS3Client(slippageModels);
@@ -191,6 +221,7 @@ describe('SlippageModelManager', () => {
             // Then
             expect(expectedSlippage).to.deep.equal(new BigNumber(0));
         });
+
         it('should return aggregated slippage if there are multiple sources', async () => {
             // Given
             const s3Client = createMockS3Client(slippageModels);
@@ -219,6 +250,7 @@ describe('SlippageModelManager', () => {
             // Then
             expect(expectedSlippage).to.deep.equal(new BigNumber(-0.000185));
         });
+
         it('should return aggregated slippage when there are multiple sources including 0x', async () => {
             // Given
             const s3Client = createMockS3Client(slippageModels);
@@ -247,6 +279,7 @@ describe('SlippageModelManager', () => {
             // Then
             expect(expectedSlippage).to.deep.equal(new BigNumber(-0.00007));
         });
+
         it('should return null if pair is not supported', async () => {
             // Given
             const s3Client = createMockS3Client(slippageModels);
@@ -271,6 +304,7 @@ describe('SlippageModelManager', () => {
             // Then
             expect(expectedSlippage).to.deep.equal(null);
         });
+
         it('should return null if any source is not supported', async () => {
             // Given
             const s3Client = createMockS3Client(slippageModels);
@@ -298,54 +332,6 @@ describe('SlippageModelManager', () => {
 
             // Then
             expect(expectedSlippage).to.deep.equal(null);
-        });
-        it('should return null if trade size is less than 10k USD', async () => {
-            // Given
-            const s3Client = createMockS3Client(slippageModels);
-            const slippageModelManager = new SlippageModelManager(s3Client);
-            await slippageModelManager.initializeAsync();
-
-            // When
-            const expectedSlippage = slippageModelManager.calculateExpectedSlippage(
-                usdc,
-                weth,
-                new BigNumber('999000000'),
-                new BigNumber('1000000'),
-                [
-                    {
-                        name: 'source 1',
-                        proportion: new BigNumber(1),
-                    },
-                ],
-                0.03,
-            );
-
-            // Then
-            expect(expectedSlippage).to.deep.equal(null);
-        });
-        it('should return 0 for 0x (Native) even if trade size is less than 10k USD', async () => {
-            // Given
-            const s3Client = createMockS3Client(slippageModels);
-            const slippageModelManager = new SlippageModelManager(s3Client);
-            await slippageModelManager.initializeAsync();
-
-            // When
-            const expectedSlippage = slippageModelManager.calculateExpectedSlippage(
-                usdc,
-                weth,
-                new BigNumber('999000000'),
-                new BigNumber('1000000'),
-                [
-                    {
-                        name: '0x',
-                        proportion: new BigNumber(1),
-                    },
-                ],
-                0.03,
-            );
-
-            // Then
-            expect(expectedSlippage).to.deep.equal(new BigNumber(0));
         });
     });
 });

--- a/test/utils/slippage_model_manager_test.ts
+++ b/test/utils/slippage_model_manager_test.ts
@@ -122,6 +122,41 @@ describe('SlippageModelManager', () => {
             expect(expectedSlippage).to.deep.equal(new BigNumber(-0.00009025));
         });
 
+        it('should return 0 slippage if the expected slippage from the model is positive', async () => {
+            // Given
+            const s3Client = createMockS3Client([
+                {
+                    token0: usdc,
+                    token1: weth,
+                    source: 'positive intercept source',
+                    slippageCoefficient: -0.0000004,
+                    volumeCoefficient: -0.000000002,
+                    intercept: 1,
+                    token0PriceInUsd: 0.000001,
+                },
+            ]);
+            const slippageModelManager = new SlippageModelManager(s3Client);
+            await slippageModelManager.initializeAsync();
+
+            // When
+            const expectedSlippage = slippageModelManager.calculateExpectedSlippage(
+                usdc,
+                weth,
+                new BigNumber('100000000000'),
+                new BigNumber('1000000'),
+                [
+                    {
+                        name: 'positive intercept source',
+                        proportion: new BigNumber(1),
+                    },
+                ],
+                0.03,
+            );
+
+            // Then
+            expect(expectedSlippage).to.deep.equal(new BigNumber(0));
+        });
+
         it('should return capped expected slippage if volume is huge', async () => {
             // Given
             const s3Client = createMockS3Client(slippageModels);

--- a/test/utils/slippage_model_manager_test.ts
+++ b/test/utils/slippage_model_manager_test.ts
@@ -119,6 +119,78 @@ describe('SlippageModelManager', () => {
             // Then
             expect(expectedSlippage).to.deep.equal(new BigNumber(-0.03));
         });
+        it('should return 0 slippage when source is 0x (Native)', async () => {
+            // Given
+            const s3Client = createMockS3Client(slippageModels);
+            const slippageModelManager = new SlippageModelManager(s3Client);
+            await slippageModelManager.initializeAsync();
+
+            // When
+            const expectedSlippage = slippageModelManager.calculateExpectedSlippage(
+                usdc,
+                weth,
+                new BigNumber('100000000000'),
+                new BigNumber('1000000'),
+                [
+                    {
+                        name: '0x',
+                        proportion: new BigNumber(1),
+                    },
+                ],
+                0.03,
+            );
+
+            // Then
+            expect(expectedSlippage).to.deep.equal(new BigNumber(0));
+        });
+        it('should return 0 slippage when source is "Native"', async () => {
+            // Given
+            const s3Client = createMockS3Client(slippageModels);
+            const slippageModelManager = new SlippageModelManager(s3Client);
+            await slippageModelManager.initializeAsync();
+
+            // When
+            const expectedSlippage = slippageModelManager.calculateExpectedSlippage(
+                usdc,
+                weth,
+                new BigNumber('100000000000'),
+                new BigNumber('1000000'),
+                [
+                    {
+                        name: 'Native',
+                        proportion: new BigNumber(1),
+                    },
+                ],
+                0.03,
+            );
+
+            // Then
+            expect(expectedSlippage).to.deep.equal(new BigNumber(0));
+        });
+        it('should return 0 slippage when sole source is 0x (Native) even when the pair is not supported', async () => {
+            // Given
+            const s3Client = createMockS3Client(slippageModels);
+            const slippageModelManager = new SlippageModelManager(s3Client);
+            await slippageModelManager.initializeAsync();
+
+            // When
+            const expectedSlippage = slippageModelManager.calculateExpectedSlippage(
+                weth,
+                otherToken,
+                new BigNumber('100000000000'),
+                new BigNumber('1000000'),
+                [
+                    {
+                        name: '0x',
+                        proportion: new BigNumber(1),
+                    },
+                ],
+                0.03,
+            );
+
+            // Then
+            expect(expectedSlippage).to.deep.equal(new BigNumber(0));
+        });
         it('should return aggregated slippage if there are multiple sources', async () => {
             // Given
             const s3Client = createMockS3Client(slippageModels);
@@ -146,6 +218,34 @@ describe('SlippageModelManager', () => {
 
             // Then
             expect(expectedSlippage).to.deep.equal(new BigNumber(-0.000185));
+        });
+        it('should return aggregated slippage when there are multiple sources including 0x', async () => {
+            // Given
+            const s3Client = createMockS3Client(slippageModels);
+            const slippageModelManager = new SlippageModelManager(s3Client);
+            await slippageModelManager.initializeAsync();
+
+            // When
+            const expectedSlippage = slippageModelManager.calculateExpectedSlippage(
+                usdc,
+                weth,
+                new BigNumber('100000000000'),
+                new BigNumber('1000000'),
+                [
+                    {
+                        name: 'source 1',
+                        proportion: new BigNumber(0.5),
+                    },
+                    {
+                        name: '0x',
+                        proportion: new BigNumber(0.5),
+                    },
+                ],
+                0.03,
+            );
+
+            // Then
+            expect(expectedSlippage).to.deep.equal(new BigNumber(-0.00007));
         });
         it('should return null if pair is not supported', async () => {
             // Given
@@ -222,6 +322,30 @@ describe('SlippageModelManager', () => {
 
             // Then
             expect(expectedSlippage).to.deep.equal(null);
+        });
+        it('should return 0 for 0x (Native) even if trade size is less than 10k USD', async () => {
+            // Given
+            const s3Client = createMockS3Client(slippageModels);
+            const slippageModelManager = new SlippageModelManager(s3Client);
+            await slippageModelManager.initializeAsync();
+
+            // When
+            const expectedSlippage = slippageModelManager.calculateExpectedSlippage(
+                usdc,
+                weth,
+                new BigNumber('999000000'),
+                new BigNumber('1000000'),
+                [
+                    {
+                        name: '0x',
+                        proportion: new BigNumber(1),
+                    },
+                ],
+                0.03,
+            );
+
+            // Then
+            expect(expectedSlippage).to.deep.equal(new BigNumber(0));
         });
     });
 });


### PR DESCRIPTION
# Description

* Treat 0x (Native) source's slippage as 0 in `SlippageModelManager`
* Remove $10k usd threshold.
* Return 0 slippage if the slippage model predicts a positive slippage.



# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
