### PR TITLE
fix: Fix valid pool path check logic in `UniswapV3Sampler`

### DIFF
--- a/contracts/src/UniswapV3Sampler.sol
+++ b/contracts/src/UniswapV3Sampler.sol
@@ -111,8 +111,8 @@ contract UniswapV3Sampler {
             // Pick the best result from the pool paths.
             uint256 topBuyAmount = 0;
             for (uint256 j = 0; j < poolPaths.length; ++j) {
-                if (address(poolPaths[j][0]) == address(0)) {
-                    break;
+                if (!isValidPoolPath(poolPaths[j])) {
+                    continue;
                 }
 
                 bytes memory uniswapPath = _toUniswapPath(path, poolPaths[j]);
@@ -175,8 +175,8 @@ contract UniswapV3Sampler {
             // Pick the best result from the pool paths.
             uint256 topSellAmount = 0;
             for (uint256 j = 0; j < poolPaths.length; ++j) {
-                if (address(poolPaths[j][0]) == address(0)) {
-                    break;
+                if (!isValidPoolPath(poolPaths[j])) {
+                    continue;
                 }
 
                 // quoter requires path to be reversed for buys.
@@ -361,6 +361,15 @@ contract UniswapV3Sampler {
         }
         if (pool.token1().balanceOf(address(pool)) == 0) {
             return false;
+        }
+        return true;
+    }
+
+    function isValidPoolPath(IUniswapV3Pool[] memory poolPaths) private pure returns (bool) {
+        for (uint256 i = 0; i < poolPaths.length; i++) {
+            if (address(poolPaths[i]) == address(0)) {
+                return false;
+            }
         }
         return true;
     }


### PR DESCRIPTION
* It is not sufficient to only check the first pool of a pool path

<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

<!--- Describe your changes in detail -->

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
