### PR TITLE
chore: Modify `calculateQuoteInfo` to handle Multiplex+MultiHop [LIT-690]

### DIFF
--- a/src/asset-swapper/index.ts
+++ b/src/asset-swapper/index.ts
@@ -30,7 +30,7 @@ export {
     SignedNativeOrder,
     SwapQuote,
     SwapQuoteGetOutputOpts,
-    SwapQuoteOrdersBreakdown,
+    SwapQuoteSourceBreakdown,
     SwapQuoteRequestOpts,
     SwapQuoterError,
     SwapQuoterOpts,

--- a/src/asset-swapper/quote_consumers/quote_consumer_utils.ts
+++ b/src/asset-swapper/quote_consumers/quote_consumer_utils.ts
@@ -45,7 +45,7 @@ export function isMultiplexBatchFillCompatible(quote: SwapQuote, opts: ExchangeP
     }
     // Use Multiplex if the non-fallback sources are a subset of
     // {UniswapV2, Sushiswap, RFQ, PLP, UniswapV3}
-    const nonFallbackSources = Object.keys(quote.sourceBreakdown);
+    const nonFallbackSources = quote.path.getOrders().map((o) => o.source);
     return nonFallbackSources.every((source) => MULTIPLEX_BATCH_FILL_SOURCES.includes(source as ERC20BridgeSource));
 }
 

--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -307,17 +307,19 @@ export interface SwapQuoteInfo {
 }
 
 /**
- * percentage breakdown of each liquidity source used in quote
+ * Percentage breakdown of each liquidity source used in quote.
+ * Each multihop order is treated as a distinct source.
  */
