### PR TITLE
chore: Make `SwapQuoteConsumer.getCalldataOrThrowAsync` not `async` [LIT-760]

### DIFF
--- a/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
+++ b/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
@@ -73,7 +73,7 @@ const FAKE_PROVIDER = {
 };
 
 export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
-    public readonly transformerNonces: {
+    private readonly transformerNonces: {
         wethTransformer: number;
         payTakerTransformer: number;
         fillQuoteTransformer: number;
@@ -81,18 +81,17 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
         positiveSlippageFeeTransformer: number;
     };
 
-    private readonly _exchangeProxy: IZeroExContract;
+    private readonly exchangeProxy: IZeroExContract;
 
     public static create(chainId: ChainId): SwapQuoteConsumer {
+        assert.isNumber('chainId', chainId);
         const contractAddresses = getContractAddressesForChainOrThrow(chainId);
         return new ExchangeProxySwapQuoteConsumer(chainId, contractAddresses);
     }
 
     constructor(private readonly chainId: ChainId, private readonly contractAddresses: ContractAddresses) {
-        assert.isNumber('chainId', chainId);
-        this.chainId = chainId;
         this.contractAddresses = contractAddresses;
-        this._exchangeProxy = new IZeroExContract(contractAddresses.exchangeProxy, FAKE_PROVIDER);
+        this.exchangeProxy = new IZeroExContract(contractAddresses.exchangeProxy, FAKE_PROVIDER);
         this.transformerNonces = {
             wethTransformer: findTransformerNonce(
                 contractAddresses.transformers.wethTransformer,
@@ -155,7 +154,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
             const source = slippedOrders[0].source;
             const fillData = (slippedOrders[0] as OptimizedMarketBridgeOrder<UniswapV2FillData>).fillData;
             return {
-                calldataHexString: this._exchangeProxy
+                calldataHexString: this.exchangeProxy
                     .sellToUniswap(
                         fillData.tokenAddressPath.map((a, i) => {
                             if (i === 0 && isFromETH) {
@@ -172,8 +171,8 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
                     )
                     .getABIEncodedTransactionData(),
                 ethAmount: isFromETH ? sellAmount : ZERO_AMOUNT,
-                toAddress: this._exchangeProxy.address,
-                allowanceTarget: this._exchangeProxy.address,
+                toAddress: this.exchangeProxy.address,
+                allowanceTarget: this.exchangeProxy.address,
                 gasOverhead: ZERO_AMOUNT,
             };
         }
@@ -185,23 +184,23 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
             const fillData = (slippedOrders[0] as OptimizedMarketBridgeOrder<FinalUniswapV3FillData>).fillData;
             let _calldataHexString;
             if (isFromETH) {
-                _calldataHexString = this._exchangeProxy
+                _calldataHexString = this.exchangeProxy
                     .sellEthForTokenToUniswapV3(fillData.uniswapPath, minBuyAmount, NULL_ADDRESS)
                     .getABIEncodedTransactionData();
             } else if (isToETH) {
-                _calldataHexString = this._exchangeProxy
+                _calldataHexString = this.exchangeProxy
                     .sellTokenForEthToUniswapV3(fillData.uniswapPath, sellAmount, minBuyAmount, NULL_ADDRESS)
                     .getABIEncodedTransactionData();
             } else {
-                _calldataHexString = this._exchangeProxy
+                _calldataHexString = this.exchangeProxy
                     .sellTokenForTokenToUniswapV3(fillData.uniswapPath, sellAmount, minBuyAmount, NULL_ADDRESS)
                     .getABIEncodedTransactionData();
             }
             return {
                 calldataHexString: _calldataHexString,
                 ethAmount: isFromETH ? sellAmount : ZERO_AMOUNT,
-                toAddress: this._exchangeProxy.address,
-                allowanceTarget: this._exchangeProxy.address,
+                toAddress: this.exchangeProxy.address,
+                allowanceTarget: this.exchangeProxy.address,
                 gasOverhead: ZERO_AMOUNT,
             };
         }
@@ -219,7 +218,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
             const source = slippedOrders[0].source;
             const fillData = (slippedOrders[0] as OptimizedMarketBridgeOrder<UniswapV2FillData>).fillData;
             return {
-                calldataHexString: this._exchangeProxy
+                calldataHexString: this.exchangeProxy
                     .sellToPancakeSwap(
                         fillData.tokenAddressPath.map((a, i) => {
                             if (i === 0 && isFromETH) {
@@ -236,8 +235,8 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
                     )
                     .getABIEncodedTransactionData(),
                 ethAmount: isFromETH ? sellAmount : ZERO_AMOUNT,
-                toAddress: this._exchangeProxy.address,
-                allowanceTarget: this._exchangeProxy.address,
+                toAddress: this.exchangeProxy.address,
+                allowanceTarget: this.exchangeProxy.address,
                 gasOverhead: ZERO_AMOUNT,
             };
         }
@@ -252,7 +251,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
         ) {
             const fillData = slippedOrders[0].fillData as CurveFillData;
             return {
-                calldataHexString: this._exchangeProxy
+                calldataHexString: this.exchangeProxy
                     .sellToLiquidityProvider(
                         isFromETH ? ETH_TOKEN_ADDRESS : sellToken,
                         isToETH ? ETH_TOKEN_ADDRESS : buyToken,
@@ -269,8 +268,8 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
                     )
                     .getABIEncodedTransactionData(),
                 ethAmount: isFromETH ? sellAmount : ZERO_AMOUNT,
-                toAddress: this._exchangeProxy.address,
-                allowanceTarget: this._exchangeProxy.address,
+                toAddress: this.exchangeProxy.address,
+                allowanceTarget: this.exchangeProxy.address,
                 gasOverhead: ZERO_AMOUNT,
             };
         }
@@ -298,10 +297,10 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
             })();
             const callData =
                 slippedOrders.length === 1
-                    ? this._exchangeProxy
+                    ? this.exchangeProxy
                           .fillRfqOrder(rfqOrdersData[0].order, rfqOrdersData[0].signature, fillAmountPerOrder[0])
                           .getABIEncodedTransactionData()
-                    : this._exchangeProxy
+                    : this.exchangeProxy
                           .batchFillRfqOrders(
                               rfqOrdersData.map((d) => d.order),
                               rfqOrdersData.map((d) => d.signature),
@@ -312,8 +311,8 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
             return {
                 calldataHexString: callData,
                 ethAmount: ZERO_AMOUNT,
-                toAddress: this._exchangeProxy.address,
-                allowanceTarget: this._exchangeProxy.address,
+                toAddress: this.exchangeProxy.address,
+                allowanceTarget: this.exchangeProxy.address,
                 gasOverhead: ZERO_AMOUNT,
             };
         }
@@ -332,26 +331,26 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
 
             // if the otc orders takerToken is the native asset
             if (isFromETH) {
-                callData = this._exchangeProxy
+                callData = this.exchangeProxy
                     .fillOtcOrderWithEth(otcOrdersData[0].order, otcOrdersData[0].signature)
                     .getABIEncodedTransactionData();
             }
             // if the otc orders makerToken is the native asset
             else if (isToETH) {
-                callData = this._exchangeProxy
+                callData = this.exchangeProxy
                     .fillOtcOrderForEth(otcOrdersData[0].order, otcOrdersData[0].signature, sellAmount)
                     .getABIEncodedTransactionData();
             } else {
                 // if the otc order contains 2 erc20 tokens
-                callData = this._exchangeProxy
+                callData = this.exchangeProxy
                     .fillOtcOrder(otcOrdersData[0].order, otcOrdersData[0].signature, sellAmount)
                     .getABIEncodedTransactionData();
             }
             return {
                 calldataHexString: callData,
                 ethAmount: isFromETH ? sellAmount : ZERO_AMOUNT,
-                toAddress: this._exchangeProxy.address,
-                allowanceTarget: this._exchangeProxy.address,
+                toAddress: this.exchangeProxy.address,
+                allowanceTarget: this.exchangeProxy.address,
                 gasOverhead: ZERO_AMOUNT,
             };
         }
@@ -360,8 +359,8 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
             return {
                 calldataHexString: this._encodeMultiplexBatchFillCalldata(quote, optsWithDefaults),
                 ethAmount,
-                toAddress: this._exchangeProxy.address,
-                allowanceTarget: this._exchangeProxy.address,
+                toAddress: this.exchangeProxy.address,
+                allowanceTarget: this.exchangeProxy.address,
                 gasOverhead: ZERO_AMOUNT,
             };
         }
@@ -370,8 +369,8 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
             return {
                 calldataHexString: this._encodeMultiplexMultiHopFillCalldata(quote, optsWithDefaults),
                 ethAmount,
-                toAddress: this._exchangeProxy.address,
-                allowanceTarget: this._exchangeProxy.address,
+                toAddress: this.exchangeProxy.address,
+                allowanceTarget: this.exchangeProxy.address,
                 gasOverhead: ZERO_AMOUNT,
             };
         }
@@ -532,7 +531,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
             }),
         });
         const TO_ETH_ADDRESS = this.chainId === ChainId.Celo ? this.contractAddresses.etherToken : ETH_TOKEN_ADDRESS;
