### PR TITLE
fix: Skip bad pool data in Balancer v1 cache [TKR-627]

### DIFF
--- a/src/asset-swapper/utils/market_operation_utils/pools_cache/balancer_pools_cache.ts
+++ b/src/asset-swapper/utils/market_operation_utils/pools_cache/balancer_pools_cache.ts
@@ -80,6 +80,9 @@ export class BalancerPoolsCache extends AbstractPoolsCache {
                     try {
                         // The list of pools must be relevant to `from` and `to`  for `parsePoolData`
                         const poolData = parsePoolData([pool], from, to);
+                        if (poolData.length === 0) {
+                            continue;
+                        }
                         fromToPools[from][to].push(poolData[0]);
                         // Cache this as we progress through
                         const expiresAt = Date.now() + this._cacheTimeMs;


### PR DESCRIPTION
# Description

`parsePoolData` can return an empty list. Unless they are filtered out, an `undefined` is populated in the pool cache and will cause a runtime error for quote of tokens that are associated with `undefined` pool cache.

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
