### PR TITLE
chore: Do not use `MultiplexFeature` on multiple two hop orders [LIT-637]

### DIFF
--- a/src/asset-swapper/constants.ts
+++ b/src/asset-swapper/constants.ts
@@ -9,7 +9,6 @@ import {
     OrderPrunerOpts,
     OrderPrunerPermittedFeeTypes,
     RfqRequestOpts,
-    SwapQuoteGetOutputOpts,
     SwapQuoteRequestOpts,
     SwapQuoterOpts,
 } from './types';
@@ -70,10 +69,6 @@ const DEFAULT_EXCHANGE_PROXY_EXTENSION_CONTRACT_OPTS: ExchangeProxyContractOpts 
     shouldSellEntireBalance: false,
 };
 
-const DEFAULT_EXCHANGE_PROXY_SWAP_QUOTE_GET_OPTS: SwapQuoteGetOutputOpts = {
-    extensionContractOpts: DEFAULT_EXCHANGE_PROXY_EXTENSION_CONTRACT_OPTS,
-};
-
 const DEFAULT_SWAP_QUOTE_REQUEST_OPTS: SwapQuoteRequestOpts = {
     ...DEFAULT_GET_MARKET_ORDERS_OPTS,
 };
@@ -108,7 +103,6 @@ export const constants = {
     DEFAULT_SWAP_QUOTER_OPTS,
     DEFAULT_INTERMEDIATE_TOKENS_BY_CHAIN_ID,
     DEFAULT_SWAP_QUOTE_REQUEST_OPTS,
-    DEFAULT_EXCHANGE_PROXY_SWAP_QUOTE_GET_OPTS,
     DEFAULT_EXCHANGE_PROXY_EXTENSION_CONTRACT_OPTS,
     DEFAULT_PER_PAGE,
     DEFAULT_RFQT_REQUEST_OPTS,

--- a/src/asset-swapper/index.ts
+++ b/src/asset-swapper/index.ts
@@ -29,7 +29,6 @@ export {
     SignedNativeOrder,
     SwapQuote,
     SwapQuoteConsumer,
-    SwapQuoteGetOutputOpts,
     SwapQuoteSourceBreakdown,
     SwapQuoteRequestOpts,
     SwapQuoterError,

--- a/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
+++ b/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
@@ -23,7 +23,6 @@ import {
     MarketSellSwapQuote,
     SwapQuote,
     SwapQuoteConsumer,
-    SwapQuoteGetOutputOpts,
 } from '../types';
 import { assert } from '../utils/utils';
 import {
@@ -118,11 +117,11 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
 
     public getCalldataOrThrow(
         quote: MarketBuySwapQuote | MarketSellSwapQuote,
-        opts: Partial<SwapQuoteGetOutputOpts> = {},
+        opts: Partial<ExchangeProxyContractOpts> = {},
     ): CalldataInfo {
         const optsWithDefaults: ExchangeProxyContractOpts = {
             ...constants.DEFAULT_EXCHANGE_PROXY_EXTENSION_CONTRACT_OPTS,
-            ...opts.extensionContractOpts,
+            ...opts,
         };
         const { refundReceiver, affiliateFee, isFromETH, isToETH, shouldSellEntireBalance } = optsWithDefaults;
 

--- a/src/asset-swapper/quote_consumers/quote_consumer_utils.ts
+++ b/src/asset-swapper/quote_consumers/quote_consumer_utils.ts
@@ -56,16 +56,25 @@ const MULTIPLEX_MULTIHOP_FILL_SOURCES = [
 ];
 
 /**
- * Returns true iff a quote can be filled via `MultiplexFeature.multiHopFill`.
+ * Returns true if a path can be filled via `MultiplexFeature.multiplexMultiHop*`.
  */
-export function isMultiplexMultiHopFillCompatible(quote: SwapQuote, opts: ExchangeProxyContractOpts): boolean {
+export function isMultiplexMultiHopFillCompatible(path: IPath, opts: ExchangeProxyContractOpts): boolean {
     if (requiresTransformERC20(opts)) {
         return false;
     }
-    if (!quote.path.hasTwoHop()) {
+    const { bridgeOrders, nativeOrders, twoHopOrders } = path.getOrdersByType();
+
+    // Path shouldn't have any other type of order.
+    if (bridgeOrders.length !== 0 || nativeOrders.length !== 0) {
         return false;
     }
-    const [firstHopOrder, secondHopOrder] = quote.path.getOrders();
+
+    // MultiplexFeature only supports single two hop order.
+    if (twoHopOrders.length !== 1) {
+        return false;
+    }
+
+    const { firstHopOrder, secondHopOrder } = twoHopOrders[0];
     return (
         MULTIPLEX_MULTIHOP_FILL_SOURCES.includes(firstHopOrder.source) &&
         MULTIPLEX_MULTIHOP_FILL_SOURCES.includes(secondHopOrder.source)

--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -194,9 +194,10 @@ enum ExchangeProxyRefundReceiver {
  *        `address(0)`: Stay in flash wallet.
  *        `address(1)`: Send to the taker.
  *        `address(2)`: Send to the sender (caller of `transformERC20()`).
+ * @param isMetaTransaction Whether the swap is for meta transaction.
  * @param shouldSellEntireBalance Whether the entire balance of the caller should be sold. Used
  *        for contracts where the balance at transaction time is different to the quote amount.
- *        This foregos certain VIP routes which do not support this feature.
+ *        This forgoes certain VIP routes which do not support this feature.
  */
 export interface ExchangeProxyContractOpts {
     isFromETH: boolean;
@@ -212,6 +213,7 @@ export interface IPath {
     getOrdersByType(): OptimizedOrdersByType;
     getOrders(): readonly OptimizedOrder[];
     getSlippedOrders(maxSlippage: number): OptimizedOrder[];
+    getSlippedOrdersByType(maxSlippage: number): OptimizedOrdersByType;
 }
 
 /**

--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -158,15 +158,7 @@ export interface CalldataInfo {
  * getCalldataOrThrow: Get CalldataInfo to swap for tokens with provided SwapQuote. Throws if invalid SwapQuote is provided.
  */
 export interface SwapQuoteConsumer {
-    getCalldataOrThrow(quote: SwapQuote, opts: Partial<SwapQuoteGetOutputOpts>): CalldataInfo;
-}
-
-/**
- * Represents the options provided to a generic SwapQuoteConsumer
- */
-export interface SwapQuoteGetOutputOpts {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: fix me!
-    extensionContractOpts?: ExchangeProxyContractOpts | any;
+    getCalldataOrThrow(quote: SwapQuote, opts: Partial<ExchangeProxyContractOpts>): CalldataInfo;
 }
 
 export enum AffiliateFeeType {

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -26,13 +26,13 @@ import {
     RfqFirmQuoteValidator,
     SwapQuote,
     SwapQuoteConsumer,
-    SwapQuoteGetOutputOpts,
     SwapQuoter,
     SwapQuoteRequestOpts,
     SwapQuoterOpts,
     ZERO_AMOUNT,
 } from '../asset-swapper';
 import { ExchangeProxySwapQuoteConsumer } from '../asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer';
+import { ExchangeProxyContractOpts } from '../asset-swapper/types';
 import {
     ALT_RFQ_MM_API_KEY,
     ALT_RFQ_MM_ENDPOINT,
@@ -703,8 +703,12 @@ export class SwapService implements ISwapService {
         affiliateAddress: string | undefined,
         affiliateFee: AffiliateFeeAmount,
     ): SwapQuoteResponsePartialTransaction & { gasOverhead: BigNumber } {
-        const opts: Partial<SwapQuoteGetOutputOpts> = {
-            extensionContractOpts: { isFromETH, isToETH, isMetaTransaction, shouldSellEntireBalance, affiliateFee },
+        const opts: Partial<ExchangeProxyContractOpts> = {
+            isFromETH,
+            isToETH,
+            isMetaTransaction,
+            shouldSellEntireBalance,
+            affiliateFee,
         };
 
         const {

--- a/test/asset-swapper/exchange_proxy_swap_quote_consumer_test.ts
+++ b/test/asset-swapper/exchange_proxy_swap_quote_consumer_test.ts
@@ -313,9 +313,7 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
 
         it('ETH -> ERC20 has a WETH transformer before the fill', () => {
             const quote = getRandomSellQuote();
-            const callInfo = consumer.getCalldataOrThrow(quote, {
-                extensionContractOpts: { isFromETH: true },
-            });
+            const callInfo = consumer.getCalldataOrThrow(quote, { isFromETH: true });
             const callArgs = transformERC20Encoder.decode(callInfo.calldataHexString) as TransformERC20Args;
             expect(callArgs.transformations[0].deploymentNonce.toNumber()).to.eq(TRANSFORMER_NONCES.wethTransformer);
             const wethTransformerData = decodeWethTransformerData(callArgs.transformations[0].data);
@@ -325,9 +323,7 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
 
         it('ERC20 -> ETH has a WETH transformer after the fill', () => {
             const quote = getRandomSellQuote();
-            const callInfo = consumer.getCalldataOrThrow(quote, {
-                extensionContractOpts: { isToETH: true },
-            });
+            const callInfo = consumer.getCalldataOrThrow(quote, { isToETH: true });
             const callArgs = transformERC20Encoder.decode(callInfo.calldataHexString) as TransformERC20Args;
             expect(callArgs.transformations[1].deploymentNonce.toNumber()).to.eq(TRANSFORMER_NONCES.wethTransformer);
             const wethTransformerData = decodeWethTransformerData(callArgs.transformations[1].data);
@@ -342,9 +338,7 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
                 sellTokenFeeAmount: ZERO_AMOUNT,
                 feeType: AffiliateFeeType.PercentageFee,
             };
-            const callInfo = consumer.getCalldataOrThrow(quote, {
-                extensionContractOpts: { affiliateFee },
-            });
+            const callInfo = consumer.getCalldataOrThrow(quote, { affiliateFee });
             const callArgs = transformERC20Encoder.decode(callInfo.calldataHexString) as TransformERC20Args;
             expect(callArgs.transformations[1].deploymentNonce.toNumber()).to.eq(
                 TRANSFORMER_NONCES.affiliateFeeTransformer,
@@ -363,9 +357,7 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
                 sellTokenFeeAmount: ZERO,
                 feeType: AffiliateFeeType.GaslessFee,
             };
-            const callInfo = consumer.getCalldataOrThrow(quote, {
-                extensionContractOpts: { affiliateFee },
-            });
+            const callInfo = consumer.getCalldataOrThrow(quote, { affiliateFee });
             const callArgs = transformERC20Encoder.decode(callInfo.calldataHexString) as TransformERC20Args;
             expect(callArgs.transformations[1].deploymentNonce.toNumber()).to.eq(
                 TRANSFORMER_NONCES.affiliateFeeTransformer,
@@ -384,9 +376,7 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
                 sellTokenFeeAmount: ZERO,
                 feeType: AffiliateFeeType.GaslessFee,
             };
-            const callInfo = consumer.getCalldataOrThrow(quote, {
-                extensionContractOpts: { affiliateFee },
-            });
+            const callInfo = consumer.getCalldataOrThrow(quote, { affiliateFee });
             const callArgs = transformERC20Encoder.decode(callInfo.calldataHexString) as TransformERC20Args;
             expect(callArgs.transformations[1].deploymentNonce.toNumber()).to.eq(
                 TRANSFORMER_NONCES.affiliateFeeTransformer,
@@ -404,9 +394,7 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
                 sellTokenFeeAmount: ZERO_AMOUNT,
                 feeType: AffiliateFeeType.PositiveSlippageFee,
             };
-            const callInfo = consumer.getCalldataOrThrow(quote, {
-                extensionContractOpts: { affiliateFee },
-            });
+            const callInfo = consumer.getCalldataOrThrow(quote, { affiliateFee });
             const callArgs = transformERC20Encoder.decode(callInfo.calldataHexString) as TransformERC20Args;
             expect(callArgs.transformations[1].deploymentNonce.toNumber()).to.eq(
                 TRANSFORMER_NONCES.positiveSlippageFeeTransformer,
@@ -433,11 +421,9 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
                 sellTokenFeeAmount: getRandomAmount(),
                 feeType: AffiliateFeeType.PercentageFee,
             };
-            expect(() =>
-                consumer.getCalldataOrThrow(quote, {
-                    extensionContractOpts: { affiliateFee },
-                }),
-            ).to.throw('Affiliate fees denominated in sell token are not yet supported');
+            expect(() => consumer.getCalldataOrThrow(quote, { affiliateFee })).to.throw(
+                'Affiliate fees denominated in sell token are not yet supported',
+            );
         });
         it('Uses two `FillQuoteTransformer`s if given two-hop sell quote', () => {
             const quote = getRandomTwoHopQuote(MarketOperation.Sell) as MarketSellSwapQuote;
@@ -477,9 +463,7 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
 
         it('allows selling the entire balance for CFL', () => {
             const quote = getRandomSellQuote();
-            const callInfo = consumer.getCalldataOrThrow(quote, {
-                extensionContractOpts: { shouldSellEntireBalance: true },
-            });
+            const callInfo = consumer.getCalldataOrThrow(quote, { shouldSellEntireBalance: true });
             const callArgs = transformERC20Encoder.decode(callInfo.calldataHexString) as TransformERC20Args;
             expect(callArgs.inputToken).to.eq(TAKER_TOKEN);
             expect(callArgs.outputToken).to.eq(MAKER_TOKEN);

--- a/test/asset-swapper/utils/market_operations_utils/quote_info_test.ts
+++ b/test/asset-swapper/utils/market_operations_utils/quote_info_test.ts
@@ -329,5 +329,8 @@ function createFakePath(params: { ordersByType: OptimizedOrdersByType }): IPath 
         hasTwoHop: () => false,
         getOrders: () => [],
         getSlippedOrders: () => [],
+        getSlippedOrdersByType: () => {
+            throw new Error('Unimplemented');
+        },
     };
 }


### PR DESCRIPTION
# Description

`MultiplexFeature`'s multihop logic assumed that there can be only single two hop order. As that may not be the case in the future modify the compatibility checking and encoding logic to account for multiple two hop orders.

# Testing & Simbot Run

* Passes existing unit test

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
