### PR TITLE
chore: Remove unused `feeTakerAmount` in `SwapQuoteInfo` [LIT-690]

### DIFF
--- a/src/asset-swapper/swap_quoter.ts
+++ b/src/asset-swapper/swap_quoter.ts
@@ -436,7 +436,6 @@ function calculateTwoHopQuoteInfo(
             makerAmount: secondHopOrder.makerAmount,
             takerAmount: firstHopOrder.takerAmount,
             totalTakerAmount: firstHopOrder.takerAmount,
-            feeTakerTokenAmount: constants.ZERO_AMOUNT,
             protocolFeeInWeiAmount: constants.ZERO_AMOUNT,
             gas,
             slippage: 0,
@@ -452,7 +451,6 @@ function calculateTwoHopQuoteInfo(
             totalTakerAmount: isSell
                 ? firstHopOrder.takerAmount
                 : firstHopOrder.takerAmount.times(1 + slippage).integerValue(BigNumber.ROUND_UP),
-            feeTakerTokenAmount: constants.ZERO_AMOUNT,
             protocolFeeInWeiAmount: constants.ZERO_AMOUNT,
             gas,
             slippage,
@@ -486,7 +484,6 @@ function fillResultsToQuoteInfo(fr: QuoteFillResult, slippage: number): SwapQuot
         makerAmount: fr.totalMakerAssetAmount,
         takerAmount: fr.takerAssetAmount,
         totalTakerAmount: fr.totalTakerAssetAmount,
-        feeTakerTokenAmount: fr.takerFeeTakerAssetAmount,
         protocolFeeInWeiAmount: fr.protocolFeeAmount,
         gas: fr.gas,
         slippage,

--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -289,7 +289,6 @@ export interface MarketBuySwapQuote extends SwapQuoteBase {
 export type SwapQuote = MarketBuySwapQuote | MarketSellSwapQuote;
 
 /**
- * feeTakerTokenAmount: The amount of takerAsset reserved for paying takerFees when swapping for desired assets.
  * takerTokenAmount: The amount of takerAsset swapped for desired makerAsset.
  * totalTakerTokenAmount: The total amount of takerAsset required to complete the swap (filling orders, and paying takerFees).
  * makerTokenAmount: The amount of makerAsset that will be acquired through the swap.
@@ -298,7 +297,6 @@ export type SwapQuote = MarketBuySwapQuote | MarketSellSwapQuote;
  * slippage: Amount of slippage to allow for.
  */
 export interface SwapQuoteInfo {
-    feeTakerTokenAmount: BigNumber;
     takerAmount: BigNumber;
     totalTakerAmount: BigNumber;
     makerAmount: BigNumber;

--- a/test/asset-swapper/exchange_proxy_swap_quote_consumer_test.ts
+++ b/test/asset-swapper/exchange_proxy_swap_quote_consumer_test.ts
@@ -134,7 +134,6 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
                 totalTakerAmount: takerTokenFillAmount,
                 gas: Math.floor(Math.random() * 8e6),
                 protocolFeeInWeiAmount: getRandomAmount(),
-                feeTakerTokenAmount: getRandomAmount(),
                 slippage: 0,
             },
             worstCaseQuoteInfo: {
@@ -143,7 +142,6 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
                 totalTakerAmount: takerTokenFillAmount,
                 gas: Math.floor(Math.random() * 8e6),
                 protocolFeeInWeiAmount: getRandomAmount(),
-                feeTakerTokenAmount: getRandomAmount(),
                 slippage: 0,
             },
             makerAmountPerEth: getRandomInteger(1, 1e9),

--- a/test/utils/mocks.ts
+++ b/test/utils/mocks.ts
@@ -44,7 +44,6 @@ export const randomSellQuote: SwapQuote = {
     path: undefined as unknown as IPath,
     bestCaseQuoteInfo,
     worstCaseQuoteInfo: {
-        feeTakerTokenAmount: new BigNumber('556208982260696635'),
         makerAmount: new BigNumber('195425597817301501'),
         gas: 277671,
         protocolFeeInWeiAmount: new BigNumber('526097088876239888'),


### PR DESCRIPTION
# Description

*  Remove unused `feeTakerAmount` in `SwapQuoteInfo`

# Testing & Simbot Run

* Passes existing tests.

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
