### PR TITLE
chore: Remove states in `Path` [LIT-690]

### DIFF
--- a/src/asset-swapper/utils/market_operation_utils/index.ts
+++ b/src/asset-swapper/utils/market_operation_utils/index.ts
@@ -404,7 +404,6 @@ export class MarketOperationUtils {
             side,
             inputToken,
             outputToken,
-            contractAddresses: this.contractAddresses,
         };
 
         const augmentedRfqtIndicativeQuotes: NativeOrderWithFillableAmounts[] = rfqtIndicativeQuotes.map(

--- a/src/asset-swapper/utils/market_operation_utils/orders.ts
+++ b/src/asset-swapper/utils/market_operation_utils/orders.ts
@@ -3,7 +3,6 @@ import { AbiEncoder, BigNumber } from '@0x/utils';
 import _ = require('lodash');
 
 import {
-    AssetSwapperContractAddresses,
     MarketOperation,
     ERC20BridgeSource,
     Fill,
@@ -52,7 +51,6 @@ export interface CreateOrderFromPathOpts {
     side: MarketOperation;
     inputToken: string;
     outputToken: string;
-    contractAddresses: AssetSwapperContractAddresses;
 }
 
 export function createOrdersFromTwoHopSample(

--- a/test/asset-swapper/utils/market_operations_utils/path_test.ts
+++ b/test/asset-swapper/utils/market_operations_utils/path_test.ts
@@ -58,6 +58,27 @@ describe('Path', () => {
             expect(path.adjustedRate()).bignumber.eq(new BigNumber(990 + 1000 / 2 - 10 - 10).div(1.5));
         });
     });
+
+    describe('source flags', () => {
+        it('Returns merged source flags from fills', () => {
+            const path = Path.create(
+                MarketOperation.Sell,
+                [
+                    createFakeFillWithFlags(BigInt(1)),
+                    createFakeFillWithFlags(BigInt(2)),
+                    createFakeFillWithFlags(BigInt(8)),
+                ],
+                ONE_ETHER,
+                {
+                    inputAmountPerEth: new BigNumber(1),
+                    outputAmountPerEth: new BigNumber(1),
+                    exchangeProxyOverhead: () => new BigNumber(0),
+                },
+            );
+
+            expect(path.sourceFlags).eq(BigInt(1 + 2 + 8));
+        });
+    });
 });
 
 function createFakeFill(params: { input: BigNumber; output?: BigNumber; adjustedOutput: BigNumber }): Fill {
@@ -72,5 +93,19 @@ function createFakeFill(params: { input: BigNumber; output?: BigNumber; adjusted
         fillData: {},
         sourcePathId: 'fake-path-id',
         flags: BigInt(0),
+    };
+}
+
+function createFakeFillWithFlags(flags: bigint): Fill {
+    return {
+        input: ONE_ETHER,
+        output: ONE_ETHER,
+        adjustedOutput: ONE_ETHER,
+        gas: 42,
+        source: ERC20BridgeSource.UniswapV3,
+        type: FillQuoteTransformerOrderType.Bridge,
+        fillData: {},
+        sourcePathId: 'fake-path-id',
+        flags,
     };
 }


### PR DESCRIPTION
# Description

* Remove states (adjustedSize and sourceFlags) in `Path` by computing them before initializing `Path` 
* Add a unit test for `sourceFlags`

# Testing & Simbot Run

* Added a unit test.

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
