### PR TITLE
chore: Make `GasSchedule` not `Partial` and remove it from `GetMarketOrdersOpts` [LIT-690]

### DIFF
--- a/src/asset-swapper/swap_quoter.ts
+++ b/src/asset-swapper/swap_quoter.ts
@@ -26,7 +26,12 @@ import {
 import { assert } from './utils/assert';
 import { MarketOperationUtils } from './utils/market_operation_utils';
 import { BancorService } from './utils/market_operation_utils/bancor_service';
-import { SAMPLER_ADDRESS, SOURCE_FLAGS, ZERO_AMOUNT } from './utils/market_operation_utils/constants';
+import {
+    DEFAULT_GAS_SCHEDULE,
+    SAMPLER_ADDRESS,
+    SOURCE_FLAGS,
+    ZERO_AMOUNT,
+} from './utils/market_operation_utils/constants';
 import { DexOrderSampler } from './utils/market_operation_utils/sampler';
 import { SourceFilters } from './utils/market_operation_utils/source_filters';
 import { OptimizerResultWithReport } from './utils/market_operation_utils/types';
@@ -220,7 +225,7 @@ export class SwapQuoter {
         const calcOpts: GetMarketOrdersOpts = {
             ...cloneOpts,
             gasPrice,
-            feeSchedule: _.mapValues(opts.gasSchedule, (gasCost) => (fillData: FillData) => {
+            feeSchedule: _.mapValues(DEFAULT_GAS_SCHEDULE, (gasCost) => (fillData: FillData) => {
                 const gas = gasCost ? gasCost(fillData) : 0;
                 const fee = gasPrice.times(gas);
                 return { gas, fee };
@@ -247,7 +252,7 @@ export class SwapQuoter {
             marketOperation,
             assetFillAmount,
             gasPrice,
-            opts.gasSchedule,
+            DEFAULT_GAS_SCHEDULE,
             opts.bridgeSlippage,
         );
 

--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -544,7 +544,7 @@ export type FeeEstimate = (fillData: FillData) => { gas: number; fee: BigNumber 
 export type FeeSchedule = Partial<{ [key in ERC20BridgeSource]: FeeEstimate }>;
 
 type GasEstimate = (fillData: FillData) => number;
-export type GasSchedule = Partial<{ [key in ERC20BridgeSource]: GasEstimate }>;
+export type GasSchedule = Record<ERC20BridgeSource, GasEstimate>;
 
 /**
  * Represents a node on a fill path.

--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -637,9 +637,8 @@ export interface GetMarketOrdersOpts {
      */
     feeSchedule: FeeSchedule;
     /**
-     * Estimated gas consumed by each liquidity source.
+     * Exchange proxy gas overhead based on source flag.
      */
-    gasSchedule: GasSchedule;
     exchangeProxyOverhead: ExchangeProxyOverhead;
     /**
      * Whether to pad the quote with a redundant fallback quote using different

--- a/src/asset-swapper/utils/market_operation_utils/constants.ts
+++ b/src/asset-swapper/utils/market_operation_utils/constants.ts
@@ -2641,7 +2641,7 @@ const uniswapV2CloneGasSchedule = (fillData?: FillData) => {
  * I.e remove the overhead cost of ExchangeProxy (130k) and
  * the ethereum transaction cost (21k)
  */
-export const DEFAULT_GAS_SCHEDULE: Required<GasSchedule> = {
+export const DEFAULT_GAS_SCHEDULE: GasSchedule = {
     [ERC20BridgeSource.Native]: (fillData) => {
         // TODO jacob re-order imports so there is no circular rependency with SignedNativeOrder
         const nativeFillData = fillData as { type: FillQuoteTransformerOrderType };

--- a/src/asset-swapper/utils/market_operation_utils/constants.ts
+++ b/src/asset-swapper/utils/market_operation_utils/constants.ts
@@ -2909,7 +2909,6 @@ export const DEFAULT_GET_MARKET_ORDERS_OPTS: Omit<GetMarketOrdersOpts, 'gasPrice
     numSamples: 13,
     sampleDistributionBase: 1,
     feeSchedule: DEFAULT_FEE_SCHEDULE,
-    gasSchedule: DEFAULT_GAS_SCHEDULE,
     exchangeProxyOverhead: () => ZERO_AMOUNT,
     allowFallback: true,
     shouldGenerateQuoteReport: true,

--- a/src/asset-swapper/utils/quote_simulation.ts
+++ b/src/asset-swapper/utils/quote_simulation.ts
@@ -65,17 +65,16 @@ interface QuoteFillInfo {
     fillAmount: BigNumber;
     gasPrice: BigNumber;
     side: MarketOperation;
-    opts: Partial<QuoteFillInfoOpts>;
+    opts: QuoteFillInfoOpts;
 }
 
 interface QuoteFillInfoOpts {
     gasSchedule: GasSchedule;
-    protocolFeeMultiplier: BigNumber;
-    slippage: number;
+    protocolFeeMultiplier?: BigNumber;
+    slippage?: number;
 }
 
-const DEFAULT_SIMULATED_FILL_QUOTE_INFO_OPTS: QuoteFillInfoOpts = {
-    gasSchedule: {},
+const DEFAULT_SIMULATED_FILL_QUOTE_INFO_OPTS = {
     protocolFeeMultiplier: PROTOCOL_FEE_MULTIPLIER,
     slippage: 0,
 };

--- a/test/asset-swapper/market_operation_utils_test.ts
+++ b/test/asset-swapper/market_operation_utils_test.ts
@@ -440,7 +440,6 @@ describe('MarketOperationUtils tests', () => {
                 maxFallbackSlippage: 100,
                 excludedSources: DEFAULT_EXCLUDED,
                 allowFallback: false,
-                gasSchedule: {},
                 feeSchedule: {},
                 gasPrice: new BigNumber(30e9),
             };
@@ -1166,7 +1165,6 @@ describe('MarketOperationUtils tests', () => {
                 maxFallbackSlippage: 100,
                 excludedSources: DEFAULT_EXCLUDED,
                 allowFallback: false,
-                gasSchedule: {},
                 feeSchedule: {},
                 gasPrice: GAS_PRICE,
             };

--- a/test/asset-swapper/quote_simulation_test.ts
+++ b/test/asset-swapper/quote_simulation_test.ts
@@ -10,6 +10,7 @@ import {
     NativeLimitOrderFillData,
     OptimizedMarketOrder,
     OptimizedMarketOrderBase,
+    GasSchedule,
 } from '../../src/asset-swapper/types';
 import {
     fillQuoteOrders,
@@ -24,7 +25,10 @@ describe('quote_simulation tests', async () => {
     const ONE = new BigNumber(1);
     const MAKER_TOKEN = randomAddress();
     const TAKER_TOKEN = randomAddress();
-    const GAS_SCHEDULE = { [ERC20BridgeSource.Uniswap]: _.constant(1), [ERC20BridgeSource.Native]: _.constant(1) };
+    const GAS_SCHEDULE: GasSchedule = (() => {
+        const sources = Object.values(ERC20BridgeSource);
+        return _.zipObject(sources, new Array(sources.length).fill(_.constant(1))) as GasSchedule;
+    })();
 
     // Check if two numbers are within `maxError` error rate within each other.
     function assertRoughlyEquals(n1: BigNumber, n2: BigNumber, maxError: BigNumber | number = 1e-10): void {


### PR DESCRIPTION
# Description

* Besides, a few tests, the only `GasSchedule` instance ever used is `DEFAULT_GAS_SCHEDULE` so it is not necessary for `GetMarketOrdersOpts` to have `GasSchedule`(an option that is never used).
* Require `GasSchedule` to have gas schedule for all sources (remove `Partial`). 


# Testing & Simbot Run

* No-op refactoring. Passes existing test suite.

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
