### PR TITLE
fix: Use correct 0x gas api url for arbitrum swaps

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -343,7 +343,7 @@ export const PROMETHEUS_PORT: number = _.isEmpty(process.env.PROMETHEUS_PORT)
     : assertEnvVarType('PROMETHEUS_PORT', process.env.PROMETHEUS_PORT, EnvVarType.Port);
 
 // ZeroEx Gas API URL
-const ZERO_EX_GAS_API_URL: string = _.isEmpty(process.env.ZERO_EX_GAS_API_URL)
+export const ZERO_EX_GAS_API_URL: string = _.isEmpty(process.env.ZERO_EX_GAS_API_URL)
     ? DEFAULT_ZERO_EX_GAS_API_URL
     : assertEnvVarType('ZERO_EX_GAS_API_URL', process.env.ZERO_EX_GAS_API_URL, EnvVarType.Url);
 

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -24,6 +24,7 @@ import {
     RFQT_API_KEY_WHITELIST,
     RFQT_INTEGRATOR_IDS,
     RFQT_REGISTRY_PASSWORDS,
+    ZERO_EX_GAS_API_URL,
 } from '../config';
 import {
     AFFILIATE_DATA_SELECTOR,
@@ -307,7 +308,10 @@ export class SwapHandlers {
 
             // Add additional L1 gas cost.
             if (CHAIN_ID === ChainId.Arbitrum) {
-                const gasUtils = GasPriceUtils.getInstance(constants.PROTOCOL_FEE_UTILS_POLLING_INTERVAL_IN_MS);
+                const gasUtils = GasPriceUtils.getInstance(
+                    constants.PROTOCOL_FEE_UTILS_POLLING_INTERVAL_IN_MS,
+                    ZERO_EX_GAS_API_URL,
+                );
                 const gasPrices = await gasUtils.getGasPriceEstimationOrDefault({
                     fast: 100_000_000, // 0.1 gwei in wei
                 });


### PR DESCRIPTION
Use correct 0x gas api url for Arbitrum swaps.
https://linear.app/0xproject/issue/LIT-724/arbitrum-swap-error


# Description
When estimating gas for Arbitrum swaps, we were erroneously using the Mainnet instance of the gas api since that is the default. Pass in the gas api url from the environment variable to get the correct gas api instance.


# Testing & Simbot Run

Tested against local API to see gas estimates in the ~2m range and verified on-chain this is about right.

Before this change, gas prices were coming from Mainnet, which are about 100x more expensive, resulting in a much too low of an estimate for Arbitrum since we divide by the gas price.

<!--- If your changes affect `swap` API (e.g. adding a new liquidity source, changes sampling or routing logic) include a link to Simbot run(s). -->

# Checklist

-   [ ] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [ ] Add tests to cover changes as needed.
-   [ ] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
