### PR TITLE
chore: Clean up excluded sources and excluded fee sources [LIT-690]

### DIFF
--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -628,11 +628,6 @@ export interface GetMarketOrdersOpts {
      */
     excludedSources: ERC20BridgeSource[];
     /**
-     * Liquidity sources to exclude when used to calculate the cost of the route.
-     * Default is none.
-     */
-    excludedFeeSources: ERC20BridgeSource[];
-    /**
      * Liquidity sources to include. Default is none, which allows all supported
      * sources that aren't excluded by `excludedSources`.
      */

--- a/src/asset-swapper/utils/market_operation_utils/constants.ts
+++ b/src/asset-swapper/utils/market_operation_utils/constants.ts
@@ -2900,7 +2900,6 @@ const DEFAULT_FEE_SCHEDULE: FeeSchedule = Object.keys(DEFAULT_GAS_SCHEDULE).redu
 
 export const DEFAULT_GET_MARKET_ORDERS_OPTS: Omit<GetMarketOrdersOpts, 'gasPrice'> = {
     excludedSources: [],
-    excludedFeeSources: [],
     includedSources: [],
     bridgeSlippage: 0.005,
     maxFallbackSlippage: 0.05,

--- a/src/asset-swapper/utils/market_operation_utils/index.ts
+++ b/src/asset-swapper/utils/market_operation_utils/index.ts
@@ -149,7 +149,6 @@ export class MarketOperationUtils {
 
         const requestFilters = new SourceFilters().exclude(_opts.excludedSources).include(_opts.includedSources);
         const quoteSourceFilters = this._sellSources.merge(requestFilters);
-        const feeSourceFilters = this._feeSources.exclude(_opts.excludedFeeSources);
 
         // Used to determine whether the tx origin is an EOA or a contract
         const txOrigin = (_opts.rfqt && _opts.rfqt.txOrigin) || NULL_ADDRESS;
@@ -163,7 +162,7 @@ export class MarketOperationUtils {
             this._sampler.getLimitOrderFillableTakerAmounts(nativeOrders, this.contractAddresses.exchangeProxy),
             // Get ETH -> maker token price.
             this._sampler.getBestNativeTokenSellRate(
-                feeSourceFilters.sources,
+                this._feeSources.sources,
                 makerToken,
                 this._nativeFeeToken,
                 this._nativeFeeTokenAmount,
@@ -171,7 +170,7 @@ export class MarketOperationUtils {
             ),
             // Get ETH -> taker token price.
             this._sampler.getBestNativeTokenSellRate(
-                feeSourceFilters.sources,
+                this._feeSources.sources,
                 takerToken,
                 this._nativeFeeToken,
                 this._nativeFeeTokenAmount,
@@ -270,7 +269,6 @@ export class MarketOperationUtils {
 
         const requestFilters = new SourceFilters().exclude(_opts.excludedSources).include(_opts.includedSources);
         const quoteSourceFilters = this._buySources.merge(requestFilters);
-        const feeSourceFilters = this._feeSources.exclude(_opts.excludedFeeSources);
 
         // Used to determine whether the tx origin is an EOA or a contract
         const txOrigin = (_opts.rfqt && _opts.rfqt.txOrigin) || NULL_ADDRESS;
@@ -284,7 +282,7 @@ export class MarketOperationUtils {
             this._sampler.getLimitOrderFillableMakerAmounts(nativeOrders, this.contractAddresses.exchangeProxy),
             // Get ETH -> makerToken token price.
             this._sampler.getBestNativeTokenSellRate(
-                feeSourceFilters.sources,
+                this._feeSources.sources,
                 makerToken,
                 this._nativeFeeToken,
                 this._nativeFeeTokenAmount,
@@ -292,7 +290,7 @@ export class MarketOperationUtils {
             ),
             // Get ETH -> taker token price.
             this._sampler.getBestNativeTokenSellRate(
-                feeSourceFilters.sources,
+                this._feeSources.sources,
                 takerToken,
                 this._nativeFeeToken,
                 this._nativeFeeTokenAmount,

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,6 @@ import {
     BlockParamLiteral,
     ChainId,
     DEFAULT_TOKEN_ADJACENCY_GRAPH_BY_CHAIN_ID,
-    ERC20BridgeSource,
     OrderPrunerPermittedFeeTypes,
     RfqMakerAssetOfferings,
     SamplerOverrides,
@@ -422,49 +421,6 @@ const UNWRAP_WETH_GAS = UNWRAP_GAS_BY_CHAIN_ID[CHAIN_ID];
 export const UNWRAP_QUOTE_GAS = TX_BASE_GAS.plus(UNWRAP_WETH_GAS);
 export const WRAP_QUOTE_GAS = UNWRAP_QUOTE_GAS;
 
-const EXCLUDED_SOURCES = (() => {
-    const allERC20BridgeSources = Object.values(ERC20BridgeSource);
-    switch (CHAIN_ID) {
-        case ChainId.Mainnet:
-            return [];
-        case ChainId.Kovan:
-            return allERC20BridgeSources.filter(
-                (s) => s !== ERC20BridgeSource.Native && s !== ERC20BridgeSource.UniswapV2,
-            );
-        case ChainId.Ganache:
-            return allERC20BridgeSources.filter((s) => s !== ERC20BridgeSource.Native);
-        case ChainId.BSC:
-        case ChainId.Polygon:
-        case ChainId.Avalanche:
-        case ChainId.Celo:
-        case ChainId.Fantom:
-        case ChainId.Optimism:
-        case ChainId.Goerli:
-        case ChainId.PolygonMumbai:
-        case ChainId.ArbitrumRinkeby:
-        case ChainId.Arbitrum:
-            return [ERC20BridgeSource.Native];
-        default:
-            throw new Error(`Excluded sources not specified for ${CHAIN_ID}`);
-    }
-})();
-
-const EXCLUDED_FEE_SOURCES = (() => {
-    switch (CHAIN_ID) {
-        case ChainId.Mainnet:
-            return [];
-        case ChainId.Kovan:
-            return [ERC20BridgeSource.Uniswap];
-        case ChainId.BSC:
-            return [ERC20BridgeSource.Uniswap];
-        case ChainId.Polygon:
-            return [];
-        case ChainId.Celo:
-            return [];
-        default:
-            return [ERC20BridgeSource.Uniswap, ERC20BridgeSource.UniswapV2];
-    }
-})();
 const FILL_QUOTE_TRANSFORMER_GAS_OVERHEAD = new BigNumber(150e3);
 const EXCHANGE_PROXY_OVERHEAD_NO_VIP = () => FILL_QUOTE_TRANSFORMER_GAS_OVERHEAD;
 const MULTIPLEX_BATCH_FILL_SOURCE_FLAGS =
@@ -531,8 +487,6 @@ const SAMPLE_DISTRIBUTION_BASE: number = _.isEmpty(process.env.SAMPLE_DISTRIBUTI
     : assertEnvVarType('SAMPLE_DISTRIBUTION_BASE', process.env.SAMPLE_DISTRIBUTION_BASE, EnvVarType.Float);
 
 export const ASSET_SWAPPER_MARKET_ORDERS_OPTS: Partial<SwapQuoteRequestOpts> = {
-    excludedSources: EXCLUDED_SOURCES,
-    excludedFeeSources: EXCLUDED_FEE_SOURCES,
     bridgeSlippage: DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE,
     maxFallbackSlippage: DEFAULT_FALLBACK_SLIPPAGE_PERCENTAGE,
     numSamples: 13,


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
-->

# Description

* Remove `EXCLUDED_SOURCES` and `EXCLUDED_FEE_SOURCES` as there is no reason to maintain both chain specific included source list as well as excluded source list.
* Remove `excludedFeeSources`  from `GetMarketOrdersOpts` as it's no longer used.


# Testing & Simbot Run

<!--- If your changes affect `swap` API (e.g. adding a new liquidity source, changes sampling or routing logic) include a link to Simbot run(s). -->

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