-        const calldataHexString = this._exchangeProxy
+        const calldataHexString = this.exchangeProxy
             .transformERC20(
                 isFromETH ? ETH_TOKEN_ADDRESS : sellToken,
                 isToETH ? TO_ETH_ADDRESS : buyToken,
@@ -545,8 +544,8 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
         return {
             calldataHexString,
             ethAmount,
-            toAddress: this._exchangeProxy.address,
-            allowanceTarget: this._exchangeProxy.address,
+            toAddress: this.exchangeProxy.address,
+            allowanceTarget: this.exchangeProxy.address,
             gasOverhead,
         };
     }
@@ -637,11 +636,11 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
             }
         }
         if (opts.isFromETH) {
-            return this._exchangeProxy
+            return this.exchangeProxy
                 .multiplexBatchSellEthForToken(quote.makerToken, subcalls, quote.worstCaseQuoteInfo.makerAmount)
                 .getABIEncodedTransactionData();
         } else if (opts.isToETH) {
-            return this._exchangeProxy
+            return this.exchangeProxy
                 .multiplexBatchSellTokenForEth(
                     quote.takerToken,
                     subcalls,
@@ -650,7 +649,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
                 )
                 .getABIEncodedTransactionData();
         } else {
-            return this._exchangeProxy
+            return this.exchangeProxy
                 .multiplexBatchSellTokenForToken(
                     quote.takerToken,
                     quote.makerToken,
@@ -694,11 +693,11 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
             }
         }
         if (opts.isFromETH) {
-            return this._exchangeProxy
+            return this.exchangeProxy
                 .multiplexMultiHopSellEthForToken(tokens, subcalls, quote.worstCaseQuoteInfo.makerAmount)
                 .getABIEncodedTransactionData();
         } else if (opts.isToETH) {
-            return this._exchangeProxy
+            return this.exchangeProxy
                 .multiplexMultiHopSellTokenForEth(
                     tokens,
                     subcalls,
@@ -707,7 +706,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
                 )
                 .getABIEncodedTransactionData();
         } else {
-            return this._exchangeProxy
+            return this.exchangeProxy
                 .multiplexMultiHopSellTokenForToken(
                     tokens,
                     subcalls,

--- a/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
+++ b/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
@@ -116,10 +116,10 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
         };
     }
 
