### PR TITLE
chore: Make `getOptimizerResultAsync` to explicitly take token addresses [LIT-690]

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "fix": "eslint --fix src test && yarn prettier",
         "prettier": "prettier --write ${npm_package_config_prettier_target} --config .prettierrc",
         "prettier:ci": "prettier --list-different ${npm_package_config_prettier_target} --config .prettierrc",
-	    "circular": "madge --circular --extensions ts ./",
+        "circular": "madge --circular --extensions ts ./",
         "start": "node -r dotenv/config lib/src/index.js",
         "start:service:http": "node -r dotenv/config lib/src/runners/http_service_runner.js",
         "start:service:sra_http": "node -r dotenv/config lib/src/runners/http_sra_service_runner.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,7 +101,6 @@ const getIntegratorIdFromLabel = (label: string): string | undefined => {
     }
 };
 
-type RfqWorkFlowType = 'rfqt' | 'rfqm';
 type RfqOrderType = 'rfq' | 'otc';
 
 /**
@@ -116,27 +115,6 @@ interface RfqMakerConfig {
     rfqtOrderTypes: RfqOrderType[];
     apiKeyHashes: string[];
 }
-
-/**
- * A Map type which map the makerId to the config object.
- */
-type MakerIdsToConfigs = Map</* makerId */ string, RfqMakerConfig>;
-
-/**
- * Generate a map from MakerId to MakerConfig that support a given order type for a given workflow
- */
-const getMakerConfigMapForOrderType = (
-    orderType: RfqOrderType | 'any',
-    workflow: RfqWorkFlowType,
-): MakerIdsToConfigs => {
-    const typesField = workflow === 'rfqt' ? 'rfqtOrderTypes' : 'rfqmOrderTypes';
-    return RFQ_MAKER_CONFIGS.reduce((acc, curr) => {
-        if (orderType === 'any' || curr[typesField].includes(orderType)) {
-            acc.set(curr.makerId, curr);
-        }
-        return acc;
-    }, new Map<string, RfqMakerConfig>());
-};
 
 /**
  * A list of type RfqMakerConfig, read from the RFQ_MAKER_CONFIGS env variable

--- a/test/asset-swapper/market_operation_utils_test.ts
+++ b/test/asset-swapper/market_operation_utils_test.ts
@@ -90,7 +90,14 @@ async function getMarketSellOrdersAsync(
     takerAmount: BigNumber,
     opts: Partial<GetMarketOrdersOpts> & { gasPrice: BigNumber },
 ): Promise<OptimizerResultWithReport> {
-    return utils.getOptimizerResultAsync(nativeOrders, takerAmount, MarketOperation.Sell, opts);
+    return utils.getOptimizerResultAsync(
+        MAKER_TOKEN,
+        TAKER_TOKEN,
+        nativeOrders,
+        takerAmount,
+        MarketOperation.Sell,
+        opts,
+    );
 }
 
 /**
@@ -107,7 +114,14 @@ async function getMarketBuyOrdersAsync(
     makerAmount: BigNumber,
     opts: Partial<GetMarketOrdersOpts> & { gasPrice: BigNumber },
 ): Promise<OptimizerResultWithReport> {
-    return utils.getOptimizerResultAsync(nativeOrders, makerAmount, MarketOperation.Buy, opts);
+    return utils.getOptimizerResultAsync(
+        MAKER_TOKEN,
+        TAKER_TOKEN,
+        nativeOrders,
+        makerAmount,
+        MarketOperation.Buy,
+        opts,
+    );
 }
 
 function toRfqClientV1Price(order: SignedLimitOrder): RfqClientV1Price {
@@ -626,6 +640,8 @@ describe('MarketOperationUtils tests', () => {
 
                 const totalAssetAmount = ORDERS.map((o) => o.order.takerAmount).reduce((a, b) => a.plus(b));
                 await mockedMarketOpUtils.object.getOptimizerResultAsync(
+                    MAKER_TOKEN,
+                    TAKER_TOKEN,
                     ORDERS,
                     totalAssetAmount,
                     MarketOperation.Sell,
@@ -662,6 +678,8 @@ describe('MarketOperationUtils tests', () => {
 
                 const totalAssetAmount = ORDERS.map((o) => o.order.takerAmount).reduce((a, b) => a.plus(b));
                 await mockedMarketOpUtils.object.getOptimizerResultAsync(
+                    MAKER_TOKEN,
+                    TAKER_TOKEN,
                     ORDERS,
                     totalAssetAmount,
                     MarketOperation.Sell,
@@ -722,6 +740,8 @@ describe('MarketOperationUtils tests', () => {
 
                 const totalAssetAmount = ORDERS.map((o) => o.order.takerAmount).reduce((a, b) => a.plus(b));
                 await mockedMarketOpUtils.object.getOptimizerResultAsync(
+                    MAKER_TOKEN,
+                    TAKER_TOKEN,
                     ORDERS.slice(2, ORDERS.length),
                     totalAssetAmount,
                     MarketOperation.Sell,
@@ -795,6 +815,8 @@ describe('MarketOperationUtils tests', () => {
 
                 const totalAssetAmount = ORDERS.map((o) => o.order.takerAmount).reduce((a, b) => a.plus(b));
                 await mockedMarketOpUtils.object.getOptimizerResultAsync(
+                    MAKER_TOKEN,
+                    TAKER_TOKEN,
                     ORDERS.slice(1, ORDERS.length),
                     totalAssetAmount,
                     MarketOperation.Sell,
@@ -873,6 +895,8 @@ describe('MarketOperationUtils tests', () => {
 
                 const totalAssetAmount = ORDERS.map((o) => o.order.takerAmount).reduce((a, b) => a.plus(b));
                 await mockedMarketOpUtils.object.getOptimizerResultAsync(
+                    MAKER_TOKEN,
+                    TAKER_TOKEN,
                     ORDERS.slice(2, ORDERS.length),
                     totalAssetAmount,
                     MarketOperation.Sell,
@@ -922,6 +946,8 @@ describe('MarketOperationUtils tests', () => {
 
                 try {
                     await mockedMarketOpUtils.object.getOptimizerResultAsync(
+                        MAKER_TOKEN,
+                        TAKER_TOKEN,
                         ORDERS.slice(2, ORDERS.length),
                         ORDERS[0].order.takerAmount,
                         MarketOperation.Sell,
@@ -945,8 +971,20 @@ describe('MarketOperationUtils tests', () => {
                     DEFAULT_OPTS,
                 );
                 const improvedOrders = improvedOrdersResponse.optimizedOrders;
-                const totaltakerAmount = BigNumber.sum(...improvedOrders.map((o) => o.takerAmount));
-                expect(totaltakerAmount).to.bignumber.gte(FILL_AMOUNT);
+                const totalTakerAmount = BigNumber.sum(...improvedOrders.map((o) => o.takerAmount));
+                expect(totalTakerAmount).to.bignumber.gte(FILL_AMOUNT);
+            });
+
+            it('generates bridge orders with correct taker amount when limit order is empty', async () => {
+                const improvedOrdersResponse = await getMarketSellOrdersAsync(
+                    marketOperationUtils,
+                    [],
+                    FILL_AMOUNT,
+                    DEFAULT_OPTS,
+                );
+                const improvedOrders = improvedOrdersResponse.optimizedOrders;
+                const totalTakerAmount = BigNumber.sum(...improvedOrders.map((o) => o.takerAmount));
+                expect(totalTakerAmount).to.bignumber.gte(FILL_AMOUNT);
             });
 
             it('generates bridge orders with max slippage of `bridgeSlippage`', async () => {
@@ -1140,6 +1178,8 @@ describe('MarketOperationUtils tests', () => {
                 const exchangeProxyOverhead = (sourceFlags: bigint) =>
                     sourceFlags === SOURCE_FLAGS.Curve ? constants.ZERO_AMOUNT : new BigNumber(1.3e5).times(gasPrice);
                 const improvedOrdersResponse = await optimizer.getOptimizerResultAsync(
+                    MAKER_TOKEN,
+                    TAKER_TOKEN,
                     createOrdersFromSellRates(FILL_AMOUNT, rates[ERC20BridgeSource.Native]),
                     FILL_AMOUNT,
                     MarketOperation.Sell,
@@ -1447,6 +1487,8 @@ describe('MarketOperationUtils tests', () => {
                 const exchangeProxyOverhead = (sourceFlags: bigint) =>
                     sourceFlags === SOURCE_FLAGS.Curve ? constants.ZERO_AMOUNT : new BigNumber(1.3e5).times(GAS_PRICE);
                 const improvedOrdersResponse = await optimizer.getOptimizerResultAsync(
+                    MAKER_TOKEN,
+                    TAKER_TOKEN,
                     createOrdersFromSellRates(FILL_AMOUNT, rates[ERC20BridgeSource.Native]),
                     FILL_AMOUNT,
                     MarketOperation.Buy,


### PR DESCRIPTION
# Description

* Remove a hack around creating a dummy limit order to pass down token addresses.

# Testing & Simbot Run

* [sanity check simbot run](https://metabase.spaceship.0x.org/dashboard/186?run_id=ethereum-dummy-limit)

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
