### PR TITLE
chore: Remove `inputAmount` from `FillAdjustor::adjustFills` [TKR-623]

### DIFF
--- a/src/asset-swapper/utils/market_operation_utils/identity_fill_adjustor.ts
+++ b/src/asset-swapper/utils/market_operation_utils/identity_fill_adjustor.ts
@@ -1,11 +1,9 @@
-import { BigNumber } from '@0x/utils';
-
 import { MarketOperation } from '../../types';
 
 import { Fill, FillAdjustor } from './types';
 
 export class IdentityFillAdjustor implements FillAdjustor {
-    public adjustFills(_side: MarketOperation, fills: Fill[], _amount: BigNumber): Fill[] {
+    public adjustFills(_side: MarketOperation, fills: Fill[]): Fill[] {
         return fills;
     }
 }

--- a/src/asset-swapper/utils/market_operation_utils/types.ts
+++ b/src/asset-swapper/utils/market_operation_utils/types.ts
@@ -611,5 +611,5 @@ export interface ComparisonPrice {
 }
 
 export interface FillAdjustor {
-    adjustFills: (side: MarketOperation, fills: Fill[], amount: BigNumber) => Fill[];
+    adjustFills: (side: MarketOperation, fills: Fill[]) => Fill[];
 }

--- a/src/utils/slippage_model_fill_adjustor.ts
+++ b/src/utils/slippage_model_fill_adjustor.ts
@@ -12,7 +12,7 @@ export class SlippageModelFillAdjustor implements FillAdjustor {
         private readonly maxSlippageRate: number,
     ) {}
 
-    public adjustFills(side: MarketOperation, fills: Fill<FillData>[], _amount: BigNumber): Fill<FillData>[] {
+    public adjustFills(side: MarketOperation, fills: Fill<FillData>[]): Fill<FillData>[] {
         return fills.map((f) => {
             // Mostly negative, as in the trade experiences a worst price
             // e.g -0.02938


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

The parameter  `inputAmount` of `adjustFills` is never used. 

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
