### PR TITLE
chore: Remove `isTwoHop` from `SwapQuoteBase` [LIT-690]

### DIFF
--- a/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
+++ b/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
@@ -395,9 +395,9 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumerBase {
 
         // If it's two hop we have an intermediate token this is needed to encode the individual FQT
         // and we also want to ensure no dust amount is left in the flash wallet
-        const intermediateToken = quote.isTwoHop ? slippedOrders[0].makerToken : NULL_ADDRESS;
+        const intermediateToken = quote.path.hasTwoHop() ? slippedOrders[0].makerToken : NULL_ADDRESS;
         // This transformer will fill the quote.
-        if (quote.isTwoHop) {
+        if (quote.path.hasTwoHop()) {
             const [firstHopOrder, secondHopOrder] = slippedOrders;
             transforms.push({
                 deploymentNonce: this.transformerNonces.fillQuoteTransformer,
@@ -518,7 +518,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumerBase {
         // Return any unspent sell tokens.
         const payTakerTokens = [sellToken];
         // Return any unspent intermediate tokens for two-hop swaps.
-        if (quote.isTwoHop) {
+        if (quote.path.hasTwoHop()) {
             payTakerTokens.push(intermediateToken);
         }
         // Return any unspent ETH. If ETH is the buy token, it will

--- a/src/asset-swapper/quote_consumers/quote_consumer_utils.ts
+++ b/src/asset-swapper/quote_consumers/quote_consumer_utils.ts
@@ -31,7 +31,7 @@ export function isMultiplexBatchFillCompatible(quote: SwapQuote, opts: ExchangeP
     if (requiresTransformERC20(opts)) {
         return false;
     }
-    if (quote.isTwoHop) {
+    if (quote.path.hasTwoHop()) {
         return false;
     }
     if (quote.orders.map((o) => o.type).includes(FillQuoteTransformerOrderType.Limit)) {
@@ -56,7 +56,7 @@ export function isMultiplexMultiHopFillCompatible(quote: SwapQuote, opts: Exchan
     if (requiresTransformERC20(opts)) {
         return false;
     }
-    if (!quote.isTwoHop) {
+    if (!quote.path.hasTwoHop()) {
         return false;
     }
     const [firstHopOrder, secondHopOrder] = quote.orders;

--- a/src/asset-swapper/swap_quoter.ts
+++ b/src/asset-swapper/swap_quoter.ts
@@ -343,11 +343,10 @@ function createSwapQuote(
         makerAmountPerEth,
         priceComparisonsReport,
     } = optimizerResult;
-    const isTwoHop = path.hasTwoHop();
     const optimizedOrders = path.createOrders();
 
     // Calculate quote info
-    const { bestCaseQuoteInfo, worstCaseQuoteInfo, sourceBreakdown } = isTwoHop
+    const { bestCaseQuoteInfo, worstCaseQuoteInfo, sourceBreakdown } = path.hasTwoHop()
         ? calculateTwoHopQuoteInfo(optimizedOrders, operation, gasSchedule, slippage)
         : calculateQuoteInfo(optimizedOrders, operation, assetFillAmount, gasPrice, gasSchedule, slippage);
 
@@ -368,7 +367,6 @@ function createSwapQuote(
         makerAmountPerEth,
         quoteReport,
         extendedQuoteReportSources,
-        isTwoHop,
         priceComparisonsReport,
         blockNumber,
     };

--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -263,8 +263,6 @@ interface SwapQuoteBase {
     quoteReport?: QuoteReport;
     extendedQuoteReportSources?: ExtendedQuoteReportSources;
     priceComparisonsReport?: PriceComparisonsReport;
-    // TODO(kyu-c): replace its usage with `path.hasTwoHop`
-    isTwoHop: boolean;
     makerTokenDecimals: number;
     takerTokenDecimals: number;
     takerAmountPerEth: BigNumber;

--- a/test/asset-swapper/exchange_proxy_swap_quote_consumer_test.ts
+++ b/test/asset-swapper/exchange_proxy_swap_quote_consumer_test.ts
@@ -129,7 +129,6 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
             takerTokenDecimals: 18,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: fix me!
             sourceBreakdown: {} as any,
-            isTwoHop: false,
             bestCaseQuoteInfo: {
                 makerAmount: makerTokenFillAmount,
                 takerAmount: takerTokenFillAmount,
@@ -445,9 +444,7 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
         });
         it('Uses two `FillQuoteTransformer`s if given two-hop sell quote', async () => {
             const quote = getRandomTwoHopQuote(MarketOperation.Sell) as MarketSellSwapQuote;
-            const callInfo = await consumer.getCalldataOrThrowAsync(quote, {
-                extensionContractOpts: { isTwoHop: true },
-            });
+            const callInfo = await consumer.getCalldataOrThrowAsync(quote);
             const callArgs = transformERC20Encoder.decode(callInfo.calldataHexString) as TransformERC20Args;
             expect(callArgs.inputToken).to.eq(TAKER_TOKEN);
             expect(callArgs.outputToken).to.eq(MAKER_TOKEN);

--- a/test/utils/mocks.ts
+++ b/test/utils/mocks.ts
@@ -56,7 +56,6 @@ export const randomSellQuote: SwapQuote = {
     },
     sourceBreakdown: {},
     takerTokenFillAmount: new BigNumber('401019713908867904'),
-    isTwoHop: false,
     makerTokenDecimals: 18,
     takerTokenDecimals: 18,
     takerAmountPerEth: new BigNumber(0),


### PR DESCRIPTION
# Description

*  Remove `isTwoHop` from `SwapQuoteBase`

# Testing & Simbot Run

* Passes existing unit / integration tests.

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
