### PR TITLE
chore: circular deps part 2

### DIFF
--- a/src/asset-swapper/index.ts
+++ b/src/asset-swapper/index.ts
@@ -51,6 +51,8 @@ export {
     NATIVE_FEE_TOKEN_BY_CHAIN_ID,
     ZERO_AMOUNT,
 } from './utils/market_operation_utils/constants';
+export { UniswapV2FillData } from './utils/market_operation_utils/types';
+
 export {
     ERC20BridgeSource,
     GasSchedule,
@@ -59,8 +61,7 @@ export {
     FillData,
     GetMarketOrdersRfqOpts,
     OptimizedMarketOrder,
-    UniswapV2FillData,
-} from './utils/market_operation_utils/types';
+} from './types';
 
 export { TokenAdjacencyGraph } from './utils/token_adjacency_graph';
 export { IdentityFillAdjustor } from './utils/market_operation_utils/identity_fill_adjustor';

--- a/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
+++ b/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
@@ -34,16 +34,15 @@ import {
     CURVE_LIQUIDITY_PROVIDER_BY_CHAIN_ID,
     NATIVE_FEE_TOKEN_BY_CHAIN_ID,
 } from '../utils/market_operation_utils/constants';
+import { CurveFillData, FinalUniswapV3FillData, UniswapV2FillData } from '../utils/market_operation_utils/types';
+
 import {
-    CurveFillData,
     ERC20BridgeSource,
-    FinalUniswapV3FillData,
     NativeOtcOrderFillData,
     NativeRfqOrderFillData,
     OptimizedMarketBridgeOrder,
     OptimizedMarketOrder,
-    UniswapV2FillData,
-} from '../utils/market_operation_utils/types';
+} from '../types';
 
 import {
     multiplexOtcOrder,

--- a/src/asset-swapper/quote_consumers/quote_consumer_utils.ts
+++ b/src/asset-swapper/quote_consumers/quote_consumer_utils.ts
@@ -1,18 +1,21 @@
 import { FillQuoteTransformerData, FillQuoteTransformerOrderType } from '@0x/protocol-utils';
 
-import { ExchangeProxyContractOpts, MarketBuySwapQuote, MarketOperation, SwapQuote } from '../types';
 import {
-    createBridgeDataForBridgeOrder,
-    getErc20BridgeSourceToBridgeSource,
-} from '../utils/market_operation_utils/orders';
-import {
+    ExchangeProxyContractOpts,
+    MarketBuySwapQuote,
+    MarketOperation,
+    SwapQuote,
     ERC20BridgeSource,
     OptimizedMarketBridgeOrder,
     OptimizedMarketOrder,
     OptimizedOtcOrder,
     OptimizedRfqOrder,
     OptimizedLimitOrder,
-} from '../utils/market_operation_utils/types';
+} from '../types';
+import {
+    createBridgeDataForBridgeOrder,
+    getErc20BridgeSourceToBridgeSource,
+} from '../utils/market_operation_utils/orders';
 
 const MULTIPLEX_BATCH_FILL_SOURCES = [
     ERC20BridgeSource.UniswapV2,

--- a/src/asset-swapper/swap_quoter.ts
+++ b/src/asset-swapper/swap_quoter.ts
@@ -29,14 +29,8 @@ import { BancorService } from './utils/market_operation_utils/bancor_service';
 import { SAMPLER_ADDRESS, SOURCE_FLAGS, ZERO_AMOUNT } from './utils/market_operation_utils/constants';
 import { DexOrderSampler } from './utils/market_operation_utils/sampler';
 import { SourceFilters } from './utils/market_operation_utils/source_filters';
-import {
-    ERC20BridgeSource,
-    FillData,
-    GasSchedule,
-    GetMarketOrdersOpts,
-    OptimizedMarketOrder,
-    OptimizerResultWithReport,
-} from './utils/market_operation_utils/types';
+import { OptimizerResultWithReport } from './utils/market_operation_utils/types';
+import { ERC20BridgeSource, FillData, GasSchedule, GetMarketOrdersOpts, OptimizedMarketOrder } from './types';
 import { ProtocolFeeUtils } from './utils/protocol_fee_utils';
 import { QuoteRequestor } from './utils/quote_requestor';
 import { QuoteFillResult, simulateBestCaseFill, simulateWorstCaseFill } from './utils/quote_simulation';

--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -12,8 +12,14 @@ import {
 import { TakerRequestQueryParamsUnnested, V4SignedRfqOrder } from '@0x/quote-server';
 import { Fee } from '@0x/quote-server/lib/src/types';
 import { BigNumber } from '@0x/utils';
+import { RfqClient } from '../utils/rfq_client';
+import { QuoteRequestor } from './utils/quote_requestor';
+import {
+    FillQuoteTransformerRfqOrderInfo,
+    FillQuoteTransformerLimitOrderInfo,
+    FillQuoteTransformerOtcOrderInfo,
+} from '@0x/protocol-utils';
 
-import { ERC20BridgeSource, GetMarketOrdersOpts, OptimizedMarketOrder } from './utils/market_operation_utils/types';
 import { ExtendedQuoteReportSources, PriceComparisonsReport, QuoteReport } from './utils/quote_report_generator';
 import { TokenAdjacencyGraph } from './utils/token_adjacency_graph';
 
@@ -303,6 +309,12 @@ export interface SwapQuoterRfqOpts {
 
 export type AssetSwapperContractAddresses = ContractAddresses;
 
+// `FillData` for native fills. Represents a single native order
+export type NativeRfqOrderFillData = FillQuoteTransformerRfqOrderInfo;
+export type NativeLimitOrderFillData = FillQuoteTransformerLimitOrderInfo;
+export type NativeOtcOrderFillData = FillQuoteTransformerOtcOrderInfo;
+export type NativeFillData = NativeRfqOrderFillData | NativeLimitOrderFillData | NativeOtcOrderFillData;
+
 /**
  * chainId: The ethereum chain id. Defaults to 1 (mainnet).
  * orderRefreshIntervalMs: The interval in ms that getBuyQuoteAsync should trigger an refresh of orders and order states. Defaults to 10000ms (10s).
@@ -509,3 +521,253 @@ export interface RfqClientV1Quote {
 export interface RfqClientV1QuoteResponse {
     quotes: RfqClientV1Quote[];
 }
+
+/**
+ * DEX sources to aggregate.
+ */
+export enum ERC20BridgeSource {
+    Native = 'Native',
+    Uniswap = 'Uniswap',
+    UniswapV2 = 'Uniswap_V2',
+    Curve = 'Curve',
+    Balancer = 'Balancer',
+    BalancerV2 = 'Balancer_V2',
+    Bancor = 'Bancor',
+    MakerPsm = 'MakerPsm',
+    MStable = 'mStable',
+    Mooniswap = 'Mooniswap',
+    MultiHop = 'MultiHop',
+    Shell = 'Shell',
+    SushiSwap = 'SushiSwap',
+    Dodo = 'DODO',
+    DodoV2 = 'DODO_V2',
+    CryptoCom = 'CryptoCom',
+    KyberDmm = 'KyberDMM',
+    Component = 'Component',
+    Saddle = 'Saddle',
+    UniswapV3 = 'Uniswap_V3',
+    CurveV2 = 'Curve_V2',
+    Lido = 'Lido',
+    ShibaSwap = 'ShibaSwap',
+    AaveV2 = 'Aave_V2',
+    Compound = 'Compound',
+    Synapse = 'Synapse',
+    BancorV3 = 'BancorV3',
+    Synthetix = 'Synthetix',
+    WOOFi = 'WOOFi',
+    // BSC only
+    PancakeSwap = 'PancakeSwap',
+    PancakeSwapV2 = 'PancakeSwap_V2',
+    BiSwap = 'BiSwap',
+    MDex = 'MDex',
+    KnightSwap = 'KnightSwap',
+    BakerySwap = 'BakerySwap',
+    Nerve = 'Nerve',
+    Belt = 'Belt',
+    Ellipsis = 'Ellipsis',
+    ApeSwap = 'ApeSwap',
+    ACryptos = 'ACryptoS',
+    // Polygon only
+    QuickSwap = 'QuickSwap',
+    Dfyn = 'Dfyn',
+    WaultSwap = 'WaultSwap',
+    FirebirdOneSwap = 'FirebirdOneSwap',
+    IronSwap = 'IronSwap',
+    MeshSwap = 'MeshSwap',
+    Dystopia = 'Dystopia',
+    // Avalanche
+    Pangolin = 'Pangolin',
+    TraderJoe = 'TraderJoe',
+    Platypus = 'Platypus',
+    GMX = 'GMX',
+    // Celo only
+    UbeSwap = 'UbeSwap',
+    MobiusMoney = 'MobiusMoney',
+    // Fantom
+    SpiritSwap = 'SpiritSwap',
+    SpookySwap = 'SpookySwap',
+    Beethovenx = 'Beethovenx',
+    MorpheusSwap = 'MorpheusSwap',
+    Yoshi = 'Yoshi',
+    // Optimism
+    Velodrome = 'Velodrome',
+}
+
+// Internal `fillData` field for `Fill` objects.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface FillData {}
+
+export type FeeEstimate = (fillData: FillData) => { gas: number; fee: BigNumber };
+// TODO:  Remove `Partial` from `FeeSchedule`
+export type FeeSchedule = Partial<{ [key in ERC20BridgeSource]: FeeEstimate }>;
+
+export type GasEstimate = (fillData: FillData) => number;
+export type GasSchedule = Partial<{ [key in ERC20BridgeSource]: GasEstimate }>;
+
+/**
+ * Represents a node on a fill path.
+ */
+export interface Fill<TFillData extends FillData = FillData> {
+    // basic data for every fill
+    source: ERC20BridgeSource;
+    // TODO jacob people seem to agree  that orderType here is more readable
+    type: FillQuoteTransformerOrderType; // should correspond with TFillData
+    fillData: TFillData;
+    // Unique ID of the original source path this fill belongs to.
+    // This is generated when the path is generated and is useful to distinguish
+    // paths that have the same `source` IDs but are distinct (e.g., Curves).
+    sourcePathId: string;
+    // See `SOURCE_FLAGS`.
+    flags: bigint;
+    // Input fill amount (taker asset amount in a sell, maker asset amount in a buy).
+    input: BigNumber;
+    // Output fill amount (maker asset amount in a sell, taker asset amount in a buy).
+    output: BigNumber;
+    // The output fill amount, adjusted by fees.
+    adjustedOutput: BigNumber;
+    // The expected gas cost of this fill
+    gas: number;
+}
+
+export type ExchangeProxyOverhead = (sourceFlags: bigint) => BigNumber;
+
+export interface FillAdjustor {
+    adjustFills: (side: MarketOperation, fills: Fill[]) => Fill[];
+}
+
+export interface GetMarketOrdersRfqOpts extends RfqRequestOpts {
+    rfqClient?: RfqClient;
+    quoteRequestor?: QuoteRequestor;
+    firmQuoteValidator?: RfqFirmQuoteValidator;
+}
+
+/**
+ * Options for `getMarketSellOrdersAsync()` and `getMarketBuyOrdersAsync()`.
+ */
+export interface GetMarketOrdersOpts {
+    /**
+     * Liquidity sources to exclude. Default is none.
+     */
+    excludedSources: ERC20BridgeSource[];
+    /**
+     * Liquidity sources to exclude when used to calculate the cost of the route.
+     * Default is none.
+     */
+    excludedFeeSources: ERC20BridgeSource[];
+    /**
+     * Liquidity sources to include. Default is none, which allows all supported
+     * sources that aren't excluded by `excludedSources`.
+     */
+    includedSources: ERC20BridgeSource[];
+    /**
+     * When generating bridge orders, we use
+     * sampled rate * (1 - bridgeSlippage)
+     * as the rate for calculating maker/taker asset amounts.
+     * This should be a small positive number (e.g., 0.0005) to make up for
+     * small discrepancies between samples and truth.
+     * Default is 0.0005 (5 basis points).
+     */
+    bridgeSlippage: number;
+    /**
+     * The maximum price slippage allowed in the fallback quote. If the slippage
+     * between the optimal quote and the fallback quote is greater than this
+     * percentage, no fallback quote will be provided.
+     */
+    maxFallbackSlippage: number;
+    /**
+     * Number of samples to take for each DEX quote.
+     */
+    numSamples: number;
+    /**
+     * The exponential sampling distribution base.
+     * A value of 1 will result in evenly spaced samples.
+     * > 1 will result in more samples at lower sizes.
+     * < 1 will result in more samples at higher sizes.
+     * Default: 1
+     */
+    sampleDistributionBase: number;
+    /**
+     * Number of samples to use when creating fill curves with neon-router
+     */
+    neonRouterNumSamples: number;
+    /**
+     * Fees for each liquidity source, expressed in gas.
+     */
+    feeSchedule: FeeSchedule;
+    /**
+     * Estimated gas consumed by each liquidity source.
+     */
+    gasSchedule: GasSchedule;
+    exchangeProxyOverhead: ExchangeProxyOverhead;
+    /**
+     * Whether to pad the quote with a redundant fallback quote using different
+     * sources. Defaults to `true`.
+     */
+    allowFallback: boolean;
+    /**
+     * Options for RFQT such as takerAddress, intent on filling
+     */
+    rfqt?: GetMarketOrdersRfqOpts;
+    /**
+     * Whether to generate a quote report
+     */
+    shouldGenerateQuoteReport: boolean;
+
+    /**
+     * Whether to include price comparison data in the quote
+     */
+    shouldIncludePriceComparisonsReport: boolean;
+    /**
+     * Token addresses with a list of adjacent intermediary tokens to consider
+     * hopping to. E.g DAI->USDC via an adjacent token WETH
+     */
+    tokenAdjacencyGraph: TokenAdjacencyGraph;
+
+    /**
+     * Gas price to use for quote
+     */
+    gasPrice: BigNumber;
+
+    /**
+     * Adjusts fills individual fills based on caller supplied criteria
+     */
+    fillAdjustor: FillAdjustor;
+}
+
+export interface OptimizedMarketOrderBase<TFillData extends FillData = FillData> {
+    source: ERC20BridgeSource;
+    fillData: TFillData;
+    type: FillQuoteTransformerOrderType; // should correspond with TFillData
+    makerToken: string;
+    takerToken: string;
+    makerAmount: BigNumber; // The amount we wish to buy from this order, e.g inclusive of any previous partial fill
+    takerAmount: BigNumber; // The amount we wish to fill this for, e.g inclusive of any previous partial fill
+    fill: Omit<Fill, 'flags' | 'fillData' | 'sourcePathId' | 'source' | 'type'>; // Remove duplicates which have been brought into the OrderBase interface
+}
+
+export interface OptimizedMarketBridgeOrder<TFillData extends FillData = FillData>
+    extends OptimizedMarketOrderBase<TFillData> {
+    type: FillQuoteTransformerOrderType.Bridge;
+    sourcePathId: string;
+}
+
+export interface OptimizedLimitOrder extends OptimizedMarketOrderBase<NativeLimitOrderFillData> {
+    type: FillQuoteTransformerOrderType.Limit;
+}
+
+export interface OptimizedRfqOrder extends OptimizedMarketOrderBase<NativeRfqOrderFillData> {
+    type: FillQuoteTransformerOrderType.Rfq;
+}
+
+export interface OptimizedOtcOrder extends OptimizedMarketOrderBase<NativeOtcOrderFillData> {
+    type: FillQuoteTransformerOrderType.Otc;
+}
+
+/**
+ * Optimized orders to fill.
+ */
+export type OptimizedMarketOrder =
+    | OptimizedMarketBridgeOrder<FillData>
+    | OptimizedMarketOrderBase<NativeLimitOrderFillData>
+    | OptimizedMarketOrderBase<NativeRfqOrderFillData>
+    | OptimizedMarketOrderBase<NativeOtcOrderFillData>;

--- a/src/asset-swapper/utils/market_operation_utils/bridge_source_utils.ts
+++ b/src/asset-swapper/utils/market_operation_utils/bridge_source_utils.ts
@@ -59,7 +59,8 @@ import {
     WAULTSWAP_ROUTER_BY_CHAIN_ID,
     YOSHI_ROUTER_BY_CHAIN_ID,
 } from './constants';
-import { CurveInfo, ERC20BridgeSource, PlatypusInfo } from './types';
+import { CurveInfo, PlatypusInfo } from './types';
+import { ERC20BridgeSource } from '../../types';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export function isValidAddress(address: string | String): address is string {

--- a/src/asset-swapper/utils/market_operation_utils/comparison_price.ts
+++ b/src/asset-swapper/utils/market_operation_utils/comparison_price.ts
@@ -5,14 +5,8 @@ import { BigNumber, logUtils } from '@0x/utils';
 import { MarketOperation } from '../../types';
 
 import { COMPARISON_PRICE_DECIMALS, SOURCE_FLAGS } from './constants';
-import {
-    ComparisonPrice,
-    ERC20BridgeSource,
-    ExchangeProxyOverhead,
-    FeeEstimate,
-    FeeSchedule,
-    MarketSideLiquidity,
-} from './types';
+import { ComparisonPrice, MarketSideLiquidity } from './types';
+import { ERC20BridgeSource, ExchangeProxyOverhead, FeeEstimate, FeeSchedule } from '../../types';
 
 /**
  * Takes in an optimizer response and returns a price for RFQT MMs to beat

--- a/src/asset-swapper/utils/market_operation_utils/constants.ts
+++ b/src/asset-swapper/utils/market_operation_utils/constants.ts
@@ -16,12 +16,7 @@ import {
     CurveFunctionSelectors,
     CurveInfo,
     DODOFillData,
-    ERC20BridgeSource,
-    FeeSchedule,
-    FillData,
     FinalUniswapV3FillData,
-    GasSchedule,
-    GetMarketOrdersOpts,
     isFinalUniswapV3FillData,
     LidoFillData,
     LidoInfo,
@@ -34,6 +29,8 @@ import {
     UniswapV3FillData,
     WOOFiFillData,
 } from './types';
+
+import { ERC20BridgeSource, FeeSchedule, FillData, GasSchedule, GetMarketOrdersOpts } from '../../types';
 
 export const ONE_ETHER = new BigNumber(1e18);
 export const POSITIVE_INF = new BigNumber('Infinity');

--- a/src/asset-swapper/utils/market_operation_utils/fills.ts
+++ b/src/asset-swapper/utils/market_operation_utils/fills.ts
@@ -1,10 +1,17 @@
 import { FillQuoteTransformerOrderType } from '@0x/protocol-utils';
 import { BigNumber, hexUtils } from '@0x/utils';
 
-import { MarketOperation, NativeOrderWithFillableAmounts } from '../../types';
+import {
+    MarketOperation,
+    NativeOrderWithFillableAmounts,
+    ERC20BridgeSource,
+    FeeEstimate,
+    FeeSchedule,
+    Fill,
+} from '../../types';
 
 import { DEFAULT_FEE_ESTIMATE, POSITIVE_INF, SOURCE_FLAGS } from './constants';
-import { DexSample, ERC20BridgeSource, FeeEstimate, FeeSchedule, Fill, MultiHopFillData } from './types';
+import { DexSample, MultiHopFillData } from './types';
 
 function toNativeSourceFlagKey(type: FillQuoteTransformerOrderType): 'LimitOrder' | 'RfqOrder' | 'OtcOrder' {
     switch (type) {

--- a/src/asset-swapper/utils/market_operation_utils/identity_fill_adjustor.ts
+++ b/src/asset-swapper/utils/market_operation_utils/identity_fill_adjustor.ts
@@ -1,6 +1,4 @@
-import { MarketOperation } from '../../types';
-
-import { Fill, FillAdjustor } from './types';
+import { MarketOperation, Fill, FillAdjustor } from '../../types';
 
 export class IdentityFillAdjustor implements FillAdjustor {
     public adjustFills(_side: MarketOperation, fills: Fill[]): Fill[] {

--- a/src/asset-swapper/utils/market_operation_utils/index.ts
+++ b/src/asset-swapper/utils/market_operation_utils/index.ts
@@ -11,6 +11,8 @@ import {
     MarketOperation,
     NativeOrderWithFillableAmounts,
     SignedNativeOrder,
+    ERC20BridgeSource,
+    GetMarketOrdersOpts,
 } from '../../types';
 import { getAltMarketInfo } from '../alt_mm_implementation_utils';
 import { QuoteRequestor, V4RFQIndicativeQuoteMM } from '../quote_requestor';
@@ -49,9 +51,7 @@ import { SourceFilters } from './source_filters';
 import {
     AggregationError,
     DexSample,
-    ERC20BridgeSource,
     GenerateOptimizedOrdersOpts,
-    GetMarketOrdersOpts,
     MarketSideLiquidity,
     OptimizerResult,
     OptimizerResultWithReport,

--- a/src/asset-swapper/utils/market_operation_utils/orders.ts
+++ b/src/asset-swapper/utils/market_operation_utils/orders.ts
@@ -2,7 +2,20 @@ import { BridgeProtocol, encodeBridgeSourceId, FillQuoteTransformerOrderType } f
 import { AbiEncoder, BigNumber } from '@0x/utils';
 import _ = require('lodash');
 
-import { AssetSwapperContractAddresses, MarketOperation } from '../../types';
+import {
+    AssetSwapperContractAddresses,
+    MarketOperation,
+    ERC20BridgeSource,
+    Fill,
+    FillData,
+    NativeFillData,
+    NativeLimitOrderFillData,
+    NativeOtcOrderFillData,
+    NativeRfqOrderFillData,
+    OptimizedMarketBridgeOrder,
+    OptimizedMarketOrder,
+    OptimizedMarketOrderBase,
+} from '../../types';
 
 import { MAX_UINT256, ZERO_AMOUNT } from './constants';
 import {
@@ -16,9 +29,6 @@ import {
     CurveFillData,
     DexSample,
     DODOFillData,
-    ERC20BridgeSource,
-    Fill,
-    FillData,
     FinalUniswapV3FillData,
     GenericRouterFillData,
     GMXFillData,
@@ -27,13 +37,6 @@ import {
     MakerPsmFillData,
     MooniswapFillData,
     MultiHopFillData,
-    NativeFillData,
-    NativeLimitOrderFillData,
-    NativeOtcOrderFillData,
-    NativeRfqOrderFillData,
-    OptimizedMarketBridgeOrder,
-    OptimizedMarketOrder,
-    OptimizedMarketOrderBase,
     PlatypusFillData,
     ShellFillData,
     SynthetixFillData,

--- a/src/asset-swapper/utils/market_operation_utils/path.ts
+++ b/src/asset-swapper/utils/market_operation_utils/path.ts
@@ -1,7 +1,14 @@
 import { BigNumber } from '@0x/utils';
 import _ = require('lodash');
 
-import { MarketOperation } from '../../types';
+import {
+    MarketOperation,
+    NativeFillData,
+    OptimizedMarketOrder,
+    ERC20BridgeSource,
+    ExchangeProxyOverhead,
+    Fill,
+} from '../../types';
 
 import { POSITIVE_INF, ZERO_AMOUNT } from './constants';
 import { ethToOutputAmount } from './fills';
@@ -13,14 +20,7 @@ import {
     getMakerTakerTokens,
 } from './orders';
 import { getCompleteRate, getRate } from './rate_utils';
-import {
-    ERC20BridgeSource,
-    ExchangeProxyOverhead,
-    Fill,
-    MultiHopFillData,
-    NativeFillData,
-    OptimizedMarketOrder,
-} from './types';
+import { MultiHopFillData } from './types';
 
 export interface PathSize {
     input: BigNumber;

--- a/src/asset-swapper/utils/market_operation_utils/path_optimizer.ts
+++ b/src/asset-swapper/utils/market_operation_utils/path_optimizer.ts
@@ -8,12 +8,20 @@ import { performance } from 'perf_hooks';
 
 import { SAMPLER_METRICS } from '../../../utils/sampler_metrics';
 import { DEFAULT_WARNING_LOGGER } from '../../constants';
-import { MarketOperation, NativeOrderWithFillableAmounts } from '../../types';
+import {
+    MarketOperation,
+    NativeOrderWithFillableAmounts,
+    ERC20BridgeSource,
+    FeeSchedule,
+    Fill,
+    FillAdjustor,
+    FillData,
+} from '../../types';
 
 import { VIP_ERC20_BRIDGE_SOURCES_BY_CHAIN_ID, ZERO_AMOUNT } from './constants';
 import { dexSampleToFill, ethToOutputAmount, nativeOrderToFill, twoHopSampleToFill } from './fills';
 import { Path, PathPenaltyOpts } from './path';
-import { DexSample, ERC20BridgeSource, FeeSchedule, Fill, FillAdjustor, FillData, MultiHopFillData } from './types';
+import { DexSample, MultiHopFillData } from './types';
 
 // NOTE: The Rust router will panic with less than 3 samples
 const MIN_NUM_SAMPLE_INPUTS = 3;

--- a/src/asset-swapper/utils/market_operation_utils/sampler_contract_operation.ts
+++ b/src/asset-swapper/utils/market_operation_utils/sampler_contract_operation.ts
@@ -3,7 +3,8 @@ import { BigNumber, decodeBytesAsRevertError, logUtils } from '@0x/utils';
 
 import { ERC20BridgeSamplerContract } from '../../../wrappers';
 
-import { ERC20BridgeSource, FillData, SourceQuoteOperation } from './types';
+import { ERC20BridgeSource, FillData } from '../../types';
+import { SourceQuoteOperation } from './types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: fix me!
 export type Parameters<T> = T extends (...args: infer TArgs) => any ? TArgs : never;

--- a/src/asset-swapper/utils/market_operation_utils/sampler_no_operation.ts
+++ b/src/asset-swapper/utils/market_operation_utils/sampler_no_operation.ts
@@ -1,6 +1,7 @@
 import { BigNumber, logUtils, NULL_BYTES } from '@0x/utils';
 
-import { ERC20BridgeSource, FillData, SourceQuoteOperation } from './types';
+import { ERC20BridgeSource, FillData } from '../../types';
+import { SourceQuoteOperation } from './types';
 
 interface SamplerNoOperationCall {
     callback: () => BigNumber[];

--- a/src/asset-swapper/utils/market_operation_utils/sampler_operations.ts
+++ b/src/asset-swapper/utils/market_operation_utils/sampler_operations.ts
@@ -6,7 +6,7 @@ import * as _ from 'lodash';
 
 import { ERC20BridgeSamplerContract } from '../../../wrappers';
 import { AaveV2Sampler } from '../../noop_samplers/AaveV2Sampler';
-import { SamplerCallResult, SignedNativeOrder } from '../../types';
+import { SamplerCallResult, SignedNativeOrder, ERC20BridgeSource, FeeSchedule } from '../../types';
 import { TokenAdjacencyGraph } from '../token_adjacency_graph';
 
 import { AaveV2ReservesCache } from './aave_reserves_cache';
@@ -76,8 +76,6 @@ import {
     CurveInfo,
     DexSample,
     DODOFillData,
-    ERC20BridgeSource,
-    FeeSchedule,
     GenericRouterFillData,
     GMXFillData,
     HopInfo,

--- a/src/asset-swapper/utils/market_operation_utils/source_filters.ts
+++ b/src/asset-swapper/utils/market_operation_utils/source_filters.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 
-import { ERC20BridgeSource } from './types';
+import { ERC20BridgeSource } from '../../types';
 
 export class SourceFilters {
     // All valid sources.

--- a/src/asset-swapper/utils/market_operation_utils/types.ts
+++ b/src/asset-swapper/utils/market_operation_utils/types.ts
@@ -1,18 +1,19 @@
 import { ChainId } from '@0x/contract-addresses';
-import {
-    FillQuoteTransformerLimitOrderInfo,
-    FillQuoteTransformerOrderType,
-    FillQuoteTransformerRfqOrderInfo,
-    FillQuoteTransformerOtcOrderInfo,
-} from '@0x/protocol-utils';
 import { MarketOperation } from '@0x/types';
 import { BigNumber } from '@0x/utils';
-import { RfqClient } from '../../../utils/rfq_client';
 
-import { NativeOrderWithFillableAmounts, RfqFirmQuoteValidator, RfqRequestOpts } from '../../types';
-import { QuoteRequestor, V4RFQIndicativeQuoteMM } from '../../utils/quote_requestor';
+import {
+    NativeOrderWithFillableAmounts,
+    ERC20BridgeSource,
+    OptimizedMarketOrder,
+    FillData,
+    FeeSchedule,
+    Fill,
+    FillAdjustor,
+    ExchangeProxyOverhead,
+} from '../../types';
+import { V4RFQIndicativeQuoteMM } from '../../utils/quote_requestor';
 import { ExtendedQuoteReportSources, PriceComparisonsReport, QuoteReport } from '../quote_report_generator';
-import { TokenAdjacencyGraph } from '../token_adjacency_graph';
 
 import { SourceFilters } from './source_filters';
 
@@ -24,77 +25,6 @@ export enum AggregationError {
     EmptyOrders = 'EMPTY_ORDERS',
     NotERC20AssetData = 'NOT_ERC20ASSET_DATA',
     NoBridgeForSource = 'NO_BRIDGE_FOR_SOURCE',
-}
-
-/**
- * DEX sources to aggregate.
- */
-export enum ERC20BridgeSource {
-    Native = 'Native',
-    Uniswap = 'Uniswap',
-    UniswapV2 = 'Uniswap_V2',
-    Curve = 'Curve',
-    Balancer = 'Balancer',
-    BalancerV2 = 'Balancer_V2',
-    Bancor = 'Bancor',
-    MakerPsm = 'MakerPsm',
-    MStable = 'mStable',
-    Mooniswap = 'Mooniswap',
-    MultiHop = 'MultiHop',
-    Shell = 'Shell',
-    SushiSwap = 'SushiSwap',
-    Dodo = 'DODO',
-    DodoV2 = 'DODO_V2',
-    CryptoCom = 'CryptoCom',
-    KyberDmm = 'KyberDMM',
-    Component = 'Component',
-    Saddle = 'Saddle',
-    UniswapV3 = 'Uniswap_V3',
-    CurveV2 = 'Curve_V2',
-    Lido = 'Lido',
-    ShibaSwap = 'ShibaSwap',
-    AaveV2 = 'Aave_V2',
-    Compound = 'Compound',
-    Synapse = 'Synapse',
-    BancorV3 = 'BancorV3',
-    Synthetix = 'Synthetix',
-    WOOFi = 'WOOFi',
-    // BSC only
-    PancakeSwap = 'PancakeSwap',
-    PancakeSwapV2 = 'PancakeSwap_V2',
-    BiSwap = 'BiSwap',
-    MDex = 'MDex',
-    KnightSwap = 'KnightSwap',
-    BakerySwap = 'BakerySwap',
-    Nerve = 'Nerve',
-    Belt = 'Belt',
-    Ellipsis = 'Ellipsis',
-    ApeSwap = 'ApeSwap',
-    ACryptos = 'ACryptoS',
-    // Polygon only
-    QuickSwap = 'QuickSwap',
-    Dfyn = 'Dfyn',
-    WaultSwap = 'WaultSwap',
-    FirebirdOneSwap = 'FirebirdOneSwap',
-    IronSwap = 'IronSwap',
-    MeshSwap = 'MeshSwap',
-    Dystopia = 'Dystopia',
-    // Avalanche
-    Pangolin = 'Pangolin',
-    TraderJoe = 'TraderJoe',
-    Platypus = 'Platypus',
-    GMX = 'GMX',
-    // Celo only
-    UbeSwap = 'UbeSwap',
-    MobiusMoney = 'MobiusMoney',
-    // Fantom
-    SpiritSwap = 'SpiritSwap',
-    SpookySwap = 'SpookySwap',
-    Beethovenx = 'Beethovenx',
-    MorpheusSwap = 'MorpheusSwap',
-    Yoshi = 'Yoshi',
-    // Optimism
-    Velodrome = 'Velodrome',
 }
 
 /**
@@ -169,16 +99,6 @@ export interface AaveV2Info {
     aToken: string;
     underlyingToken: string;
 }
-
-// Internal `fillData` field for `Fill` objects.
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface FillData {}
-
-// `FillData` for native fills. Represents a single native order
-export type NativeRfqOrderFillData = FillQuoteTransformerRfqOrderInfo;
-export type NativeLimitOrderFillData = FillQuoteTransformerLimitOrderInfo;
-export type NativeOtcOrderFillData = FillQuoteTransformerOtcOrderInfo;
-export type NativeFillData = NativeRfqOrderFillData | NativeLimitOrderFillData | NativeOtcOrderFillData;
 
 // Represents an individual DEX sample from the sampler contract
 export interface DexSample<TFillData extends FillData = FillData> {
@@ -363,177 +283,6 @@ export interface SynthetixFillData extends FillData {
 }
 
 /**
- * Represents a node on a fill path.
- */
-export interface Fill<TFillData extends FillData = FillData> {
-    // basic data for every fill
-    source: ERC20BridgeSource;
-    // TODO jacob people seem to agree  that orderType here is more readable
-    type: FillQuoteTransformerOrderType; // should correspond with TFillData
-    fillData: TFillData;
-    // Unique ID of the original source path this fill belongs to.
-    // This is generated when the path is generated and is useful to distinguish
-    // paths that have the same `source` IDs but are distinct (e.g., Curves).
-    sourcePathId: string;
-    // See `SOURCE_FLAGS`.
-    flags: bigint;
-    // Input fill amount (taker asset amount in a sell, maker asset amount in a buy).
-    input: BigNumber;
-    // Output fill amount (maker asset amount in a sell, taker asset amount in a buy).
-    output: BigNumber;
-    // The output fill amount, adjusted by fees.
-    adjustedOutput: BigNumber;
-    // The expected gas cost of this fill
-    gas: number;
-}
-
-export interface OptimizedMarketOrderBase<TFillData extends FillData = FillData> {
-    source: ERC20BridgeSource;
-    fillData: TFillData;
-    type: FillQuoteTransformerOrderType; // should correspond with TFillData
-    makerToken: string;
-    takerToken: string;
-    makerAmount: BigNumber; // The amount we wish to buy from this order, e.g inclusive of any previous partial fill
-    takerAmount: BigNumber; // The amount we wish to fill this for, e.g inclusive of any previous partial fill
-    fill: Omit<Fill, 'flags' | 'fillData' | 'sourcePathId' | 'source' | 'type'>; // Remove duplicates which have been brought into the OrderBase interface
-}
-
-export interface OptimizedMarketBridgeOrder<TFillData extends FillData = FillData>
-    extends OptimizedMarketOrderBase<TFillData> {
-    type: FillQuoteTransformerOrderType.Bridge;
-    sourcePathId: string;
-}
-
-export interface OptimizedLimitOrder extends OptimizedMarketOrderBase<NativeLimitOrderFillData> {
-    type: FillQuoteTransformerOrderType.Limit;
-}
-
-export interface OptimizedRfqOrder extends OptimizedMarketOrderBase<NativeRfqOrderFillData> {
-    type: FillQuoteTransformerOrderType.Rfq;
-}
-
-export interface OptimizedOtcOrder extends OptimizedMarketOrderBase<NativeOtcOrderFillData> {
-    type: FillQuoteTransformerOrderType.Otc;
-}
-
-/**
- * Optimized orders to fill.
- */
-export type OptimizedMarketOrder =
-    | OptimizedMarketBridgeOrder<FillData>
-    | OptimizedMarketOrderBase<NativeLimitOrderFillData>
-    | OptimizedMarketOrderBase<NativeRfqOrderFillData>
-    | OptimizedMarketOrderBase<NativeOtcOrderFillData>;
-
-export interface GetMarketOrdersRfqOpts extends RfqRequestOpts {
-    rfqClient?: RfqClient;
-    quoteRequestor?: QuoteRequestor;
-    firmQuoteValidator?: RfqFirmQuoteValidator;
-}
-
-export type FeeEstimate = (fillData: FillData) => { gas: number; fee: BigNumber };
-// TODO:  Remove `Partial` from `FeeSchedule`
-export type FeeSchedule = Partial<{ [key in ERC20BridgeSource]: FeeEstimate }>;
-
-export type GasEstimate = (fillData: FillData) => number;
-export type GasSchedule = Partial<{ [key in ERC20BridgeSource]: GasEstimate }>;
-
-export type ExchangeProxyOverhead = (sourceFlags: bigint) => BigNumber;
-
-/**
- * Options for `getMarketSellOrdersAsync()` and `getMarketBuyOrdersAsync()`.
- */
-export interface GetMarketOrdersOpts {
-    /**
-     * Liquidity sources to exclude. Default is none.
-     */
-    excludedSources: ERC20BridgeSource[];
-    /**
-     * Liquidity sources to exclude when used to calculate the cost of the route.
-     * Default is none.
-     */
-    excludedFeeSources: ERC20BridgeSource[];
-    /**
-     * Liquidity sources to include. Default is none, which allows all supported
-     * sources that aren't excluded by `excludedSources`.
-     */
-    includedSources: ERC20BridgeSource[];
-    /**
-     * When generating bridge orders, we use
-     * sampled rate * (1 - bridgeSlippage)
-     * as the rate for calculating maker/taker asset amounts.
-     * This should be a small positive number (e.g., 0.0005) to make up for
-     * small discrepancies between samples and truth.
-     * Default is 0.0005 (5 basis points).
-     */
-    bridgeSlippage: number;
-    /**
-     * The maximum price slippage allowed in the fallback quote. If the slippage
-     * between the optimal quote and the fallback quote is greater than this
-     * percentage, no fallback quote will be provided.
-     */
-    maxFallbackSlippage: number;
-    /**
-     * Number of samples to take for each DEX quote.
-     */
-    numSamples: number;
-    /**
-     * The exponential sampling distribution base.
-     * A value of 1 will result in evenly spaced samples.
-     * > 1 will result in more samples at lower sizes.
-     * < 1 will result in more samples at higher sizes.
-     * Default: 1
-     */
-    sampleDistributionBase: number;
-    /**
-     * Number of samples to use when creating fill curves with neon-router
-     */
-    neonRouterNumSamples: number;
-    /**
-     * Fees for each liquidity source, expressed in gas.
-     */
-    feeSchedule: FeeSchedule;
-    /**
-     * Estimated gas consumed by each liquidity source.
-     */
-    gasSchedule: GasSchedule;
-    exchangeProxyOverhead: ExchangeProxyOverhead;
-    /**
-     * Whether to pad the quote with a redundant fallback quote using different
-     * sources. Defaults to `true`.
-     */
-    allowFallback: boolean;
-    /**
-     * Options for RFQT such as takerAddress, intent on filling
-     */
-    rfqt?: GetMarketOrdersRfqOpts;
-    /**
-     * Whether to generate a quote report
-     */
-    shouldGenerateQuoteReport: boolean;
-
-    /**
-     * Whether to include price comparison data in the quote
-     */
-    shouldIncludePriceComparisonsReport: boolean;
-    /**
-     * Token addresses with a list of adjacent intermediary tokens to consider
-     * hopping to. E.g DAI->USDC via an adjacent token WETH
-     */
-    tokenAdjacencyGraph: TokenAdjacencyGraph;
-
-    /**
-     * Gas price to use for quote
-     */
-    gasPrice: BigNumber;
-
-    /**
-     * Adjusts fills individual fills based on caller supplied criteria
-     */
-    fillAdjustor: FillAdjustor;
-}
-
-/**
  * A composable operation the be run in `DexOrderSampler.executeAsync()`.
  */
 export interface BatchedOperation<TResult> {
@@ -595,8 +344,4 @@ export interface GenerateOptimizedOrdersOpts {
 
 export interface ComparisonPrice {
     wholeOrder: BigNumber | undefined;
-}
-
-export interface FillAdjustor {
-    adjustFills: (side: MarketOperation, fills: Fill[]) => Fill[];
 }

--- a/src/asset-swapper/utils/quote_report_generator.ts
+++ b/src/asset-swapper/utils/quote_report_generator.ts
@@ -2,17 +2,16 @@ import { FillQuoteTransformerOrderType, RfqOrderFields, Signature } from '@0x/pr
 import { BigNumber } from '@0x/utils';
 import _ = require('lodash');
 
-import { MarketOperation, NativeOrderWithFillableAmounts } from '../types';
-
 import {
-    DexSample,
+    MarketOperation,
+    NativeOrderWithFillableAmounts,
     ERC20BridgeSource,
     Fill,
     FillData,
-    MultiHopFillData,
     NativeFillData,
-    RawQuotes,
-} from './market_operation_utils/types';
+} from '../types';
+
+import { DexSample, MultiHopFillData, RawQuotes } from './market_operation_utils/types';
 import { QuoteRequestor, V4RFQIndicativeQuoteMM } from './quote_requestor';
 
 export interface QuoteReportEntryBase {

--- a/src/asset-swapper/utils/quote_simulation.ts
+++ b/src/asset-swapper/utils/quote_simulation.ts
@@ -2,9 +2,8 @@ import { FillQuoteTransformerOrderType } from '@0x/protocol-utils';
 import { BigNumber } from '@0x/utils';
 
 import { constants } from '../constants';
-import { MarketOperation } from '../types';
+import { MarketOperation, GasSchedule, NativeLimitOrderFillData, OptimizedMarketOrder } from '../types';
 
-import { GasSchedule, NativeLimitOrderFillData, OptimizedMarketOrder } from './market_operation_utils/types';
 import { getNativeAdjustedTakerFeeAmount } from './utils';
 
 const { PROTOCOL_FEE_MULTIPLIER, ZERO_AMOUNT } = constants;

--- a/test/asset-swapper/comparison_price_test.ts
+++ b/test/asset-swapper/comparison_price_test.ts
@@ -4,14 +4,10 @@ import * as _ from 'lodash';
 import 'mocha';
 
 import { SOURCE_FLAGS } from '../../src/asset-swapper';
-import { MarketOperation } from '../../src/asset-swapper/types';
+import { MarketOperation, ERC20BridgeSource } from '../../src/asset-swapper/types';
 import { getComparisonPrices } from '../../src/asset-swapper/utils/market_operation_utils/comparison_price';
 import { SourceFilters } from '../../src/asset-swapper/utils/market_operation_utils/source_filters';
-import {
-    DexSample,
-    ERC20BridgeSource,
-    MarketSideLiquidity,
-} from '../../src/asset-swapper/utils/market_operation_utils/types';
+import { DexSample, MarketSideLiquidity } from '../../src/asset-swapper/utils/market_operation_utils/types';
 
 import { chaiSetup } from './utils/chai_setup';
 

--- a/test/asset-swapper/dex_sampler_test.ts
+++ b/test/asset-swapper/dex_sampler_test.ts
@@ -3,10 +3,9 @@ import { constants, expect, getRandomFloat, getRandomInteger, randomAddress } fr
 import { FillQuoteTransformerOrderType, LimitOrderFields, SignatureType } from '@0x/protocol-utils';
 import { BigNumber, hexUtils, NULL_ADDRESS } from '@0x/utils';
 import * as _ from 'lodash';
-import { SignedLimitOrder } from '../../src/asset-swapper/types';
+import { SignedLimitOrder, ERC20BridgeSource } from '../../src/asset-swapper/types';
 
 import { DexOrderSampler, getSampleAmounts } from '../../src/asset-swapper/utils/market_operation_utils/sampler';
-import { ERC20BridgeSource } from '../../src/asset-swapper/utils/market_operation_utils/types';
 import { TokenAdjacencyGraphBuilder } from '../../src/asset-swapper/utils/token_adjacency_graph';
 
 import { MockSamplerContract } from './utils/mock_sampler_contract';

--- a/test/asset-swapper/exchange_proxy_swap_quote_consumer_test.ts
+++ b/test/asset-swapper/exchange_proxy_swap_quote_consumer_test.ts
@@ -26,14 +26,12 @@ import {
     MarketBuySwapQuote,
     MarketOperation,
     MarketSellSwapQuote,
-} from '../../src/asset-swapper/types';
-import {
     ERC20BridgeSource,
     Fill,
     NativeFillData,
     OptimizedLimitOrder,
     OptimizedMarketOrder,
-} from '../../src/asset-swapper/utils/market_operation_utils/types';
+} from '../../src/asset-swapper/types';
 
 import { chaiSetup } from './utils/chai_setup';
 import { getRandomAmount, getRandomSignature } from './utils/utils';

--- a/test/asset-swapper/market_operation_utils_test.ts
+++ b/test/asset-swapper/market_operation_utils_test.ts
@@ -21,7 +21,13 @@ import {
     SignedNativeOrder,
     TokenAdjacencyGraph,
 } from '../../src/asset-swapper';
-import { Integrator, SignedLimitOrder } from '../../src/asset-swapper/types';
+import {
+    Integrator,
+    SignedLimitOrder,
+    ERC20BridgeSource,
+    FillData,
+    GetMarketOrdersOpts,
+} from '../../src/asset-swapper/types';
 import { MarketOperationUtils } from '../../src/asset-swapper/utils/market_operation_utils/';
 import {
     BUY_SOURCE_FILTER_BY_CHAIN_ID,
@@ -35,10 +41,7 @@ import { BATCH_SOURCE_FILTERS } from '../../src/asset-swapper/utils/market_opera
 import {
     AggregationError,
     DexSample,
-    ERC20BridgeSource,
-    FillData,
     GenerateOptimizedOrdersOpts,
-    GetMarketOrdersOpts,
     MarketSideLiquidity,
     OptimizerResultWithReport,
 } from '../../src/asset-swapper/utils/market_operation_utils/types';

--- a/test/asset-swapper/quote_report_generator_test.ts
+++ b/test/asset-swapper/quote_report_generator_test.ts
@@ -5,16 +5,16 @@ import * as _ from 'lodash';
 import 'mocha';
 import * as TypeMoq from 'typemoq';
 
-import { MarketOperation, NativeOrderWithFillableAmounts } from '../../src/asset-swapper/types';
 import {
-    DexSample,
+    MarketOperation,
+    NativeOrderWithFillableAmounts,
     ERC20BridgeSource,
     Fill,
-    MultiHopFillData,
     NativeFillData,
     NativeLimitOrderFillData,
     NativeRfqOrderFillData,
-} from '../../src/asset-swapper/utils/market_operation_utils/types';
+} from '../../src/asset-swapper/types';
+import { DexSample, MultiHopFillData } from '../../src/asset-swapper/utils/market_operation_utils/types';
 import { QuoteRequestor } from '../../src/asset-swapper/utils/quote_requestor';
 
 import {

--- a/test/asset-swapper/quote_simulation_test.ts
+++ b/test/asset-swapper/quote_simulation_test.ts
@@ -3,14 +3,14 @@ import { FillQuoteTransformerOrderType, SignatureType } from '@0x/protocol-utils
 import { BigNumber, hexUtils, NULL_BYTES } from '@0x/utils';
 import * as _ from 'lodash';
 
-import { MarketOperation } from '../../src/asset-swapper/types';
 import {
+    MarketOperation,
     ERC20BridgeSource,
     Fill,
     NativeLimitOrderFillData,
     OptimizedMarketOrder,
     OptimizedMarketOrderBase,
-} from '../../src/asset-swapper/utils/market_operation_utils/types';
+} from '../../src/asset-swapper/types';
 import {
     fillQuoteOrders,
     QuoteFillOrderCall,

--- a/test/asset-swapper/utils/market_operations_utils/path_optimizer_test.ts
+++ b/test/asset-swapper/utils/market_operations_utils/path_optimizer_test.ts
@@ -9,13 +9,8 @@ import {
     SignatureType,
 } from '../../../../src/asset-swapper';
 import { PathOptimizer } from '../../../../src/asset-swapper/utils/market_operation_utils/path_optimizer';
-import {
-    DexSample,
-    ERC20BridgeSource,
-    FeeSchedule,
-    FillData,
-    MultiHopFillData,
-} from '../../../../src/asset-swapper/utils/market_operation_utils/types';
+import { ERC20BridgeSource, FeeSchedule, FillData } from '../../../../src/asset-swapper/types';
+import { DexSample, MultiHopFillData } from '../../../../src/asset-swapper/utils/market_operation_utils/types';
 import { BigNumber } from '@0x/utils';
 import { chaiSetup } from '../chai_setup';
 import { PathPenaltyOpts } from '../../../../src/asset-swapper/utils/market_operation_utils/path';


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
-->

# Description

started working on removing circular deps in asset-swapper. I moved a lot of things up from inside asset-swapper/market-operations up to asset-swapper/types

# Testing & Simbot Run

<!--- If your changes affect `swap` API (e.g. adding a new liquidity source, changes sampling or routing logic) include a link to Simbot run(s). -->

# Checklist

-   [ ] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [ ] Add tests to cover changes as needed.
-   [ ] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
