### PR TITLE
chore: Disable `max-file-line-count` tslint rule and remove its references [TKR-484]

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,3 @@
-// tslint:disable:max-file-line-count
 import { assert } from '@0x/assert';
 import {
     BlockParamLiteral,

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -1,4 +1,3 @@
-// tslint:disable:max-file-line-count
 import { isAPIError, isRevertError } from '@0x/api-utils';
 import { ERC20BridgeSource, RfqRequestOpts, SwapQuoterError } from '@0x/asset-swapper';
 import {

--- a/src/services/meta_transaction_service.ts
+++ b/src/services/meta_transaction_service.ts
@@ -455,4 +455,3 @@ function calculateProtocolFeeRequiredForOrders(gasPrice: BigNumber, orders: (Sig
     ).length;
     return gasPrice.times(nativeOrderCount).times(PROTOCOL_FEE_MULTIPLIER);
 }
-// tslint:disable-next-line: max-file-line-count

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -812,4 +812,3 @@ export class SwapService {
         }
     }
 }
-

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -813,4 +813,3 @@ export class SwapService {
     }
 }
 
-// tslint:disable:max-file-line-count

--- a/src/services/transaction_watcher_signer_service.ts
+++ b/src/services/transaction_watcher_signer_service.ts
@@ -552,4 +552,3 @@ export class TransactionWatcherSignerService {
         await this._kvRepository.save(statusKV!);
     }
 }
-// tslint:disable-line:max-file-line-count

--- a/src/types.ts
+++ b/src/types.ts
@@ -461,4 +461,3 @@ export enum OrderEventEndState {
     // future.
     StoppedWatching = 'STOPPED_WATCHING',
 }
-

--- a/src/types.ts
+++ b/src/types.ts
@@ -462,4 +462,3 @@ export enum OrderEventEndState {
     StoppedWatching = 'STOPPED_WATCHING',
 }
 
-// tslint:disable-line:max-file-line-count

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         "custom-no-magic-numbers": false,
         "no-unnecessary-type-assertion": false,
+        "max-file-line-count": false,
         "arrow-parens": false
     },
     "linterOptions": {


### PR DESCRIPTION
# Description

* Disable `max-file-line-count` prior to `assest-swapper` migration to avoid lint error issues. 
* Remove references to `max-file-line-count`


# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
