### PR TITLE
fix: If chain has no VIPs, then be sure to include FQT gas overhead [LIT-717]

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -473,6 +473,10 @@ export const ASSET_SWAPPER_MARKET_ORDERS_OPTS_NO_VIP: Partial<SwapQuoteRequestOp
     exchangeProxyOverhead: EXCHANGE_PROXY_OVERHEAD_NO_VIP,
 };
 
+export const CHAIN_HAS_VIPS = (chainId: ChainId) => {
+    return [ChainId.Mainnet, ChainId.BSC].includes(chainId);
+};
+
 const SAMPLER_OVERRIDES: SamplerOverrides | undefined = (() => {
     switch (CHAIN_ID) {
         case ChainId.Ganache:

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -37,6 +37,7 @@ import {
     ALT_RFQ_MM_ENDPOINT,
     ASSET_SWAPPER_MARKET_ORDERS_OPTS,
     ASSET_SWAPPER_MARKET_ORDERS_OPTS_NO_VIP,
+    CHAIN_HAS_VIPS,
     CHAIN_ID,
     RFQT_REQUEST_MAX_RESPONSE_MS,
     SWAP_QUOTER_OPTS,
@@ -299,7 +300,8 @@ export class SwapService implements ISwapService {
             isMetaTransaction ||
             shouldSellEntireBalance ||
             // Note: We allow VIP to continue ahead when positive slippage fee is enabled
-            affiliateFee.feeType === AffiliateFeeType.PercentageFee
+            affiliateFee.feeType === AffiliateFeeType.PercentageFee ||
+            !CHAIN_HAS_VIPS(CHAIN_ID)
         ) {
             swapQuoteRequestOpts = ASSET_SWAPPER_MARKET_ORDERS_OPTS_NO_VIP;
         } else {


### PR DESCRIPTION
Tested locally and manually verified no VIP chains such as Polygon get the FQT gas overhead.



<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
-->

# Description

<!--- Describe your changes in detail -->

# Testing & Simbot Run

<!--- If your changes affect `swap` API (e.g. adding a new liquidity source, changes sampling or routing logic) include a link to Simbot run(s). -->

# Checklist

-   [ ] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [ ] Add tests to cover changes as needed.
-   [ ] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
