### PR TITLE
chore: Clean up various `OptimizedOrder` related code [LIT-690]

### DIFF
--- a/src/asset-swapper/swap_quoter.ts
+++ b/src/asset-swapper/swap_quoter.ts
@@ -428,7 +428,6 @@ function calculateTwoHopQuoteInfo(
 ): { bestCaseQuoteInfo: SwapQuoteInfo; worstCaseQuoteInfo: SwapQuoteInfo; sourceBreakdown: SwapQuoteOrdersBreakdown } {
     const [firstHopOrder, secondHopOrder] = optimizedOrders;
     const gas = new BigNumber(
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- TODO: fix me!
         gasSchedule[ERC20BridgeSource.MultiHop]!({
             firstHopSource: _.pick(firstHopOrder, 'source', 'fillData'),
             secondHopSource: _.pick(secondHopOrder, 'source', 'fillData'),
@@ -438,9 +437,9 @@ function calculateTwoHopQuoteInfo(
 
     return {
         bestCaseQuoteInfo: {
-            makerAmount: isSell ? secondHopOrder.fill.output : secondHopOrder.fill.input,
-            takerAmount: isSell ? firstHopOrder.fill.input : firstHopOrder.fill.output,
-            totalTakerAmount: isSell ? firstHopOrder.fill.input : firstHopOrder.fill.output,
+            makerAmount: secondHopOrder.makerAmount,
+            takerAmount: firstHopOrder.takerAmount,
+            totalTakerAmount: firstHopOrder.takerAmount,
             feeTakerTokenAmount: constants.ZERO_AMOUNT,
             protocolFeeInWeiAmount: constants.ZERO_AMOUNT,
             gas,

--- a/src/asset-swapper/swap_quoter.ts
+++ b/src/asset-swapper/swap_quoter.ts
@@ -428,7 +428,7 @@ function calculateTwoHopQuoteInfo(
 ): { bestCaseQuoteInfo: SwapQuoteInfo; worstCaseQuoteInfo: SwapQuoteInfo; sourceBreakdown: SwapQuoteOrdersBreakdown } {
     const [firstHopOrder, secondHopOrder] = optimizedOrders;
     const gas = new BigNumber(
-        gasSchedule[ERC20BridgeSource.MultiHop]!({
+        gasSchedule[ERC20BridgeSource.MultiHop]({
             firstHopSource: _.pick(firstHopOrder, 'source', 'fillData'),
             secondHopSource: _.pick(secondHopOrder, 'source', 'fillData'),
         }),

--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -582,10 +582,21 @@ export type FeeSchedule = Record<ERC20BridgeSource, FeeEstimate>;
 type GasEstimate = (fillData: FillData) => number;
 export type GasSchedule = Record<ERC20BridgeSource, GasEstimate>;
 
+export interface FillBase {
+    // Input fill amount (taker asset amount in a sell, maker asset amount in a buy).
+    input: BigNumber;
+    // Output fill amount (maker asset amount in a sell, taker asset amount in a buy).
+    output: BigNumber;
+    // The output fill amount, adjusted by fees.
+    adjustedOutput: BigNumber;
+    // The expected gas cost of this fill
+    gas: number;
+}
+
 /**
  * Represents a node on a fill path.
  */
-export interface Fill<TFillData extends FillData = FillData> {
+export interface Fill<TFillData extends FillData = FillData> extends FillBase {
     // basic data for every fill
     source: ERC20BridgeSource;
     // TODO jacob people seem to agree  that orderType here is more readable
@@ -597,14 +608,6 @@ export interface Fill<TFillData extends FillData = FillData> {
     sourcePathId: string;
     // See `SOURCE_FLAGS`.
     flags: bigint;
-    // Input fill amount (taker asset amount in a sell, maker asset amount in a buy).
-    input: BigNumber;
-    // Output fill amount (maker asset amount in a sell, taker asset amount in a buy).
-    output: BigNumber;
-    // The output fill amount, adjusted by fees.
-    adjustedOutput: BigNumber;
-    // The expected gas cost of this fill
-    gas: number;
 }
 
 export type ExchangeProxyOverhead = (sourceFlags: bigint) => BigNumber;
@@ -719,7 +722,7 @@ interface OptimizedMarketOrderBase<TFillData extends FillData = FillData> {
     takerToken: string;
     makerAmount: BigNumber; // The amount we wish to buy from this order, e.g inclusive of any previous partial fill
     takerAmount: BigNumber; // The amount we wish to fill this for, e.g inclusive of any previous partial fill
-    fill: Omit<Fill, 'flags' | 'fillData' | 'sourcePathId' | 'source' | 'type'>; // Remove duplicates which have been brought into the OrderBase interface
+    fill: FillBase;
 }
 
 export interface OptimizedMarketBridgeOrder<TFillData extends FillData = FillData>

--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -725,7 +725,6 @@ interface OptimizedMarketOrderBase<TFillData extends FillData = FillData> {
 export interface OptimizedMarketBridgeOrder<TFillData extends FillData = FillData>
     extends OptimizedMarketOrderBase<TFillData> {
     type: FillQuoteTransformerOrderType.Bridge;
-    sourcePathId: string;
 }
 
 export interface OptimizedLimitOrder extends OptimizedMarketOrderBase<NativeLimitOrderFillData> {

--- a/src/asset-swapper/utils/market_operation_utils/orders.ts
+++ b/src/asset-swapper/utils/market_operation_utils/orders.ts
@@ -15,6 +15,7 @@ import {
     OptimizedMarketBridgeOrder,
     OptimizedOrder,
     OptimizedNativeOrder,
+    FillBase,
 } from '../../types';
 
 import { MAX_UINT256, ZERO_AMOUNT } from './constants';
@@ -550,7 +551,7 @@ export function createNativeOptimizedOrder(fill: Fill<NativeFillData>, side: Mar
         makerAmount,
         takerAmount,
         fillData,
-        fill: cleanFillForExport(fill),
+        fill: toFillBase(fill),
     };
     switch (fill.type) {
         case FillQuoteTransformerOrderType.Rfq:
@@ -587,12 +588,12 @@ export function createBridgeOrder(
         makerAmount,
         takerAmount,
         fillData: createFinalBridgeOrderFillDataFromCollapsedFill(fill),
-        fill: cleanFillForExport(fill),
+        fill: toFillBase(fill),
     };
 }
 
-function cleanFillForExport(fill: Fill): Fill {
-    return _.omit(fill, ['flags', 'fillData', 'sourcePathId', 'source', 'type']) as Fill;
+function toFillBase(fill: Fill): FillBase {
+    return _.pick(fill, ['input', 'output', 'adjustedOutput', 'gas']);
 }
 
 function createFinalBridgeOrderFillDataFromCollapsedFill(fill: Fill): FillData {

--- a/src/asset-swapper/utils/market_operation_utils/orders.ts
+++ b/src/asset-swapper/utils/market_operation_utils/orders.ts
@@ -59,7 +59,7 @@ export function createOrdersFromTwoHopSample(
     sample: DexSample<MultiHopFillData>,
     opts: CreateOrderFromPathOpts,
 ): [OptimizedOrder, OptimizedOrder] {
-    const [makerToken, takerToken] = getMakerTakerTokens(opts);
+    const { makerToken, takerToken } = getMakerTakerTokens(opts);
     const { firstHopSource, secondHopSource, intermediateToken } = sample.fillData;
     const firstHopFill: Fill = {
         sourcePathId: '',
@@ -632,8 +632,11 @@ function getBestUniswapV3PathAmountForInputAmount(
     return fillData.pathAmounts[fillData.pathAmounts.length - 1];
 }
 
-export function getMakerTakerTokens(opts: CreateOrderFromPathOpts): [string, string] {
+export function getMakerTakerTokens(opts: CreateOrderFromPathOpts): {
+    makerToken: string;
+    takerToken: string;
+} {
     const makerToken = opts.side === MarketOperation.Sell ? opts.outputToken : opts.inputToken;
     const takerToken = opts.side === MarketOperation.Sell ? opts.inputToken : opts.outputToken;
-    return [makerToken, takerToken];
+    return { makerToken, takerToken };
 }

--- a/src/asset-swapper/utils/market_operation_utils/orders.ts
+++ b/src/asset-swapper/utils/market_operation_utils/orders.ts
@@ -588,7 +588,6 @@ export function createBridgeOrder(
         takerAmount,
         fillData: createFinalBridgeOrderFillDataFromCollapsedFill(fill),
         fill: cleanFillForExport(fill),
-        sourcePathId: fill.sourcePathId,
     };
 }
 

--- a/src/asset-swapper/utils/market_operation_utils/path.ts
+++ b/src/asset-swapper/utils/market_operation_utils/path.ts
@@ -73,7 +73,7 @@ export class Path {
      * for settlement
      */
     public finalize(opts: CreateOrderFromPathOpts): FinalizedPath {
-        const [makerToken, takerToken] = getMakerTakerTokens(opts);
+        const { makerToken, takerToken } = getMakerTakerTokens(opts);
         this.orders = [];
         for (const fill of this.fills) {
             // internal BigInt flag field is not supported JSON and is tricky


### PR DESCRIPTION
# Description

* Remove unused `sourcePathId` in `OptimizedMarketBridgeOrder`
* Simplify `calculateTwoHopQuoteInfo`
* Define `FillBase` instead of using `Omit<Fill, ...>`.
* Rename `cleanFillForExport` to `toFillBase` and make it type-safe

# Testing & Simbot Run

<!--- If your changes affect `swap` API (e.g. adding a new liquidity source, changes sampling or routing logic) include a link to Simbot run(s). -->

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
