### PR TITLE
fix: Include RFQt v2 prices as indicative quotes when passing to optimizer

### DIFF
--- a/src/asset-swapper/utils/market_operation_utils/index.ts
+++ b/src/asset-swapper/utils/market_operation_utils/index.ts
@@ -613,7 +613,10 @@ export class MarketOperationUtils {
 
                 DEFAULT_INFO_LOGGER({ v2Prices, isEmpty: v2Prices?.length === 0 }, 'v2Prices from RFQ Client');
 
-                const indicativeQuotes = v1Prices as V4RFQIndicativeQuoteMM[];
+                const indicativeQuotes = [
+                    ...v1Prices as V4RFQIndicativeQuoteMM[],
+                    ...v2Prices as V4RFQIndicativeQuoteMM[]
+                ];
                 const deltaTime = new Date().getTime() - timeStart;
                 DEFAULT_INFO_LOGGER({
                     rfqQuoteType: 'indicative',

--- a/src/asset-swapper/utils/market_operation_utils/index.ts
+++ b/src/asset-swapper/utils/market_operation_utils/index.ts
@@ -614,8 +614,8 @@ export class MarketOperationUtils {
                 DEFAULT_INFO_LOGGER({ v2Prices, isEmpty: v2Prices?.length === 0 }, 'v2Prices from RFQ Client');
 
                 const indicativeQuotes = [
-                    ...v1Prices as V4RFQIndicativeQuoteMM[],
-                    ...v2Prices as V4RFQIndicativeQuoteMM[]
+                    ...(v1Prices as V4RFQIndicativeQuoteMM[]),
+                    ...(v2Prices as V4RFQIndicativeQuoteMM[]),
                 ];
                 const deltaTime = new Date().getTime() - timeStart;
                 DEFAULT_INFO_LOGGER({


### PR DESCRIPTION


<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
-->

# Description

RFQt v2 prices are not included in indicative quotes when passing to optimizer in for `/price`

# Testing & Simbot Run

<!--- If your changes affect `swap` API (e.g. adding a new liquidity source, changes sampling or routing logic) include a link to Simbot run(s). -->

# Checklist

-   [ ] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [ ] Add tests to cover changes as needed.
-   [ ] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
