### PR TITLE
chore: Refactor `SignedNativeOrder` related types [TKR-623]

### DIFF
--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -33,16 +33,26 @@ export interface OrderPrunerOpts {
     permittedOrderFeeTypes: Set<OrderPrunerPermittedFeeTypes>;
 }
 
-export interface SignedOrder<T> {
-    order: T;
-    type: FillQuoteTransformerOrderType.Limit | FillQuoteTransformerOrderType.Rfq | FillQuoteTransformerOrderType.Otc;
+export interface SignedOrder {
     signature: Signature;
 }
 
-export type SignedNativeOrder =
-    | SignedOrder<LimitOrderFields>
-    | SignedOrder<RfqOrderFields>
-    | SignedOrder<OtcOrderFields>;
+export interface SignedLimitOrder extends SignedOrder {
+    order: LimitOrderFields;
+    type: FillQuoteTransformerOrderType.Limit;
+}
+
+export interface SignedRfqOrder extends SignedOrder {
+    order: RfqOrderFields;
+    type: FillQuoteTransformerOrderType.Rfq;
+}
+
+export interface SignedOtcOrder extends SignedOrder {
+    order: OtcOrderFields;
+    type: FillQuoteTransformerOrderType.Otc;
+}
+
+export type SignedNativeOrder = SignedLimitOrder | SignedRfqOrder | SignedOtcOrder;
 export type NativeOrderWithFillableAmounts = SignedNativeOrder & NativeOrderFillableAmountFields;
 
 /**

--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -33,23 +33,22 @@ export interface OrderPrunerOpts {
     permittedOrderFeeTypes: Set<OrderPrunerPermittedFeeTypes>;
 }
 
-export interface SignedOrder {
+export interface SignedLimitOrder {
+    order: LimitOrderFields;
+    type: FillQuoteTransformerOrderType.Limit;
     signature: Signature;
 }
 
-export interface SignedLimitOrder extends SignedOrder {
-    order: LimitOrderFields;
-    type: FillQuoteTransformerOrderType.Limit;
-}
-
-export interface SignedRfqOrder extends SignedOrder {
+export interface SignedRfqOrder {
     order: RfqOrderFields;
     type: FillQuoteTransformerOrderType.Rfq;
+    signature: Signature;
 }
 
-export interface SignedOtcOrder extends SignedOrder {
+export interface SignedOtcOrder {
     order: OtcOrderFields;
     type: FillQuoteTransformerOrderType.Otc;
+    signature: Signature;
 }
 
 export type SignedNativeOrder = SignedLimitOrder | SignedRfqOrder | SignedOtcOrder;

--- a/src/utils/quote_comparison_utils.ts
+++ b/src/utils/quote_comparison_utils.ts
@@ -1,6 +1,6 @@
-import { OtcOrder, OtcOrderFields } from '@0x/protocol-utils';
+import { FillQuoteTransformerOrderType, OtcOrder } from '@0x/protocol-utils';
 import { BigNumber, SignedNativeOrder, V4RFQIndicativeQuote } from '../asset-swapper';
-import { SignedOrder } from '../asset-swapper/types';
+import { SignedOtcOrder } from '../asset-swapper/types';
 import { ONE_SECOND_MS } from '../constants';
 
 /**
@@ -95,6 +95,6 @@ const isSignedNativeOrder = (quote: V4RFQIndicativeQuote | SignedNativeOrder): q
     return (quote as SignedNativeOrder).order !== undefined;
 };
 
-const isOtcOrder = (order: SignedNativeOrder): order is SignedOrder<OtcOrderFields> => {
-    return (order as SignedOrder<OtcOrderFields>).order.expiryAndNonce !== undefined;
+const isOtcOrder = (order: SignedNativeOrder): order is SignedOtcOrder => {
+    return order.type === FillQuoteTransformerOrderType.Otc;
 };

--- a/test/asset-swapper/dex_sampler_test.ts
+++ b/test/asset-swapper/dex_sampler_test.ts
@@ -10,8 +10,8 @@ import {
 import { FillQuoteTransformerOrderType, LimitOrderFields, SignatureType } from '@0x/protocol-utils';
 import { BigNumber, hexUtils, NULL_ADDRESS } from '@0x/utils';
 import * as _ from 'lodash';
+import { SignedLimitOrder } from '../../src/asset-swapper/types';
 
-import { SignedOrder } from '../../src/asset-swapper/types';
 import { DexOrderSampler, getSampleAmounts } from '../../src/asset-swapper/utils/market_operation_utils/sampler';
 import { ERC20BridgeSource } from '../../src/asset-swapper/utils/market_operation_utils/types';
 import { TokenAdjacencyGraphBuilder } from '../../src/asset-swapper/utils/token_adjacency_graph';
@@ -66,8 +66,8 @@ describe('DexSampler tests', () => {
         });
     });
 
-    function createOrder(overrides?: Partial<LimitOrderFields>): SignedOrder<LimitOrderFields> {
-        const o: SignedOrder<LimitOrderFields> = {
+    function createOrder(overrides?: Partial<LimitOrderFields>): SignedLimitOrder {
+        const o: SignedLimitOrder = {
             order: {
                 salt: generatePseudoRandomSalt(),
                 expiry: getRandomInteger(0, 2 ** 64),

--- a/test/asset-swapper/market_operation_utils_test.ts
+++ b/test/asset-swapper/market_operation_utils_test.ts
@@ -7,13 +7,7 @@ import {
     Numberish,
     randomAddress,
 } from '@0x/contracts-test-utils';
-import {
-    FillQuoteTransformerOrderType,
-    LimitOrder,
-    LimitOrderFields,
-    RfqOrder,
-    SignatureType,
-} from '@0x/protocol-utils';
+import { FillQuoteTransformerOrderType, LimitOrder, RfqOrder, SignatureType } from '@0x/protocol-utils';
 import { BigNumber, hexUtils, NULL_BYTES } from '@0x/utils';
 import { Pool } from 'balancer-labs-sor-v1/dist/types';
 import * as _ from 'lodash';
@@ -27,7 +21,7 @@ import {
     SignedNativeOrder,
     TokenAdjacencyGraph,
 } from '../../src/asset-swapper';
-import { Integrator, SignedOrder } from '../../src/asset-swapper/types';
+import { Integrator, SignedLimitOrder } from '../../src/asset-swapper/types';
 import { MarketOperationUtils } from '../../src/asset-swapper/utils/market_operation_utils/';
 import {
     BUY_SOURCE_FILTER_BY_CHAIN_ID,
@@ -111,7 +105,7 @@ async function getMarketBuyOrdersAsync(
     return utils.getOptimizerResultAsync(nativeOrders, makerAmount, MarketOperation.Buy, opts);
 }
 
-function toRfqClientV1Price(order: SignedOrder<LimitOrderFields>): RfqClientV1Price {
+function toRfqClientV1Price(order: SignedLimitOrder): RfqClientV1Price {
     return {
         expiry: order.order.expiry,
         kind: 'rfq',
@@ -182,7 +176,7 @@ describe('MarketOperationUtils tests', () => {
         return requestor;
     }
 
-    function createOrdersFromSellRates(takerAmount: BigNumber, rates: Numberish[]): SignedOrder<LimitOrderFields>[] {
+    function createOrdersFromSellRates(takerAmount: BigNumber, rates: Numberish[]): SignedLimitOrder[] {
         const singleTakerAmount = takerAmount.div(rates.length).integerValue(BigNumber.ROUND_UP);
         return rates.map((r) => {
             const o: SignedNativeOrder = {
@@ -199,7 +193,7 @@ describe('MarketOperationUtils tests', () => {
         });
     }
 
-    function createOrdersFromBuyRates(makerAmount: BigNumber, rates: Numberish[]): SignedOrder<LimitOrderFields>[] {
+    function createOrdersFromBuyRates(makerAmount: BigNumber, rates: Numberish[]): SignedLimitOrder[] {
         const singleMakerAmount = makerAmount.div(rates.length).integerValue(BigNumber.ROUND_UP);
         return rates.map((r) => {
             const o: SignedNativeOrder = {

--- a/test/utils/quote_comparison_utils_test.ts
+++ b/test/utils/quote_comparison_utils_test.ts
@@ -8,15 +8,16 @@ import {
     SignedNativeOrder,
     V4RFQIndicativeQuote,
 } from '../../src/asset-swapper';
+import { SignedRfqOrder } from '../../src/asset-swapper/types';
 import { ONE_SECOND_MS } from '../../src/asset-swapper/utils/market_operation_utils/constants';
 import { ONE_MINUTE_MS, RFQM_MINIMUM_EXPIRY_DURATION_MS, ZERO } from '../../src/constants';
 import { getBestQuote } from '../../src/utils/quote_comparison_utils';
 
 const NEVER_EXPIRES = new BigNumber('9999999999999999');
 
-function createBaseOrder(): SignedNativeOrder {
+function createBaseOrder(): SignedRfqOrder {
     return {
-        type: FillQuoteTransformerOrderType.Limit,
+        type: FillQuoteTransformerOrderType.Rfq,
         order: {
             ...new RfqOrder({
                 makerAmount: ZERO,


### PR DESCRIPTION
* Use discriminating unions for `SignedNativeOrder` to make invalid type (e.g. `LimitOrder` `type` with `RfqOrderFields` `order` not possible).

<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

<!--- Describe your changes in detail -->

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
