### PR TITLE
chore: Simplify `MultiHopFillData` [LIT-690]

### DIFF
--- a/src/asset-swapper/utils/market_operation_utils/sampler_operations.ts
+++ b/src/asset-swapper/utils/market_operation_utils/sampler_operations.ts
@@ -804,13 +804,17 @@ export class SamplerOperations {
                         [HopInfo, HopInfo, BigNumber[]]
                     >('sampleTwoHopSell', callResults);
                     // Ensure the hop sources are set even when the buy amount is zero
-                    fillData.firstHopSource = firstHopOps[firstHop.sourceIndex.toNumber()];
-                    fillData.secondHopSource = secondHopOps[secondHop.sourceIndex.toNumber()];
                     if (buyAmounts[buyAmounts.length - 1].isZero()) {
                         return new Array(buyAmounts.length).fill(ZERO_AMOUNT);
                     }
-                    fillData.firstHopSource.handleCallResults(firstHop.returnData);
-                    fillData.secondHopSource.handleCallResults(secondHop.returnData);
+
+                    const firstHopOp = firstHopOps[firstHop.sourceIndex.toNumber()];
+                    const secondHopOp = secondHopOps[secondHop.sourceIndex.toNumber()];
+                    firstHopOp.handleCallResults(firstHop.returnData);
+                    secondHopOp.handleCallResults(secondHop.returnData);
+                    fillData.firstHopSource = { source: firstHopOp.source, fillData: firstHopOp.fillData };
+                    fillData.secondHopSource = { source: secondHopOp.source, fillData: secondHopOp.fillData };
+
                     return buyAmounts;
                 },
             });
@@ -871,10 +875,12 @@ export class SamplerOperations {
                     if (sellAmounts[sellAmounts.length - 1].isEqualTo(MAX_UINT256)) {
                         return new Array(sellAmounts.length).fill(MAX_UINT256);
                     }
-                    fillData.firstHopSource = firstHopOps[firstHop.sourceIndex.toNumber()];
-                    fillData.secondHopSource = secondHopOps[secondHop.sourceIndex.toNumber()];
-                    fillData.firstHopSource.handleCallResults(firstHop.returnData);
-                    fillData.secondHopSource.handleCallResults(secondHop.returnData);
+                    const firstHopOp = firstHopOps[firstHop.sourceIndex.toNumber()];
+                    const secondHopOp = secondHopOps[secondHop.sourceIndex.toNumber()];
+                    firstHopOp.handleCallResults(firstHop.returnData);
+                    secondHopOp.handleCallResults(secondHop.returnData);
+                    fillData.firstHopSource = { source: firstHopOp.source, fillData: firstHopOp.fillData };
+                    fillData.secondHopSource = { source: secondHopOp.source, fillData: secondHopOp.fillData };
                     return sellAmounts;
                 },
             });

--- a/src/asset-swapper/utils/market_operation_utils/types.ts
+++ b/src/asset-swapper/utils/market_operation_utils/types.ts
@@ -177,12 +177,15 @@ export interface GenericRouterFillData extends FillData {
     router: string;
 }
 
-// TODO(kyu-c): investigate
-// It seems unnecessary for `firstHopSource` and `secondHopSource` to be a `SourceQuoteOperation`.
-// It may only need `source` and `fillData`.
 export interface MultiHopFillData extends FillData {
-    firstHopSource: SourceQuoteOperation;
-    secondHopSource: SourceQuoteOperation;
+    firstHopSource: {
+        source: ERC20BridgeSource;
+        fillData: FillData;
+    };
+    secondHopSource: {
+        source: ERC20BridgeSource;
+        fillData: FillData;
+    };
     intermediateToken: string;
 }
 

--- a/test/asset-swapper/quote_report_generator_test.ts
+++ b/test/asset-swapper/quote_report_generator_test.ts
@@ -307,16 +307,10 @@ describe('generateQuoteReport', async () => {
             firstHopSource: {
                 source: ERC20BridgeSource.Balancer,
                 fillData: {},
-                encodeCall: () => '',
-                handleCallResults: (_callResults) => [new BigNumber(1337)],
-                handleRevert: (_c) => [],
             },
             secondHopSource: {
                 source: ERC20BridgeSource.Curve,
                 fillData: {},
-                encodeCall: () => '',
-                handleCallResults: (_callResults) => [new BigNumber(1337)],
-                handleRevert: (_c) => [],
             },
         };
         const twoHopSample: DexSample<MultiHopFillData> = {

--- a/test/asset-swapper/utils/market_operations_utils/path_optimizer_test.ts
+++ b/test/asset-swapper/utils/market_operations_utils/path_optimizer_test.ts
@@ -349,16 +349,10 @@ function createMultihopSample(params: {
             firstHopSource: {
                 source: params.firstHopSource,
                 fillData: {},
-                encodeCall: () => 'fake-encodedCall',
-                handleCallResults: () => [],
-                handleRevert: () => [],
             },
             secondHopSource: {
                 source: params.secondHopSource,
                 fillData: {},
-                encodeCall: () => 'fake-encodedCall',
-                handleCallResults: () => [],
-                handleRevert: () => [],
             },
             intermediateToken: 'fake-intermediate-token',
         },


### PR DESCRIPTION
# Description

* Simplify `MultiHopFillData`
* `firstHopSource` and `secondHopSource` does not need to be `SourceQuoteOperation`

# Testing & Simbot Run

* [Sanity simbot run](https://metabase.spaceship.0x.org/dashboard/186?run_id=two-hop-fill-data&adjusted_amount_bought_win_tolerance__bps_=1.0)

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
