### PR TITLE
fix: Restore invalid two hop `DexSample` filtering logic

### DIFF
--- a/src/asset-swapper/utils/market_operation_utils/path_optimizer.ts
+++ b/src/asset-swapper/utils/market_operation_utils/path_optimizer.ts
@@ -112,8 +112,20 @@ export class PathOptimizer {
             return undefined;
         }
 
+        // Ensure the expected data we require exists. In the case where all hops reverted
+        // or there were no sources included that allowed for multi hop,
+        // we can end up with an empty, but not undefined, fill data.
+        const validTwoHopSamples = twoHopSamples.filter(
+            (sample) =>
+                sample &&
+                sample.fillData &&
+                sample.fillData.firstHopSource &&
+                sample.fillData.secondHopSource &&
+                sample.output.isGreaterThan(ZERO_AMOUNT),
+        );
+
         const singleSourceRoutablePaths = this.singleSourceSamplesToRoutablePaths(samples);
-        const twoHopRoutablePaths = this.twoHopSamplesToRoutablePaths(twoHopSamples);
+        const twoHopRoutablePaths = this.twoHopSamplesToRoutablePaths(validTwoHopSamples);
         const nativeOrderRoutablePaths = this.nativeOrdersToRoutablePaths(nativeOrders);
 
         const allRoutablePaths = [...singleSourceRoutablePaths, ...twoHopRoutablePaths, ...nativeOrderRoutablePaths];


### PR DESCRIPTION
* Two-hop `DexSample` may have an empty fill data when sampling was reverted.
* This logic was mistakenly removed in PR 1063 [0].

[0] https://github.com/0xProject/0x-api/pull/1063

<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
The title will be used to generate the [changelog](/CHANGELOG.md) and release notes, so be descriptive.
You can use prefixes other than fix: and feat: if you think your change should not go in the [changelog](/CHANGELOG.md).
When a new version is released, the API will automatically be deployed to all environments (once a week).
-->

# Description

<!--- Describe your changes in detail -->

# Testing Instructions

<!--- Please describe how reviewers can test your changes -->

# Checklist

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Update [documentation](https://github.com/0xProject/website/blob/development/mdx/api/index.mdx) as needed. **Website Documentation PR:**
-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Test changes on the staging environment with [Matcha API Staging](https://api-staging.matcha.xyz).

    -   [ ] SRA/Limit orders
    -   [ ] Swap endpoints
    -   [ ] Meta transaction endpoints
    -   [ ] Depth charts

    For more information see `0x API Matcha smoke test runbook` in Quip.
