### PR TITLE
chore: Make PostgreSQL an optional dependency [LIT-708]

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,6 @@ import {
 } from './asset-swapper';
 import {
     DEFAULT_FALLBACK_SLIPPAGE_PERCENTAGE,
-    DEFAULT_LOCAL_POSTGRES_URI,
     DEFAULT_LOGGER_INCLUDE_TIMESTAMP,
     DEFAULT_META_TX_MIN_ALLOWED_SLIPPAGE,
     DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE,
@@ -286,8 +285,8 @@ export const SRA_ORDER_EXPIRATION_BUFFER_SECONDS: number = _.isEmpty(process.env
           EnvVarType.KeepAliveTimeout,
       );
 
-export const POSTGRES_URI = _.isEmpty(process.env.POSTGRES_URI)
-    ? DEFAULT_LOCAL_POSTGRES_URI
+export const POSTGRES_URI: string | undefined = _.isEmpty(process.env.POSTGRES_URI)
+    ? undefined
     : assertEnvVarType('POSTGRES_URI', process.env.POSTGRES_URI, EnvVarType.Url);
 
 export const POSTGRES_READ_REPLICA_URIS: string[] | undefined = _.isEmpty(process.env.POSTGRES_READ_REPLICA_URIS)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,6 @@ export const DEFAULT_PAGE = 1;
 export const DEFAULT_PER_PAGE = 20;
 export const ZERO = new BigNumber(0);
 export const ONE = new BigNumber(1);
-export const DEFAULT_LOCAL_POSTGRES_URI = 'postgres://api:api@localhost/api';
 export const DEFAULT_LOGGER_INCLUDE_TIMESTAMP = true;
 export const ONE_SECOND_MS = 1000;
 export const ONE_MINUTE_MS = ONE_SECOND_MS * 60;

--- a/src/db_connection.ts
+++ b/src/db_connection.ts
@@ -1,15 +1,25 @@
-import { Connection, ConnectionOptions, createConnection } from 'typeorm';
+import { Connection, createConnection } from 'typeorm';
+import { getOrmConfig } from './ormconfig';
 
-import * as config from './ormconfig';
+let connection: Connection | undefined;
 
-let connection: Connection;
+export async function getDBConnection(): Promise<Connection | undefined> {
+    if (connection !== undefined) {
+        return connection;
+    }
 
-/**
- * Creates the DB connnection to use in an app
- */
-export async function getDBConnectionAsync(): Promise<Connection> {
-    if (!connection) {
-        connection = await createConnection(config as ConnectionOptions);
+    const ormConfig = getOrmConfig();
+    if (ormConfig === undefined) {
+        return undefined;
+    }
+    connection = await createConnection(ormConfig);
+    return connection;
+}
+
+export async function getDBConnectionOrThrow(): Promise<Connection> {
+    const connection = await getDBConnection();
+    if (connection === undefined) {
+        throw new Error('Could not get a DB connection');
     }
     return connection;
 }

--- a/src/ormconfig.ts
+++ b/src/ormconfig.ts
@@ -56,4 +56,10 @@ const config: ConnectionOptions = {
         migrationsDir: 'migrations',
     },
 };
-module.exports = config;
+
+export function getOrmConfig(): ConnectionOptions | undefined {
+    if (POSTGRES_URI === undefined) {
+        return undefined;
+    }
+    return config;
+}

--- a/src/runners/http_service_runner.ts
+++ b/src/runners/http_service_runner.ts
@@ -94,11 +94,13 @@ export async function runHttpServiceAsync(
     // transform all values of `req.query.[xx]Address` to lowercase
     app.use(addressNormalizer);
 
-    // SRA http service
-    app.use(SRA_PATH, createSRARouter(dependencies.orderBookService));
+    if (dependencies.orderBookService !== undefined) {
+        // SRA http service
+        app.use(SRA_PATH, createSRARouter(dependencies.orderBookService));
 
-    // OrderBook http service
-    app.use(ORDERBOOK_PATH, createOrderBookRouter(dependencies.orderBookService));
+        // OrderBook http service
+        app.use(ORDERBOOK_PATH, createOrderBookRouter(dependencies.orderBookService));
+    }
 
     // metatxn http service
     if (dependencies.metaTransactionService) {

--- a/src/runners/http_sra_service_runner.ts
+++ b/src/runners/http_sra_service_runner.ts
@@ -76,6 +76,12 @@ async function runHttpServiceAsync(
     const server = createDefaultServer(config, app, logger, destroyCallback(dependencies));
 
     app.get('/', rootHandler);
+
+    if (dependencies.orderBookService === undefined) {
+        logger.error('OrderBookService dependency is missing, exiting');
+        process.exit(1);
+    }
+
     // SRA http service
     app.use(SRA_PATH, createSRARouter(dependencies.orderBookService));
 

--- a/src/runners/rfq_maker_balance_cache_runner.ts
+++ b/src/runners/rfq_maker_balance_cache_runner.ts
@@ -11,7 +11,7 @@ import { artifacts } from '../artifacts';
 import { BalanceCheckerContract } from '../asset-swapper';
 import * as defaultConfig from '../config';
 import { METRICS_PATH, ONE_SECOND_MS, RFQ_ALLOWANCE_TARGET, RFQ_FIRM_QUOTE_CACHE_EXPIRY } from '../constants';
-import { getDBConnectionAsync } from '../db_connection';
+import { getDBConnectionOrThrow } from '../db_connection';
 import { MakerBalanceChainCacheEntity } from '../entities';
 import { logger } from '../logger';
 import { providerUtils } from '../utils/provider_utils';
@@ -77,8 +77,7 @@ if (require.main === module) {
         );
         const web3Wrapper = new Web3Wrapper(provider);
 
-        const connection = await getDBConnectionAsync();
-
+        const connection = await getDBConnectionOrThrow();
         const balanceCheckerContractInterface = getBalanceCheckerContractInterface(RANDOM_ADDRESS, provider);
 
         await runRfqBalanceCacheAsync(web3Wrapper, connection, balanceCheckerContractInterface);

--- a/src/services/postgres_rfqt_firm_quote_validator.ts
+++ b/src/services/postgres_rfqt_firm_quote_validator.ts
@@ -1,10 +1,10 @@
 import * as _ from 'lodash';
 import { Counter, Summary } from 'prom-client';
-import { In } from 'typeorm';
+import { Connection, In } from 'typeorm';
 import { Repository } from 'typeorm/repository/Repository';
 
 import { BigNumber, RfqFirmQuoteValidator, RfqOrderFields } from '../asset-swapper';
-import { ONE_MINUTE_MS, ZERO } from '../constants';
+import { ONE_MINUTE_MS, RFQ_FIRM_QUOTE_CACHE_EXPIRY, ZERO } from '../constants';
 import { MakerBalanceChainCacheEntity } from '../entities/MakerBalanceChainCacheEntity';
 import { logger } from '../logger';
 
@@ -59,6 +59,17 @@ export class PostgresRfqtFirmQuoteValidator implements RfqFirmQuoteValidator {
     private readonly _chainCacheRepository: Repository<MakerBalanceChainCacheEntity>;
     private readonly _cacheExpiryThresholdMs: number;
     private readonly _workerId: string;
+
+    public static create(connection: Connection | undefined): RfqFirmQuoteValidator | undefined {
+        if (connection === undefined) {
+            return undefined;
+        }
+
+        return new PostgresRfqtFirmQuoteValidator(
+            connection.getRepository(MakerBalanceChainCacheEntity),
+            RFQ_FIRM_QUOTE_CACHE_EXPIRY,
+        );
+    }
 
     constructor(
         chainCacheRepository: Repository<MakerBalanceChainCacheEntity>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -393,9 +393,9 @@ export interface ISwapService {
 
 export interface AppDependencies {
     contractAddresses: ContractAddresses;
-    connection: Connection;
+    connection?: Connection;
     kafkaClient?: Kafka;
-    orderBookService: IOrderBookService;
+    orderBookService?: IOrderBookService;
     swapService?: ISwapService;
     metaTransactionService?: IMetaTransactionService;
     provider: SupportedProvider;

--- a/src/utils/no_op_orderbook.ts
+++ b/src/utils/no_op_orderbook.ts
@@ -1,0 +1,25 @@
+import { Orderbook, SignedNativeOrder } from '../asset-swapper';
+
+export class NoOpOrderbook extends Orderbook {
+    constructor() {
+        super();
+    }
+
+    public async getOrdersAsync(
+        _makerToken: string,
+        _takerToken: string,
+        _pruneFn?: (o: SignedNativeOrder) => boolean,
+    ): Promise<SignedNativeOrder[]> {
+        return [];
+    }
+    public async getBatchOrdersAsync(
+        _makerTokens: string[],
+        _takerToken: string,
+        _pruneFn?: (o: SignedNativeOrder) => boolean,
+    ): Promise<SignedNativeOrder[][]> {
+        return [];
+    }
+    public async destroyAsync(): Promise<void> {
+        return;
+    }
+}

--- a/src/utils/rfq_dyanmic_blacklist.ts
+++ b/src/utils/rfq_dyanmic_blacklist.ts
@@ -1,4 +1,6 @@
 import { Connection } from 'typeorm';
+import { RFQT_TX_ORIGIN_BLACKLIST } from '../config';
+import { RFQ_DYNAMIC_BLACKLIST_TTL } from '../constants';
 
 import { RfqBlockedAddressUtils } from './rfq_blocked_address_utils';
 
@@ -9,6 +11,14 @@ import { RfqBlockedAddressUtils } from './rfq_blocked_address_utils';
 export class RfqDynamicBlacklist implements Set<string> {
     public size: number;
     private readonly _rfqBlockedAddressUtils: RfqBlockedAddressUtils;
+
+    public static create(connection: Connection | undefined): RfqDynamicBlacklist | undefined {
+        if (connection === undefined) {
+            return undefined;
+        }
+
+        return new RfqDynamicBlacklist(connection, RFQT_TX_ORIGIN_BLACKLIST, RFQ_DYNAMIC_BLACKLIST_TTL);
+    }
 
     constructor(connection: Connection, initialBlockedSet: Set<string>, ttlMs: number) {
         this._rfqBlockedAddressUtils = new RfqBlockedAddressUtils(connection, initialBlockedSet, ttlMs);

--- a/test/orderbook_service_test.ts
+++ b/test/orderbook_service_test.ts
@@ -9,7 +9,7 @@ import { Connection } from 'typeorm';
 const { color, symbols } = Mocha.reporters.Base;
 
 import { DEFAULT_PAGE, DEFAULT_PER_PAGE } from '../src/constants';
-import { getDBConnectionAsync } from '../src/db_connection';
+import { getDBConnectionOrThrow } from '../src/db_connection';
 import { OrderWatcherSignedOrderEntity, PersistentSignedOrderV4Entity } from '../src/entities';
 import { OrderBookService } from '../src/services/orderbook_service';
 import { OrderEventEndState, PaginatedCollection, SRAOrder, SRAOrderMetaData } from '../src/types';
@@ -93,7 +93,7 @@ describe(SUITE_NAME, () => {
 
     before(async () => {
         await setupDependenciesAsync(SUITE_NAME);
-        connection = await getDBConnectionAsync();
+        connection = await getDBConnectionOrThrow();
         await connection.runMigrations();
         orderBookService = new OrderBookService(connection, new MockOrderWatcher(connection));
         provider = getProvider();
@@ -107,6 +107,7 @@ describe(SUITE_NAME, () => {
         privateKey = `0x${privateKeyBuf.toString('hex')}`;
         await blockchainLifecycle.startAsync();
     });
+
     after(async () => {
         await teardownDependenciesAsync(SUITE_NAME);
     });

--- a/test/sra_test.ts
+++ b/test/sra_test.ts
@@ -70,7 +70,7 @@ describe(SUITE_NAME, () => {
             },
         };
         const orderEntity = orderUtils.serializeOrder(apiOrder);
-        await dependencies.connection.getRepository(OrderWatcherSignedOrderEntity).save(orderEntity);
+        await dependencies.connection?.getRepository(OrderWatcherSignedOrderEntity).save(orderEntity);
         return apiOrder;
     }
 
@@ -107,14 +107,14 @@ describe(SUITE_NAME, () => {
     });
 
     beforeEach(async () => {
-        await dependencies.connection.runMigrations();
+        await dependencies.connection?.runMigrations();
         await blockchainLifecycle.startAsync();
     });
 
     afterEach(async () => {
         await blockchainLifecycle.revertAsync();
         await dependencies.connection
-            .createQueryBuilder()
+            ?.createQueryBuilder()
             .delete()
             .from(OrderWatcherSignedOrderEntity)
             .where('true')
@@ -249,7 +249,7 @@ describe(SUITE_NAME, () => {
         });
         it('should return 404 if order is not found', async () => {
             const apiOrder = await addNewOrderAsync({ maker: makerAddress });
-            await dependencies.connection.manager.delete(OrderWatcherSignedOrderEntity, apiOrder.metaData.orderHash);
+            await dependencies.connection?.manager.delete(OrderWatcherSignedOrderEntity, apiOrder.metaData.orderHash);
             const response = await httpGetAsync({ app, route: `${SRA_PATH}/order/${apiOrder.metaData.orderHash}` });
             expect(response.status).to.deep.eq(HttpStatus.NOT_FOUND);
         });

--- a/test/swap_test.ts
+++ b/test/swap_test.ts
@@ -16,7 +16,7 @@ import { AppDependencies } from '../src/types';
 import { BUY_SOURCE_FILTER_BY_CHAIN_ID, ChainId, ERC20BridgeSource, LimitOrderFields } from '../src/asset-swapper';
 import * as config from '../src/config';
 import { AFFILIATE_FEE_TRANSFORMER_GAS, GAS_LIMIT_BUFFER_MULTIPLIER, SWAP_PATH } from '../src/constants';
-import { getDBConnectionAsync } from '../src/db_connection';
+import { getDBConnectionOrThrow } from '../src/db_connection';
 import { ValidationErrorCodes, ValidationErrorItem, ValidationErrorReasons } from '../src/errors';
 import { logger } from '../src/logger';
 import { GetSwapQuoteResponse, SignedLimitOrder } from '../src/types';
@@ -73,7 +73,7 @@ describe(SUITE_NAME, () => {
 
     before(async () => {
         await setupDependenciesAsync(SUITE_NAME);
-        const connection = await getDBConnectionAsync();
+        const connection = await getDBConnectionOrThrow();
         await connection.runMigrations();
         provider = getProvider();
         const web3Wrapper = new Web3Wrapper(provider);

--- a/test/test_env
+++ b/test/test_env
@@ -1,4 +1,5 @@
 ETHEREUM_RPC_URL=http://ganache:8545
+POSTGRES_URI=postgres://api:api@localhost/api
 CHAIN_ID=1337
 RFQT_API_KEY_WHITELIST_JSON='["koolApiKey1","koolApikey2"]'
 RFQT_MAKER_ASSET_OFFERINGS='{"https://mock-rfqt1.club":[["0x871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c","0x0b1ba0af832d7c05fd64161e0db78e85978e8082"]]}'
@@ -7,7 +8,6 @@ META_TXN_RELAY_ADDRESS=0x9eFCa436873b55a0d6AEa260f92DE50150360dca
 META_TXN_RELAY_PRIVATE_KEY=82b9c3b8d45f608badd8fda250a0d95088381540e850734519b659e1e1ac3e71
 META_TXN_RATE_LIMITER_CONFIG='{"api_key":{"daily":{"allowedDailyLimit": 1}}}'
 NODE_ENV=test
-ETH_GAS_STATION_API_URL=https://ethgasstation.api.0x.org/api/ethgasAPI.json
 ALT_RFQ_MM_ENDPOINT=https://altrfq.com
 ALT_RFQ_MM_API_KEY=averysecurekey
 ALT_RFQ_MM_PROFILE=acoolprofile

--- a/test/utils/db_connection.ts
+++ b/test/utils/db_connection.ts
@@ -1,13 +1,14 @@
 import { Connection } from 'typeorm';
 
-import { getDBConnectionAsync } from '../../src/db_connection';
+import { getDBConnectionOrThrow } from '../../src/db_connection';
 
 /**
  * Get the DB connection and initialize it by installing extension and synchronize schemas
  * @returns db connection
  */
 export async function initDBConnectionAsync(): Promise<Connection> {
-    const connection = await getDBConnectionAsync();
+    const connection = await getDBConnectionOrThrow();
+
     await connection.query(`CREATE EXTENSION IF NOT EXISTS pgcrypto`); // used by view `rfq_maker_pairs_update_time_hashes`
     await connection.synchronize(true);
     return connection;


### PR DESCRIPTION
# Description

* Make PostgreSQL an optional dependency of a `/swap`
* Exit with an error when PostgreSQL is required (`/orderbook`, `/sra`)

# Testing & Simbot Run

* [Simbot without local PostgreSQL instance](https://metabase.spaceship.0x.org/dashboard/186?run_id=ethereum-no-pg)
* [Simbot with local PostgreSQL instance](https://metabase.spaceship.0x.org/dashboard/186?run_id=ethereum-with-pg)

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
