### PR TITLE
chore: Replace `Path.finalize` and `FinalizedPath` with `Path.createOrders` [LIT-690]

### DIFF
--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -458,8 +458,6 @@ export interface SamplerCallResult {
     data: string;
 }
 
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-
 export interface RfqClientV1PriceRequest {
     altRfqAssetOfferings: AltRfqMakerAssetOfferings | undefined;
     assetFillAmount: BigNumber;

--- a/src/asset-swapper/utils/market_operation_utils/index.ts
+++ b/src/asset-swapper/utils/market_operation_utils/index.ts
@@ -450,12 +450,10 @@ export class MarketOperationUtils {
             throw new Error(AggregationError.NoOptimalPath);
         }
 
-        const finalizedPath = optimalPath.finalize(orderOpts);
-
         return {
-            optimizedOrders: finalizedPath.orders,
-            liquidityDelivered: finalizedPath.fills,
-            sourceFlags: finalizedPath.sourceFlags,
+            optimizedOrders: optimalPath.createOrders(orderOpts),
+            liquidityDelivered: optimalPath.fills,
+            sourceFlags: optimalPath.sourceFlags,
             marketSideLiquidity,
             adjustedRate: optimalPathAdjustedRate,
             takerAmountPerEth,

--- a/src/asset-swapper/utils/market_operation_utils/path_optimizer.ts
+++ b/src/asset-swapper/utils/market_operation_utils/path_optimizer.ts
@@ -355,9 +355,7 @@ export class PathOptimizer {
     private createFillFromTwoHopSample(sample: DexSample<MultiHopFillData>): Fill {
         const { fillData } = sample;
 
-        // TODO: remove below once `FeeSchedule` become non-Partial.
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const multihopFeeEstimate = this.feeSchedule[ERC20BridgeSource.MultiHop]!;
+        const multihopFeeEstimate = this.feeSchedule[ERC20BridgeSource.MultiHop];
         const fill = twoHopSampleToFill(
             this.side,
             sample,

--- a/src/asset-swapper/utils/market_operation_utils/types.ts
+++ b/src/asset-swapper/utils/market_operation_utils/types.ts
@@ -177,6 +177,9 @@ export interface GenericRouterFillData extends FillData {
     router: string;
 }
 
+// TODO(kyu-c): investigate
+// It seems unnecessary for `firstHopSource` and `secondHopSource` to be a `SourceQuoteOperation`.
+// It may only need `source` and `fillData`.
 export interface MultiHopFillData extends FillData {
     firstHopSource: SourceQuoteOperation;
     secondHopSource: SourceQuoteOperation;
@@ -311,6 +314,7 @@ export interface SourceQuoteOperation<TFillData extends FillData = FillData> ext
 export interface OptimizerResult {
     optimizedOrders: OptimizedOrder[];
     sourceFlags: bigint;
+    // TODO(kyu-c): `liquidityDelivered` is never `DexSample<MultiHopFillData>`.
     liquidityDelivered: Readonly<Fill[] | DexSample<MultiHopFillData>>;
     marketSideLiquidity: MarketSideLiquidity;
     adjustedRate: BigNumber;


### PR DESCRIPTION
# Description

* Replace `Path.finalize` and `FinalizedPath` with `Path.createOrders`

# Testing & Simbot Run

* Added some unit tests

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
