### PR TITLE
chore: Move `slipNonNativeOrders` to `Path` [LIT-690]

### DIFF
--- a/src/asset-swapper/swap_quoter.ts
+++ b/src/asset-swapper/swap_quoter.ts
@@ -358,6 +358,7 @@ function createSwapQuote(
         takerToken,
         gasPrice,
         orders: optimizedOrders,
+        path,
         bestCaseQuoteInfo,
         worstCaseQuoteInfo,
         sourceBreakdown,

--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -19,7 +19,6 @@ import {
 import { RfqClient } from '../utils/rfq_client';
 import { QuoteRequestor } from './utils/quote_requestor';
 import { TokenAdjacencyGraph } from './utils/token_adjacency_graph';
-import { Path } from './utils/market_operation_utils/path';
 
 export interface QuoteReport {
     sourcesConsidered: QuoteReportEntry[];
@@ -237,6 +236,12 @@ export interface ExchangeProxyContractOpts {
     shouldSellEntireBalance: boolean;
 }
 
+export interface IPath {
+    hasTwoHop(): boolean;
+    createOrders(): OptimizedOrder[];
+    createSlippedOrders(maxSlippage: number): OptimizedOrder[];
+}
+
 /**
  * takerToken: Address of the taker asset.
  * makerToken: Address of the maker asset.
@@ -251,7 +256,7 @@ interface SwapQuoteBase {
     gasPrice: BigNumber;
     // TODO(kyu-c): replace its usage with `path.createOrders`.
     orders: OptimizedOrder[];
-    path: Path;
+    path: IPath;
     bestCaseQuoteInfo: SwapQuoteInfo;
     worstCaseQuoteInfo: SwapQuoteInfo;
     sourceBreakdown: SwapQuoteOrdersBreakdown;

--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -19,6 +19,7 @@ import {
 import { RfqClient } from '../utils/rfq_client';
 import { QuoteRequestor } from './utils/quote_requestor';
 import { TokenAdjacencyGraph } from './utils/token_adjacency_graph';
+import { Path } from './utils/market_operation_utils/path';
 
 export interface QuoteReport {
     sourcesConsidered: QuoteReportEntry[];
@@ -248,15 +249,16 @@ interface SwapQuoteBase {
     takerToken: string;
     makerToken: string;
     gasPrice: BigNumber;
-    // TODO(kyu-c): replace `orders` with a `Path`
+    // TODO(kyu-c): replace its usage with `path.createOrders`.
     orders: OptimizedOrder[];
+    path: Path;
     bestCaseQuoteInfo: SwapQuoteInfo;
     worstCaseQuoteInfo: SwapQuoteInfo;
     sourceBreakdown: SwapQuoteOrdersBreakdown;
     quoteReport?: QuoteReport;
     extendedQuoteReportSources?: ExtendedQuoteReportSources;
     priceComparisonsReport?: PriceComparisonsReport;
-    // TODO(kyu-c): remove and derive from `Path`
+    // TODO(kyu-c): replace its usage with `path.hasTwoHop`
     isTwoHop: boolean;
     makerTokenDecimals: number;
     takerTokenDecimals: number;

--- a/src/asset-swapper/utils/market_operation_utils/path.ts
+++ b/src/asset-swapper/utils/market_operation_utils/path.ts
@@ -8,6 +8,7 @@ import {
     ERC20BridgeSource,
     ExchangeProxyOverhead,
     Fill,
+    IPath,
 } from '../../types';
 
 import { MAX_UINT256, SOURCE_FLAGS, ZERO_AMOUNT } from './constants';
@@ -32,7 +33,7 @@ export interface PathPenaltyOpts {
     exchangeProxyOverhead: ExchangeProxyOverhead;
 }
 
-export class Path {
+export class Path implements IPath {
     public static create(
         context: PathContext,
         fills: readonly Fill[],

--- a/test/asset-swapper/exchange_proxy_swap_quote_consumer_test.ts
+++ b/test/asset-swapper/exchange_proxy_swap_quote_consumer_test.ts
@@ -32,6 +32,7 @@ import {
     OptimizedLimitOrder,
     OptimizedOrder,
 } from '../../src/asset-swapper/types';
+import { Path } from '../../src/asset-swapper/utils/market_operation_utils/path';
 
 import { chaiSetup } from './utils/chai_setup';
 import { getRandomAmount, getRandomSignature } from './utils/utils';
@@ -118,6 +119,11 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
             makerToken: MAKER_TOKEN,
             takerToken: TAKER_TOKEN,
             orders: [order],
+            path: {
+                createOrders: () => [order],
+                createSlippedOrders: (_maxSlippage: number) => [order],
+                hasTwoHop: () => false,
+            } as unknown as Path,
             makerTokenDecimals: 18,
             takerTokenDecimals: 18,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: fix me!
@@ -151,12 +157,23 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
     }
 
     function getRandomTwoHopQuote(side: MarketOperation): MarketBuySwapQuote | MarketSellSwapQuote {
+        const firstHopOrder = getRandomOptimizedMarketOrder(
+            { makerToken: INTERMEDIATE_TOKEN },
+            { makerToken: INTERMEDIATE_TOKEN },
+        );
+        const secondHopOrder = getRandomOptimizedMarketOrder(
+            { takerToken: INTERMEDIATE_TOKEN },
+            { takerToken: INTERMEDIATE_TOKEN },
+        );
         return {
             ...getRandomQuote(side),
-            orders: [
-                getRandomOptimizedMarketOrder({ makerToken: INTERMEDIATE_TOKEN }, { makerToken: INTERMEDIATE_TOKEN }),
-                getRandomOptimizedMarketOrder({ takerToken: INTERMEDIATE_TOKEN }, { takerToken: INTERMEDIATE_TOKEN }),
-            ],
+            orders: [firstHopOrder, secondHopOrder],
+            path: {
+                createOrders: () => [firstHopOrder, secondHopOrder],
+                createSlippedOrders: (_maxSlippage: number) => [firstHopOrder, secondHopOrder],
+                hasTwoHop: () => true,
+            } as unknown as Path,
+
             isTwoHop: true,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: fix me!
         } as any;

--- a/test/asset-swapper/exchange_proxy_swap_quote_consumer_test.ts
+++ b/test/asset-swapper/exchange_proxy_swap_quote_consumer_test.ts
@@ -31,6 +31,7 @@ import {
     NativeFillData,
     OptimizedLimitOrder,
     OptimizedOrder,
+    IPath,
 } from '../../src/asset-swapper/types';
 import { Path } from '../../src/asset-swapper/utils/market_operation_utils/path';
 
@@ -123,7 +124,7 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
                 createOrders: () => [order],
                 createSlippedOrders: (_maxSlippage: number) => [order],
                 hasTwoHop: () => false,
-            } as unknown as Path,
+            } as IPath,
             makerTokenDecimals: 18,
             takerTokenDecimals: 18,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: fix me!

--- a/test/utils/mocks.ts
+++ b/test/utils/mocks.ts
@@ -1,6 +1,7 @@
 import { BigNumber, NULL_ADDRESS, NULL_BYTES } from '@0x/utils';
 
 import { MarketOperation, RfqOrderFields, SwapQuote } from '../../src/asset-swapper';
+import { IPath } from '../../src/asset-swapper/types';
 import { Path } from '../../src/asset-swapper/utils/market_operation_utils/path';
 
 export const rfqtIndicativeQuoteResponse = {
@@ -42,7 +43,7 @@ export const randomSellQuote: SwapQuote = {
     makerToken: '0xb9302bbc853c3e3480a1eefc2bb6bf4cdca809e6',
     takerToken: '0x5471a5833768d1151d34701eba1c9123d1ba2f8a',
     orders: [],
-    path: undefined as unknown as Path,
+    path: undefined as unknown as IPath,
     bestCaseQuoteInfo,
     worstCaseQuoteInfo: {
         feeTakerTokenAmount: new BigNumber('556208982260696635'),

--- a/test/utils/mocks.ts
+++ b/test/utils/mocks.ts
@@ -1,6 +1,7 @@
 import { BigNumber, NULL_ADDRESS, NULL_BYTES } from '@0x/utils';
 
 import { MarketOperation, RfqOrderFields, SwapQuote } from '../../src/asset-swapper';
+import { Path } from '../../src/asset-swapper/utils/market_operation_utils/path';
 
 export const rfqtIndicativeQuoteResponse = {
     makerAmount: '100000000000000000',
@@ -41,6 +42,7 @@ export const randomSellQuote: SwapQuote = {
     makerToken: '0xb9302bbc853c3e3480a1eefc2bb6bf4cdca809e6',
     takerToken: '0x5471a5833768d1151d34701eba1c9123d1ba2f8a',
     orders: [],
+    path: undefined as unknown as Path,
     bestCaseQuoteInfo,
     worstCaseQuoteInfo: {
         feeTakerTokenAmount: new BigNumber('556208982260696635'),


### PR DESCRIPTION
# Description

*  Move `slipNonNativeOrders` to `Path.createSlippedOrders`

# Testing & Simbot Run

* Added unit tests

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
