### PR TITLE
fix: log ammQuoteUniqueId for metatransaction quote report

### DIFF
--- a/src/asset-swapper/utils/quote_report_generator.ts
+++ b/src/asset-swapper/utils/quote_report_generator.ts
@@ -90,6 +90,7 @@ export interface ExtendedQuoteReportSources {
 }
 
 export interface ExtendedQuoteReport {
+    ammQuoteUniqueId?: string;
     quoteId?: string;
     taker?: string;
     timestamp: number;

--- a/src/services/meta_transaction_service.ts
+++ b/src/services/meta_transaction_service.ts
@@ -137,7 +137,7 @@ export class MetaTransactionService {
                     taker: params.takerAddress,
                     quoteReportSources: quote.extendedQuoteReportSources,
                     submissionBy: 'gaslessSwapAmm',
-                    decodedUniqueId: params.quoteUniqueId ? params.quoteUniqueId : quote.decodedUniqueId,
+                    ammQuoteUniqueId: params.quoteUniqueId,
                     buyTokenAddress: quote.buyTokenAddress,
                     sellTokenAddress: quote.sellTokenAddress,
                     buyAmount: params.buyAmount,

--- a/src/utils/quote_report_utils.ts
+++ b/src/utils/quote_report_utils.ts
@@ -1,6 +1,4 @@
-import type { PinoLogger } from '@0x/api-utils';
 import { Producer } from 'kafkajs';
-import _ = require('lodash');
 
 import {
     BigNumber,
@@ -33,7 +31,7 @@ interface ExtendedQuoteReportForTakerTxn extends QuoteReportLogOptionsBase {
 interface ExtendedQuoteReportForGaslessSwapAmm extends QuoteReportLogOptionsBase {
     quoteReportSources: ExtendedQuoteReportSources;
     submissionBy: 'gaslessSwapAmm';
-    decodedUniqueId: string;
+    ammQuoteUniqueId?: string;
 }
 
 export interface WrappedSignedNativeOrderMM {
@@ -67,6 +65,7 @@ export function publishQuoteReport(
 ): void {
     if (kafkaProducer && KAFKA_TOPIC_QUOTE_REPORT) {
         const extendedQuoteReport: ExtendedQuoteReport = {
+            ammQuoteUniqueId: logOpts.submissionBy === 'gaslessSwapAmm' ? logOpts.ammQuoteUniqueId : undefined,
             quoteId: logOpts.quoteId,
             taker: logOpts.taker,
             timestamp:
@@ -79,10 +78,7 @@ export function publishQuoteReport(
             sellTokenAddress: logOpts.sellTokenAddress,
             integratorId: logOpts.integratorId,
             slippageBips: logOpts.slippage ? logOpts.slippage * BIPS_IN_INT : undefined,
-            decodedUniqueId:
-                logOpts.submissionBy === 'taker' || logOpts.submissionBy === 'gaslessSwapAmm'
-                    ? logOpts.decodedUniqueId
-                    : undefined,
+            decodedUniqueId: logOpts.submissionBy === 'taker' ? logOpts.decodedUniqueId : undefined,
             sourcesConsidered: logOpts.quoteReportSources.sourcesConsidered.map(jsonifyFillData),
             sourcesDelivered: logOpts.quoteReportSources.sourcesDelivered?.map(jsonifyFillData),
             blockNumber: logOpts.blockNumber,


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

`decodedUniqueId` doesn't show up in the database. I thought this translated (somewhere) to ammQuoteUniqueId, but the mysteries of quote report are not that easily divined.

Send `ammQuoteUniqueId` instead.

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