-    public async getCalldataOrThrowAsync(
+    public getCalldataOrThrow(
         quote: MarketBuySwapQuote | MarketSellSwapQuote,
         opts: Partial<SwapQuoteGetOutputOpts> = {},
-    ): Promise<CalldataInfo> {
+    ): CalldataInfo {
         const optsWithDefaults: ExchangeProxyContractOpts = {
             ...constants.DEFAULT_EXCHANGE_PROXY_EXTENSION_CONTRACT_OPTS,
             ...opts.extensionContractOpts,

--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -158,7 +158,7 @@ export interface CalldataInfo {
  * getCalldataOrThrow: Get CalldataInfo to swap for tokens with provided SwapQuote. Throws if invalid SwapQuote is provided.
  */
 export interface SwapQuoteConsumer {
-    getCalldataOrThrowAsync(quote: SwapQuote, opts: Partial<SwapQuoteGetOutputOpts>): Promise<CalldataInfo>;
+    getCalldataOrThrow(quote: SwapQuote, opts: Partial<SwapQuoteGetOutputOpts>): CalldataInfo;
 }
 
 /**

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -712,7 +712,7 @@ export class SwapService implements ISwapService {
             ethAmount: value,
             toAddress: to,
             gasOverhead,
-        } = await this._swapQuoteConsumer.getCalldataOrThrowAsync(swapQuote, opts);
+        } = this._swapQuoteConsumer.getCalldataOrThrow(swapQuote, opts);
 
         const { affiliatedData, decodedUniqueId } = serviceUtils.attributeCallData(data, affiliateAddress);
         return {

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -364,7 +364,7 @@ export class SwapService implements ISwapService {
         } = serviceUtils.getAffiliateFeeAmounts(swapQuote, affiliateFee);
 
         // Grab the encoded version of the swap quote
-        const { to, value, data, decodedUniqueId, gasOverhead } = await this._getSwapQuotePartialTransactionAsync(
+        const { to, value, data, decodedUniqueId, gasOverhead } = this.getSwapQuotePartialTransaction(
             swapQuote,
             isETHSell,
             isETHBuy,
@@ -694,7 +694,7 @@ export class SwapService implements ISwapService {
         return gasEstimate;
     }
 
-    private async _getSwapQuotePartialTransactionAsync(
+    private getSwapQuotePartialTransaction(
         swapQuote: SwapQuote,
         isFromETH: boolean,
         isToETH: boolean,
@@ -702,7 +702,7 @@ export class SwapService implements ISwapService {
         shouldSellEntireBalance: boolean,
         affiliateAddress: string | undefined,
         affiliateFee: AffiliateFeeAmount,
-    ): Promise<SwapQuoteResponsePartialTransaction & { gasOverhead: BigNumber }> {
+    ): SwapQuoteResponsePartialTransaction & { gasOverhead: BigNumber } {
         const opts: Partial<SwapQuoteGetOutputOpts> = {
             extensionContractOpts: { isFromETH, isToETH, isMetaTransaction, shouldSellEntireBalance, affiliateFee },
         };

--- a/test/asset-swapper/exchange_proxy_swap_quote_consumer_test.ts
+++ b/test/asset-swapper/exchange_proxy_swap_quote_consumer_test.ts
@@ -43,7 +43,7 @@ const expect = chai.expect;
 const { NULL_ADDRESS } = constants;
 const { MAX_UINT256, ZERO_AMOUNT } = contractConstants;
 
-describe.only('ExchangeProxySwapQuoteConsumer', () => {
+describe('ExchangeProxySwapQuoteConsumer', () => {
     const CHAIN_ID = 1;
     const TAKER_TOKEN = randomAddress();
     const MAKER_TOKEN = randomAddress();
@@ -77,7 +77,7 @@ describe.only('ExchangeProxySwapQuoteConsumer', () => {
     };
     let consumer: ExchangeProxySwapQuoteConsumer;
 
-    before(async () => {
+    before(() => {
         consumer = new ExchangeProxySwapQuoteConsumer(CHAIN_ID, contractAddresses);
     });
 
@@ -249,9 +249,9 @@ describe.only('ExchangeProxySwapQuoteConsumer', () => {
     }
 
     describe('getCalldataOrThrow()', () => {
-        it('can produce a sell quote', async () => {
+        it('can produce a sell quote', () => {
             const quote = getRandomSellQuote();
-            const callInfo = await consumer.getCalldataOrThrowAsync(quote);
+            const callInfo = consumer.getCalldataOrThrow(quote);
             const callArgs = transformERC20Encoder.decode(callInfo.calldataHexString) as TransformERC20Args;
             expect(callArgs.inputToken).to.eq(TAKER_TOKEN);
             expect(callArgs.outputToken).to.eq(MAKER_TOKEN);
@@ -274,9 +274,9 @@ describe.only('ExchangeProxySwapQuoteConsumer', () => {
             expect(payTakerTransformerData.tokens).to.deep.eq([TAKER_TOKEN, ETH_TOKEN_ADDRESS]);
         });
 
-        it('can produce a buy quote', async () => {
+        it('can produce a buy quote', () => {
             const quote = getRandomBuyQuote();
-            const callInfo = await consumer.getCalldataOrThrowAsync(quote);
+            const callInfo = consumer.getCalldataOrThrow(quote);
             const callArgs = transformERC20Encoder.decode(callInfo.calldataHexString) as TransformERC20Args;
             expect(callArgs.inputToken).to.eq(TAKER_TOKEN);
             expect(callArgs.outputToken).to.eq(MAKER_TOKEN);
@@ -303,17 +303,17 @@ describe.only('ExchangeProxySwapQuoteConsumer', () => {
             expect(payTakerTransformerData.tokens).to.deep.eq([TAKER_TOKEN, ETH_TOKEN_ADDRESS]);
         });
 
-        it('ERC20 -> ERC20 does not have a WETH transformer', async () => {
+        it('ERC20 -> ERC20 does not have a WETH transformer', () => {
             const quote = getRandomSellQuote();
-            const callInfo = await consumer.getCalldataOrThrowAsync(quote);
+            const callInfo = consumer.getCalldataOrThrow(quote);
             const callArgs = transformERC20Encoder.decode(callInfo.calldataHexString) as TransformERC20Args;
             const nonces = callArgs.transformations.map((t) => t.deploymentNonce);
             expect(nonces).to.not.include(TRANSFORMER_NONCES.wethTransformer);
         });
 
-        it('ETH -> ERC20 has a WETH transformer before the fill', async () => {
+        it('ETH -> ERC20 has a WETH transformer before the fill', () => {
             const quote = getRandomSellQuote();
-            const callInfo = await consumer.getCalldataOrThrowAsync(quote, {
+            const callInfo = consumer.getCalldataOrThrow(quote, {
                 extensionContractOpts: { isFromETH: true },
             });
             const callArgs = transformERC20Encoder.decode(callInfo.calldataHexString) as TransformERC20Args;
@@ -323,9 +323,9 @@ describe.only('ExchangeProxySwapQuoteConsumer', () => {
             expect(wethTransformerData.token).to.eq(ETH_TOKEN_ADDRESS);
         });
 
-        it('ERC20 -> ETH has a WETH transformer after the fill', async () => {
+        it('ERC20 -> ETH has a WETH transformer after the fill', () => {
             const quote = getRandomSellQuote();
-            const callInfo = await consumer.getCalldataOrThrowAsync(quote, {
+            const callInfo = consumer.getCalldataOrThrow(quote, {
                 extensionContractOpts: { isToETH: true },
             });
             const callArgs = transformERC20Encoder.decode(callInfo.calldataHexString) as TransformERC20Args;
@@ -334,7 +334,7 @@ describe.only('ExchangeProxySwapQuoteConsumer', () => {
             expect(wethTransformerData.amount).to.bignumber.eq(MAX_UINT256);
             expect(wethTransformerData.token).to.eq(contractAddresses.etherToken);
         });
-        it('Appends an affiliate fee transformer after the fill if a buy token affiliate fee is provided', async () => {
+        it('Appends an affiliate fee transformer after the fill if a buy token affiliate fee is provided', () => {
             const quote = getRandomSellQuote();
             const affiliateFee = {
                 recipient: randomAddress(),
@@ -342,7 +342,7 @@ describe.only('ExchangeProxySwapQuoteConsumer', () => {
                 sellTokenFeeAmount: ZERO_AMOUNT,
                 feeType: AffiliateFeeType.PercentageFee,
             };
-            const callInfo = await consumer.getCalldataOrThrowAsync(quote, {
+            const callInfo = consumer.getCalldataOrThrow(quote, {
                 extensionContractOpts: { affiliateFee },
             });
             const callArgs = transformERC20Encoder.decode(callInfo.calldataHexString) as TransformERC20Args;
@@ -354,7 +354,7 @@ describe.only('ExchangeProxySwapQuoteConsumer', () => {
                 { token: MAKER_TOKEN, amount: affiliateFee.buyTokenFeeAmount, recipient: affiliateFee.recipient },
             ]);
         });
-        it('Appends an affiliate fee transformer if conversion to native token is known', async () => {
+        it('Appends an affiliate fee transformer if conversion to native token is known', () => {
             const quote = getRandomSellQuote();
             quote.takerAmountPerEth = new BigNumber(0.5);
             const affiliateFee = {
@@ -363,7 +363,7 @@ describe.only('ExchangeProxySwapQuoteConsumer', () => {
                 sellTokenFeeAmount: ZERO,
                 feeType: AffiliateFeeType.GaslessFee,
             };
-            const callInfo = await consumer.getCalldataOrThrowAsync(quote, {
+            const callInfo = consumer.getCalldataOrThrow(quote, {
                 extensionContractOpts: { affiliateFee },
             });
             const callArgs = transformERC20Encoder.decode(callInfo.calldataHexString) as TransformERC20Args;
@@ -375,7 +375,7 @@ describe.only('ExchangeProxySwapQuoteConsumer', () => {
                 { token: MAKER_TOKEN, amount: affiliateFee.buyTokenFeeAmount, recipient: affiliateFee.recipient },
             ]);
         });
-        it('Appends an affiliate fee transformer if conversion to native token is unknown of 0.1%', async () => {
+        it('Appends an affiliate fee transformer if conversion to native token is unknown of 0.1%', () => {
             const quote = getRandomSellQuote();
             quote.takerAmountPerEth = new BigNumber(0);
             const affiliateFee = {
@@ -384,7 +384,7 @@ describe.only('ExchangeProxySwapQuoteConsumer', () => {
                 sellTokenFeeAmount: ZERO,
                 feeType: AffiliateFeeType.GaslessFee,
             };
-            const callInfo = await consumer.getCalldataOrThrowAsync(quote, {
+            const callInfo = consumer.getCalldataOrThrow(quote, {
                 extensionContractOpts: { affiliateFee },
             });
             const callArgs = transformERC20Encoder.decode(callInfo.calldataHexString) as TransformERC20Args;
@@ -396,7 +396,7 @@ describe.only('ExchangeProxySwapQuoteConsumer', () => {
                 { token: MAKER_TOKEN, amount: affiliateFee.buyTokenFeeAmount, recipient: affiliateFee.recipient },
             ]);
         });
-        it('Appends a positive slippage affiliate fee transformer after the fill if the positive slippage fee feeType is specified', async () => {
+        it('Appends a positive slippage affiliate fee transformer after the fill if the positive slippage fee feeType is specified', () => {
             const quote = getRandomSellQuote();
             const affiliateFee = {
                 recipient: randomAddress(),
@@ -404,7 +404,7 @@ describe.only('ExchangeProxySwapQuoteConsumer', () => {
                 sellTokenFeeAmount: ZERO_AMOUNT,
                 feeType: AffiliateFeeType.PositiveSlippageFee,
             };
-            const callInfo = await consumer.getCalldataOrThrowAsync(quote, {
+            const callInfo = consumer.getCalldataOrThrow(quote, {
                 extensionContractOpts: { affiliateFee },
             });
             const callArgs = transformERC20Encoder.decode(callInfo.calldataHexString) as TransformERC20Args;
@@ -425,7 +425,7 @@ describe.only('ExchangeProxySwapQuoteConsumer', () => {
                 recipient: affiliateFee.recipient,
             });
         });
-        it('Throws if a sell token affiliate fee is provided', async () => {
+        it('Throws if a sell token affiliate fee is provided', () => {
             const quote = getRandomSellQuote();
             const affiliateFee = {
                 recipient: randomAddress(),
@@ -433,15 +433,15 @@ describe.only('ExchangeProxySwapQuoteConsumer', () => {
                 sellTokenFeeAmount: getRandomAmount(),
                 feeType: AffiliateFeeType.PercentageFee,
             };
-            expect(
-                consumer.getCalldataOrThrowAsync(quote, {
+            expect(() =>
+                consumer.getCalldataOrThrow(quote, {
                     extensionContractOpts: { affiliateFee },
                 }),
-            ).to.eventually.be.rejectedWith('Affiliate fees denominated in sell token are not yet supported');
+            ).to.throw('Affiliate fees denominated in sell token are not yet supported');
         });
-        it('Uses two `FillQuoteTransformer`s if given two-hop sell quote', async () => {
+        it('Uses two `FillQuoteTransformer`s if given two-hop sell quote', () => {
             const quote = getRandomTwoHopQuote(MarketOperation.Sell) as MarketSellSwapQuote;
-            const callInfo = await consumer.getCalldataOrThrowAsync(quote);
+            const callInfo = consumer.getCalldataOrThrow(quote);
             const callArgs = transformERC20Encoder.decode(callInfo.calldataHexString) as TransformERC20Args;
             expect(callArgs.inputToken).to.eq(TAKER_TOKEN);
             expect(callArgs.outputToken).to.eq(MAKER_TOKEN);
@@ -475,9 +475,9 @@ describe.only('ExchangeProxySwapQuoteConsumer', () => {
             expect(payTakerTransformerData.tokens).to.deep.eq([TAKER_TOKEN, INTERMEDIATE_TOKEN, ETH_TOKEN_ADDRESS]);
         });
 
-        it('allows selling the entire balance for CFL', async () => {
+        it('allows selling the entire balance for CFL', () => {
             const quote = getRandomSellQuote();
-            const callInfo = await consumer.getCalldataOrThrowAsync(quote, {
+            const callInfo = consumer.getCalldataOrThrow(quote, {
                 extensionContractOpts: { shouldSellEntireBalance: true },
             });
             const callArgs = transformERC20Encoder.decode(callInfo.calldataHexString) as TransformERC20Args;


### PR DESCRIPTION
# Description

A few minor clean up related to `SwapQuoteConsumer`.
* Make `transformerNonces` private
* Make `SwapQuoteConsumer.getCalldataOrThrowAsync` not `async`
* Make `SwapService._getSwapQuotePartialTransactionAsync` not `async`



# Testing & Simbot Run

* Updated unit tests

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
