### PR TITLE
chore: Remove `excludedFeeSources` from `GetMarketOrdersOpts` [LIT-690]

### DIFF
--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -628,11 +628,6 @@ export interface GetMarketOrdersOpts {
      */
     excludedSources: ERC20BridgeSource[];
     /**
-     * Liquidity sources to exclude when used to calculate the cost of the route.
-     * Default is none.
-     */
-    excludedFeeSources: ERC20BridgeSource[];
-    /**
      * Liquidity sources to include. Default is none, which allows all supported
      * sources that aren't excluded by `excludedSources`.
      */

--- a/src/asset-swapper/utils/market_operation_utils/constants.ts
+++ b/src/asset-swapper/utils/market_operation_utils/constants.ts
@@ -2900,7 +2900,6 @@ const DEFAULT_FEE_SCHEDULE: FeeSchedule = Object.keys(DEFAULT_GAS_SCHEDULE).redu
 
 export const DEFAULT_GET_MARKET_ORDERS_OPTS: Omit<GetMarketOrdersOpts, 'gasPrice'> = {
     excludedSources: [],
-    excludedFeeSources: [],
     includedSources: [],
     bridgeSlippage: 0.005,
     maxFallbackSlippage: 0.05,

--- a/src/asset-swapper/utils/market_operation_utils/index.ts
+++ b/src/asset-swapper/utils/market_operation_utils/index.ts
@@ -64,7 +64,7 @@ const NO_CONVERSION_TO_NATIVE_FOUND = new Counter({
 export class MarketOperationUtils {
     private readonly _sellSources: SourceFilters;
     private readonly _buySources: SourceFilters;
-    private readonly _feeSources: SourceFilters;
+    private readonly _feeSources: ERC20BridgeSource[];
     private readonly _nativeFeeToken: string;
     private readonly _nativeFeeTokenAmount: BigNumber;
 
@@ -126,7 +126,7 @@ export class MarketOperationUtils {
     ) {
         this._buySources = BUY_SOURCE_FILTER_BY_CHAIN_ID[_sampler.chainId];
         this._sellSources = SELL_SOURCE_FILTER_BY_CHAIN_ID[_sampler.chainId];
-        this._feeSources = new SourceFilters(FEE_QUOTE_SOURCES_BY_CHAIN_ID[_sampler.chainId]);
+        this._feeSources = FEE_QUOTE_SOURCES_BY_CHAIN_ID[_sampler.chainId];
         this._nativeFeeToken = NATIVE_FEE_TOKEN_BY_CHAIN_ID[_sampler.chainId];
         this._nativeFeeTokenAmount = NATIVE_FEE_TOKEN_AMOUNT_BY_CHAIN_ID[_sampler.chainId];
     }
@@ -149,7 +149,6 @@ export class MarketOperationUtils {
 
         const requestFilters = new SourceFilters().exclude(_opts.excludedSources).include(_opts.includedSources);
         const quoteSourceFilters = this._sellSources.merge(requestFilters);
-        const feeSourceFilters = this._feeSources.exclude(_opts.excludedFeeSources);
 
         // Used to determine whether the tx origin is an EOA or a contract
         const txOrigin = (_opts.rfqt && _opts.rfqt.txOrigin) || NULL_ADDRESS;
@@ -163,7 +162,7 @@ export class MarketOperationUtils {
             this._sampler.getLimitOrderFillableTakerAmounts(nativeOrders, this.contractAddresses.exchangeProxy),
             // Get ETH -> maker token price.
             this._sampler.getBestNativeTokenSellRate(
-                feeSourceFilters.sources,
+                this._feeSources,
                 makerToken,
                 this._nativeFeeToken,
                 this._nativeFeeTokenAmount,
@@ -171,7 +170,7 @@ export class MarketOperationUtils {
             ),
             // Get ETH -> taker token price.
             this._sampler.getBestNativeTokenSellRate(
-                feeSourceFilters.sources,
+                this._feeSources,
                 takerToken,
                 this._nativeFeeToken,
                 this._nativeFeeTokenAmount,
@@ -270,7 +269,6 @@ export class MarketOperationUtils {
 
         const requestFilters = new SourceFilters().exclude(_opts.excludedSources).include(_opts.includedSources);
         const quoteSourceFilters = this._buySources.merge(requestFilters);
-        const feeSourceFilters = this._feeSources.exclude(_opts.excludedFeeSources);
 
         // Used to determine whether the tx origin is an EOA or a contract
         const txOrigin = (_opts.rfqt && _opts.rfqt.txOrigin) || NULL_ADDRESS;
@@ -284,7 +282,7 @@ export class MarketOperationUtils {
             this._sampler.getLimitOrderFillableMakerAmounts(nativeOrders, this.contractAddresses.exchangeProxy),
             // Get ETH -> makerToken token price.
             this._sampler.getBestNativeTokenSellRate(
-                feeSourceFilters.sources,
+                this._feeSources,
                 makerToken,
                 this._nativeFeeToken,
                 this._nativeFeeTokenAmount,
@@ -292,7 +290,7 @@ export class MarketOperationUtils {
             ),
             // Get ETH -> taker token price.
             this._sampler.getBestNativeTokenSellRate(
-                feeSourceFilters.sources,
+                this._feeSources,
                 takerToken,
                 this._nativeFeeToken,
                 this._nativeFeeTokenAmount,

--- a/src/config.ts
+++ b/src/config.ts
@@ -443,22 +443,6 @@ const EXCLUDED_SOURCES = (() => {
     }
 })();
 
-const EXCLUDED_FEE_SOURCES = (() => {
-    switch (CHAIN_ID) {
-        case ChainId.Mainnet:
-            return [];
-        case ChainId.Kovan:
-            return [ERC20BridgeSource.Uniswap];
-        case ChainId.BSC:
-            return [ERC20BridgeSource.Uniswap];
-        case ChainId.Polygon:
-            return [];
-        case ChainId.Celo:
-            return [];
-        default:
-            return [ERC20BridgeSource.Uniswap, ERC20BridgeSource.UniswapV2];
-    }
-})();
 const FILL_QUOTE_TRANSFORMER_GAS_OVERHEAD = new BigNumber(150e3);
 const EXCHANGE_PROXY_OVERHEAD_NO_VIP = () => FILL_QUOTE_TRANSFORMER_GAS_OVERHEAD;
 const MULTIPLEX_BATCH_FILL_SOURCE_FLAGS =
@@ -526,7 +510,6 @@ const SAMPLE_DISTRIBUTION_BASE: number = _.isEmpty(process.env.SAMPLE_DISTRIBUTI
 
 export const ASSET_SWAPPER_MARKET_ORDERS_OPTS: Partial<SwapQuoteRequestOpts> = {
     excludedSources: EXCLUDED_SOURCES,
-    excludedFeeSources: EXCLUDED_FEE_SOURCES,
     bridgeSlippage: DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE,
     maxFallbackSlippage: DEFAULT_FALLBACK_SLIPPAGE_PERCENTAGE,
     numSamples: 13,


### PR DESCRIPTION
# Description

Remove `excludedFeeSources` from `GetMarketOrdersOpts` 

* `excludedFeeSources` is a no-op as there is no overlap between `EXCLUDED_FEE_SOURCES` and 
`BUY_SOURCE_FILTER_BY_CHAIN_ID`/`SELL_SOURCE_FILTER_BY_CHAIN_ID`

# Testing & Simbot Run

* [sanity simbot run](https://metabase.spaceship.0x.org/dashboard/186?run_id=ethereum-excl-fee-sources&adjusted_amount_bought_win_tolerance__bps_=1.0)

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
