### PR TITLE
chore: Remove `orders` in `SwapQuoteBase` [LIT-690]

### DIFF
--- a/src/asset-swapper/swap_quoter.ts
+++ b/src/asset-swapper/swap_quoter.ts
@@ -356,7 +356,6 @@ function createSwapQuote(
         makerToken,
         takerToken,
         gasPrice,
-        orders: optimizedOrders,
         path,
         bestCaseQuoteInfo,
         worstCaseQuoteInfo,

--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -254,8 +254,6 @@ interface SwapQuoteBase {
     takerToken: string;
     makerToken: string;
     gasPrice: BigNumber;
-    // TODO(kyu-c): replace its usage with `path.createOrders`.
-    orders: OptimizedOrder[];
     path: IPath;
     bestCaseQuoteInfo: SwapQuoteInfo;
     worstCaseQuoteInfo: SwapQuoteInfo;

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -484,7 +484,7 @@ export class SwapService implements ISwapService {
             buyAmount: makerAmount.minus(buyTokenFeeAmount),
             sellAmount: totalTakerAmount,
             sources: serviceUtils.convertSourceBreakdownToArray(sourceBreakdown),
-            orders: swapQuote.orders,
+            orders: swapQuote.path.createOrders(),
             allowanceTarget,
             decodedUniqueId,
             extendedQuoteReportSources,

--- a/src/types.ts
+++ b/src/types.ts
@@ -201,7 +201,7 @@ interface SwapQuoteParamsBase {
 // GET /swap/quote
 export interface GetSwapQuoteResponse extends SwapQuoteResponsePartialTransaction, BasePriceResponse {
     guaranteedPrice: BigNumber;
-    // orders: SignedOrder[];
+    // TODO(kyu-c): It seems `orders` must not be optional. Investigate and change its type.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: fix me!
     orders?: any;
     from?: string;

--- a/test/asset-swapper/exchange_proxy_swap_quote_consumer_test.ts
+++ b/test/asset-swapper/exchange_proxy_swap_quote_consumer_test.ts
@@ -119,7 +119,6 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
             gasPrice: getRandomInteger(1, 1e9),
             makerToken: MAKER_TOKEN,
             takerToken: TAKER_TOKEN,
-            orders: [order],
             path: {
                 createOrders: () => [order],
                 createSlippedOrders: (_maxSlippage: number) => [order],
@@ -167,7 +166,6 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
         );
         return {
             ...getRandomQuote(side),
-            orders: [firstHopOrder, secondHopOrder],
             path: {
                 createOrders: () => [firstHopOrder, secondHopOrder],
                 createSlippedOrders: (_maxSlippage: number) => [firstHopOrder, secondHopOrder],
@@ -260,9 +258,9 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
             const fillQuoteTransformerData = decodeFillQuoteTransformerData(callArgs.transformations[0].data);
             expect(fillQuoteTransformerData.side).to.eq(FillQuoteTransformerSide.Sell);
             expect(fillQuoteTransformerData.fillAmount).to.bignumber.eq(quote.takerTokenFillAmount);
-            expect(fillQuoteTransformerData.limitOrders).to.deep.eq(cleanOrders(quote.orders));
+            expect(fillQuoteTransformerData.limitOrders).to.deep.eq(cleanOrders(quote.path.createOrders()));
             expect(fillQuoteTransformerData.limitOrders.map((o) => o.signature)).to.deep.eq(
-                (quote.orders as OptimizedLimitOrder[]).map((o) => o.fillData.signature),
+                (quote.path.createOrders() as OptimizedLimitOrder[]).map((o) => o.fillData.signature),
             );
             expect(fillQuoteTransformerData.sellToken).to.eq(TAKER_TOKEN);
             expect(fillQuoteTransformerData.buyToken).to.eq(MAKER_TOKEN);
@@ -291,9 +289,9 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
             const fillQuoteTransformerData = decodeFillQuoteTransformerData(callArgs.transformations[0].data);
             expect(fillQuoteTransformerData.side).to.eq(FillQuoteTransformerSide.Buy);
             expect(fillQuoteTransformerData.fillAmount).to.bignumber.eq(quote.makerTokenFillAmount);
-            expect(fillQuoteTransformerData.limitOrders).to.deep.eq(cleanOrders(quote.orders));
+            expect(fillQuoteTransformerData.limitOrders).to.deep.eq(cleanOrders(quote.path.createOrders()));
             expect(fillQuoteTransformerData.limitOrders.map((o) => o.signature)).to.deep.eq(
-                (quote.orders as OptimizedLimitOrder[]).map((o) => o.fillData.signature),
+                (quote.path.createOrders() as OptimizedLimitOrder[]).map((o) => o.fillData.signature),
             );
             expect(fillQuoteTransformerData.sellToken).to.eq(TAKER_TOKEN);
             expect(fillQuoteTransformerData.buyToken).to.eq(MAKER_TOKEN);
@@ -463,7 +461,7 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
                 callArgs.transformations[2].deploymentNonce.toNumber() ===
                     consumer.transformerNonces.payTakerTransformer,
             );
-            const [firstHopOrder, secondHopOrder] = quote.orders;
+            const [firstHopOrder, secondHopOrder] = quote.path.createOrders();
             const firstHopFillQuoteTransformerData = decodeFillQuoteTransformerData(callArgs.transformations[0].data);
             expect(firstHopFillQuoteTransformerData.side).to.eq(FillQuoteTransformerSide.Sell);
             expect(firstHopFillQuoteTransformerData.fillAmount).to.bignumber.eq(firstHopOrder.takerAmount);
@@ -509,9 +507,9 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
             const fillQuoteTransformerData = decodeFillQuoteTransformerData(callArgs.transformations[0].data);
             expect(fillQuoteTransformerData.side).to.eq(FillQuoteTransformerSide.Sell);
             expect(fillQuoteTransformerData.fillAmount).to.bignumber.eq(MAX_UINT256);
-            expect(fillQuoteTransformerData.limitOrders).to.deep.eq(cleanOrders(quote.orders));
+            expect(fillQuoteTransformerData.limitOrders).to.deep.eq(cleanOrders(quote.path.createOrders()));
             expect(fillQuoteTransformerData.limitOrders.map((o) => o.signature)).to.deep.eq(
-                (quote.orders as OptimizedLimitOrder[]).map((o) => o.fillData.signature),
+                (quote.path.createOrders() as OptimizedLimitOrder[]).map((o) => o.fillData.signature),
             );
             expect(fillQuoteTransformerData.sellToken).to.eq(TAKER_TOKEN);
             expect(fillQuoteTransformerData.buyToken).to.eq(MAKER_TOKEN);

--- a/test/utils/mocks.ts
+++ b/test/utils/mocks.ts
@@ -2,7 +2,6 @@ import { BigNumber, NULL_ADDRESS, NULL_BYTES } from '@0x/utils';
 
 import { MarketOperation, RfqOrderFields, SwapQuote } from '../../src/asset-swapper';
 import { IPath } from '../../src/asset-swapper/types';
-import { Path } from '../../src/asset-swapper/utils/market_operation_utils/path';
 
 export const rfqtIndicativeQuoteResponse = {
     makerAmount: '100000000000000000',
@@ -42,7 +41,6 @@ export const randomSellQuote: SwapQuote = {
     type: MarketOperation.Sell as MarketOperation.Sell,
     makerToken: '0xb9302bbc853c3e3480a1eefc2bb6bf4cdca809e6',
     takerToken: '0x5471a5833768d1151d34701eba1c9123d1ba2f8a',
-    orders: [],
     path: undefined as unknown as IPath,
     bestCaseQuoteInfo,
     worstCaseQuoteInfo: {


### PR DESCRIPTION
# Description

* Remove `orders` in `SwapQuoteBase` 

# Testing & Simbot Run

* Passes existing unit/integration tests.
* [Sanity simbot run](https://metabase.spaceship.0x.org/dashboard/186?run_id=2023-01-rm-orders-2)

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
