### PR TITLE
fix: do not overwrite fillOtcOrderWithEth with fillOtcOrder

### DIFF
--- a/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
+++ b/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
@@ -336,7 +336,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumerBase {
                     .getABIEncodedTransactionData();
             }
             // if the otc orders makerToken is the native asset
-            if (isToETH) {
+            else if (isToETH) {
                 callData = this._exchangeProxy
                     .fillOtcOrderForEth(otcOrdersData[0].order, otcOrdersData[0].signature, sellAmount)
                     .getABIEncodedTransactionData();


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
-->

# Description

We were not utilizing `fillOtcOrderWithEth` when we should have. This was because we have two `if` statements, but the second should have been an `else if` since we wanted these conditions to be mutually exclusive
<!--- Describe your changes in detail -->

# Testing & Simbot Run

<!--- If your changes affect `swap` API (e.g. adding a new liquidity source, changes sampling or routing logic) include a link to Simbot run(s). -->

# Checklist

-   [ ] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [ ] Add tests to cover changes as needed.
-   [ ] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
