### PR TITLE
chore: Implement `Path.getOrdersByType` [LIT-690]

### DIFF
--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -745,7 +745,13 @@ export interface OptimizedOtcOrder extends OptimizedMarketOrderBase<NativeOtcOrd
 
 export type OptimizedNativeOrder = OptimizedLimitOrder | OptimizedRfqOrder | OptimizedOtcOrder;
 
-export type OptimizedOrder = OptimizedMarketBridgeOrder<FillData> | OptimizedNativeOrder;
+export type OptimizedOrder = OptimizedMarketBridgeOrder | OptimizedNativeOrder;
+
+export interface OptimizedOrdersByType {
+    nativeOrders: readonly OptimizedNativeOrder[];
+    twoHopOrders: readonly { firstHopOrder: OptimizedOrder; secondHopOrder: OptimizedOrder }[];
+    bridgeOrders: readonly OptimizedMarketBridgeOrder[];
+}
 
 // TODO: `SignedNativeOrder` should be `SignedLimitOrder`.
 export abstract class Orderbook {

--- a/src/asset-swapper/utils/market_operation_utils/orders.ts
+++ b/src/asset-swapper/utils/market_operation_utils/orders.ts
@@ -51,7 +51,7 @@ import {
 export function createOrdersFromTwoHopSample(
     sample: DexSample<MultiHopFillData>,
     pathContext: PathContext,
-): [OptimizedOrder, OptimizedOrder] {
+): { firstHopOrder: OptimizedOrder; secondHopOrder: OptimizedOrder } {
     const { side } = pathContext;
     const { makerToken, takerToken } = getMakerTakerTokens(pathContext);
     const { firstHopSource, secondHopSource, intermediateToken } = sample.fillData;
@@ -78,10 +78,10 @@ export function createOrdersFromTwoHopSample(
         flags: BigInt(0),
         gas: 1,
     };
-    return [
-        createBridgeOrder(firstHopFill, intermediateToken, takerToken, side),
-        createBridgeOrder(secondHopFill, makerToken, intermediateToken, side),
-    ];
+    return {
+        firstHopOrder: createBridgeOrder(firstHopFill, intermediateToken, takerToken, side),
+        secondHopOrder: createBridgeOrder(secondHopFill, makerToken, intermediateToken, side),
+    };
 }
 
 export function getErc20BridgeSourceToBridgeSource(source: ERC20BridgeSource): string {


### PR DESCRIPTION
# Description

* Implement `Path.getOrdersByType` which returns orders grouped by type (native, multihop, DEX single hop).

# Testing & Simbot Run

* Updated unit tests.

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