-export type SwapQuoteOrdersBreakdown = Partial<
-    { [key in Exclude<ERC20BridgeSource, typeof ERC20BridgeSource.MultiHop>]: BigNumber } & {
-        [ERC20BridgeSource.MultiHop]: {
-            proportion: BigNumber;
-            intermediateToken: string;
-            hops: ERC20BridgeSource[];
-        };
-    }
->;
+export type SwapQuoteOrdersBreakdown = {
+    singleSource: Partial<{
+        [key in Exclude<ERC20BridgeSource, ERC20BridgeSource.MultiHop>]: BigNumber;
+    }>;
+    multihop: {
+        proportion: BigNumber;
+        intermediateToken: string;
+        hops: ERC20BridgeSource[];
+    }[];
+};
 
 export interface RfqRequestOpts {
     takerAddress: string;

--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -258,7 +258,7 @@ interface SwapQuoteBase {
     path: IPath;
     bestCaseQuoteInfo: SwapQuoteInfo;
     worstCaseQuoteInfo: SwapQuoteInfo;
-    sourceBreakdown: SwapQuoteOrdersBreakdown;
+    sourceBreakdown: SwapQuoteSourceBreakdown;
     quoteReport?: QuoteReport;
     extendedQuoteReportSources?: ExtendedQuoteReportSources;
     priceComparisonsReport?: PriceComparisonsReport;
@@ -310,7 +310,7 @@ export interface SwapQuoteInfo {
  * Percentage breakdown of each liquidity source used in quote.
  * Each multihop order is treated as a distinct source.
  */
-export type SwapQuoteOrdersBreakdown = {
+export type SwapQuoteSourceBreakdown = {
     singleSource: Partial<{
         [key in Exclude<ERC20BridgeSource, ERC20BridgeSource.MultiHop>]: BigNumber;
     }>;

--- a/src/asset-swapper/utils/quote_info.ts
+++ b/src/asset-swapper/utils/quote_info.ts
@@ -6,16 +6,16 @@ import {
     MarketOperation,
     OptimizedOrder,
     SwapQuoteInfo,
-    SwapQuoteOrdersBreakdown,
+    SwapQuoteSourceBreakdown,
 } from '../types';
 import { QuoteFillResult, simulateBestCaseFill, simulateWorstCaseFill } from './quote_simulation';
 import * as _ from 'lodash';
 import { constants } from '../constants';
 
-export interface QuoteInfo {
+interface QuoteInfo {
     bestCaseQuoteInfo: SwapQuoteInfo;
     worstCaseQuoteInfo: SwapQuoteInfo;
-    sourceBreakdown: SwapQuoteOrdersBreakdown;
+    sourceBreakdown: SwapQuoteSourceBreakdown;
 }
 
 interface MultiHopFill {
@@ -170,7 +170,7 @@ function mergeSwapQuoteInfos(...swapQuoteInfos: readonly SwapQuoteInfo[]): SwapQ
 function calculateSwapQuoteOrdersBreakdown(
     fillAmountBySource: { [source: string]: BigNumber },
     multihopFills: MultiHopFill[],
-): SwapQuoteOrdersBreakdown {
+): SwapQuoteSourceBreakdown {
     const totalFillAmount = BigNumber.sum(
         ...Object.values(fillAmountBySource),
         ...multihopFills.map((fill) => fill.amount),

--- a/src/asset-swapper/utils/quote_info.ts
+++ b/src/asset-swapper/utils/quote_info.ts
@@ -12,10 +12,17 @@ import { QuoteFillResult, simulateBestCaseFill, simulateWorstCaseFill } from './
 import * as _ from 'lodash';
 import { constants } from '../constants';
 
-interface QuoteInfo {
+export interface QuoteInfo {
     bestCaseQuoteInfo: SwapQuoteInfo;
     worstCaseQuoteInfo: SwapQuoteInfo;
     sourceBreakdown: SwapQuoteOrdersBreakdown;
+}
+
+interface MultiHopFill {
+    amount: BigNumber;
+    // intermediateToken should be an array but keeping it as a string for backward compatibility
+    intermediateToken: string;
+    hops: ERC20BridgeSource[];
 }
 
 export function calculateQuoteInfo(params: {
@@ -29,14 +36,33 @@ export function calculateQuoteInfo(params: {
     const { path, operation, assetFillAmount, gasPrice, gasSchedule, slippage } = params;
     const { nativeOrders, bridgeOrders, twoHopOrders } = path.getOrdersByType();
     const singleHopOrders = [...nativeOrders, ...bridgeOrders];
-    // TODO: generalize calculateQuoteInfo to handle a mix multihop+multiplex.
 
-    // NOTES: until multihop+multiplex is supported a path will have either single hop order(s) or a single two hop order.
-    if (path.hasTwoHop()) {
-        return calculateTwoHopQuoteInfo(twoHopOrders[0], operation, gasSchedule, slippage);
-    }
+    const singleHopQuoteInfo = calculateSingleHopQuoteInfo(
+        singleHopOrders,
+        operation,
+        assetFillAmount,
+        gasPrice,
+        gasSchedule,
+        slippage,
+    );
+    const twoHopQuoteInfos = twoHopOrders.map((order) =>
+        calculateTwoHopQuoteInfo(order, operation, gasSchedule, slippage),
+    );
 
-    return calculateSingleHopQuoteInfo(singleHopOrders, operation, assetFillAmount, gasPrice, gasSchedule, slippage);
+    return {
+        bestCaseQuoteInfo: mergeSwapQuoteInfos(
+            singleHopQuoteInfo.bestCaseQuoteInfo,
+            ...twoHopQuoteInfos.map((info) => info.bestCaseQuoteInfo),
+        ),
+        worstCaseQuoteInfo: mergeSwapQuoteInfos(
+            singleHopQuoteInfo.worstCaseQuoteInfo,
+            ...twoHopQuoteInfos.map((info) => info.worstCaseQuoteInfo),
+        ),
+        sourceBreakdown: calculateSwapQuoteOrdersBreakdown(
+            singleHopQuoteInfo.fillAmountBySource,
+            twoHopQuoteInfos.map((info) => info.multiHopFill),
+        ),
+    };
 }
 
 function calculateSingleHopQuoteInfo(
@@ -46,7 +72,11 @@ function calculateSingleHopQuoteInfo(
     gasPrice: BigNumber,
     gasSchedule: GasSchedule,
     slippage: number,
-): { bestCaseQuoteInfo: SwapQuoteInfo; worstCaseQuoteInfo: SwapQuoteInfo; sourceBreakdown: SwapQuoteOrdersBreakdown } {
+): {
+    bestCaseQuoteInfo: SwapQuoteInfo;
+    worstCaseQuoteInfo: SwapQuoteInfo;
+    fillAmountBySource: { [source: string]: BigNumber };
+} {
     const bestCaseFillResult = simulateBestCaseFill({
         gasPrice,
         orders: optimizedOrders,
@@ -66,7 +96,7 @@ function calculateSingleHopQuoteInfo(
     return {
         bestCaseQuoteInfo: fillResultsToQuoteInfo(bestCaseFillResult, 0),
         worstCaseQuoteInfo: fillResultsToQuoteInfo(worstCaseFillResult, slippage),
-        sourceBreakdown: getSwapQuoteOrdersBreakdown(bestCaseFillResult.fillAmountBySource),
+        fillAmountBySource: bestCaseFillResult.fillAmountBySource,
     };
 }
 
@@ -75,7 +105,7 @@ function calculateTwoHopQuoteInfo(
     operation: MarketOperation,
     gasSchedule: GasSchedule,
     slippage: number,
-): { bestCaseQuoteInfo: SwapQuoteInfo; worstCaseQuoteInfo: SwapQuoteInfo; sourceBreakdown: SwapQuoteOrdersBreakdown } {
+): { bestCaseQuoteInfo: SwapQuoteInfo; worstCaseQuoteInfo: SwapQuoteInfo; multiHopFill: MultiHopFill } {
     const { firstHopOrder, secondHopOrder } = twoHopOrder;
     const gas = new BigNumber(
         gasSchedule[ERC20BridgeSource.MultiHop]({
@@ -109,28 +139,51 @@ function calculateTwoHopQuoteInfo(
             gas,
             slippage,
         },
-        sourceBreakdown: {
-            [ERC20BridgeSource.MultiHop]: {
-                proportion: new BigNumber(1),
-                intermediateToken: secondHopOrder.takerToken,
-                hops: [firstHopOrder.source, secondHopOrder.source],
-            },
+        multiHopFill: {
+            amount: firstHopOrder.takerAmount,
+            intermediateToken: secondHopOrder.takerToken,
+            hops: [firstHopOrder.source, secondHopOrder.source],
         },
     };
 }
+function mergeSwapQuoteInfos(...swapQuoteInfos: readonly SwapQuoteInfo[]): SwapQuoteInfo {
+    if (swapQuoteInfos.length == 0) {
+        throw new Error('swapQuoteInfos.length should be at least one');
+    }
+    const slippages = _.uniq(swapQuoteInfos.map((info) => info.slippage));
+    if (slippages.length != 1) {
+        throw new Error(`slippages of swapQuoteInfos vary: ${slippages}`);
+    }
 
-function getSwapQuoteOrdersBreakdown(fillAmountBySource: { [source: string]: BigNumber }): SwapQuoteOrdersBreakdown {
-    const totalFillAmount = BigNumber.sum(...Object.values(fillAmountBySource));
-    const breakdown: SwapQuoteOrdersBreakdown = {};
-    Object.entries(fillAmountBySource).forEach(([s, fillAmount]) => {
-        const source = s as keyof SwapQuoteOrdersBreakdown;
-        if (source === ERC20BridgeSource.MultiHop) {
-            // TODO jacob has a different breakdown
-        } else {
-            breakdown[source] = fillAmount.div(totalFillAmount);
-        }
-    });
-    return breakdown;
+    const slippage = swapQuoteInfos[0].slippage;
+    return {
+        takerAmount: BigNumber.sum(...swapQuoteInfos.map((info) => info.takerAmount)),
+        totalTakerAmount: BigNumber.sum(...swapQuoteInfos.map((info) => info.totalTakerAmount)),
+        makerAmount: BigNumber.sum(...swapQuoteInfos.map((info) => info.makerAmount)),
+        protocolFeeInWeiAmount: BigNumber.sum(...swapQuoteInfos.map((info) => info.protocolFeeInWeiAmount)),
+        gas: _.sum(swapQuoteInfos.map((info) => info.gas)),
+        // fillAmountBySource:
+        slippage,
+    };
+}
+
+function calculateSwapQuoteOrdersBreakdown(
+    fillAmountBySource: { [source: string]: BigNumber },
+    multihopFills: MultiHopFill[],
+): SwapQuoteOrdersBreakdown {
+    const totalFillAmount = BigNumber.sum(
+        ...Object.values(fillAmountBySource),
+        ...multihopFills.map((fill) => fill.amount),
+    );
+
+    return {
+        singleSource: _.mapValues(fillAmountBySource, (amount) => amount.div(totalFillAmount)),
+        multihop: multihopFills.map((fill) => ({
+            proportion: fill.amount.div(totalFillAmount),
+            intermediateToken: fill.intermediateToken,
+            hops: fill.hops,
+        })),
+    };
 }
 
 function fillResultsToQuoteInfo(fr: QuoteFillResult, slippage: number): SwapQuoteInfo {

--- a/src/asset-swapper/utils/quote_simulation.ts
+++ b/src/asset-swapper/utils/quote_simulation.ts
@@ -30,6 +30,7 @@ export interface QuoteFillResult {
     // Fill amounts by source.
     // For sells, this is the taker assets sold.
     // For buys, this is the maker assets bought.
+    // TODO: key should be ERC20BridgeSource
     fillAmountBySource: { [source: string]: BigNumber };
 }
 
@@ -49,6 +50,7 @@ interface IntermediateQuoteFillResult {
     // (Estimated) gas used.
     gas: number;
     // Input amounts filled by sources.
+    // TODO: key should be ERC20BridgeSource
     inputBySource: { [source: string]: BigNumber };
 }
 
@@ -111,6 +113,7 @@ export function simulateBestCaseFill(quoteInfo: QuoteFillInfo): QuoteFillResult 
 }
 
 // Simulates filling a quote in the worst case.
+// NOTES: this isn't correct as it applies slippage to native orders as well.
 export function simulateWorstCaseFill(quoteInfo: QuoteFillInfo): QuoteFillResult {
     const opts = {
         ...DEFAULT_SIMULATED_FILL_QUOTE_INFO_OPTS,

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -483,7 +483,7 @@ export class SwapService implements ISwapService {
             sellTokenAddress: isETHSell ? ETH_TOKEN_ADDRESS : sellToken,
             buyAmount: makerAmount.minus(buyTokenFeeAmount),
             sellAmount: totalTakerAmount,
-            sources: serviceUtils.convertSourceBreakdownToArray(sourceBreakdown),
+            sources: serviceUtils.convertToLiquiditySources(sourceBreakdown),
             orders: swapQuote.path.getOrders(),
             allowanceTarget,
             decodedUniqueId,

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -381,7 +381,7 @@ export class SwapService implements ISwapService {
         let conservativeBestCaseGasEstimate = new BigNumber(worstCaseGas).plus(affiliateFeeGasCost);
 
         // Cannot eth_gasEstimate for /price when RFQ Native liquidity is included
-        const isNativeIncluded = swapQuote.sourceBreakdown.Native !== undefined;
+        const isNativeIncluded = swapQuote.sourceBreakdown.singleSource.Native !== undefined;
         const isQuote = endpoint === 'quote';
         const canEstimateGas = isQuote || !isNativeIncluded;
 

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -413,7 +413,7 @@ export class SwapService implements ISwapService {
                         accuracy: realGasEstimate.minus(fauxGasEstimate).dividedBy(realGasEstimate).toFixed(4),
                         buyToken,
                         sellToken,
-                        sources: Object.keys(swapQuote.sourceBreakdown),
+                        sources: _.uniq(swapQuote.path.getOrders().map((o) => o.source)),
                     },
                     'Improved gas estimate',
                 );

--- a/test/utils/mocks.ts
+++ b/test/utils/mocks.ts
@@ -51,7 +51,7 @@ export const randomSellQuote: SwapQuote = {
         totalTakerAmount: new BigNumber('858719009621193719'),
         slippage: 0,
     },
-    sourceBreakdown: {},
+    sourceBreakdown: { singleSource: {}, multihop: [] },
     takerTokenFillAmount: new BigNumber('401019713908867904'),
     makerTokenDecimals: 18,
     takerTokenDecimals: 18,


### PR DESCRIPTION
# Description

* Modify to `calculateQuoteInfo` to handle Multiplex+MultiHop
* Change the schema of `SwapQuoteOrdersBreakdown` 
  * Rename it `SwapQuoteSourceBreakdown`
* Modify `convertSourceBreakdownToArray` to handle new `SwapQuoteOrdersBreakdown`
  * Rename it to `convertToLiquiditySource`

# Testing & Simbot Run
* Modified existing tests for `calculateQuoteInfo`
* Added unit tests for `convertToLiquiditySources`
* [Sanity simbot run](https://metabase.spaceship.0x.org/dashboard/186?run_id=2023-01-source-breakdown-3)

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
