### PR TITLE
fix: incorrect UniswapV3 buy sampler pool path order [LIT-765]

### DIFF
--- a/contracts/src/UniswapV3Sampler.sol
+++ b/contracts/src/UniswapV3Sampler.sol
@@ -174,7 +174,7 @@ contract UniswapV3Sampler {
                 }
 
                 // quoter requires path to be reversed for buys.
-                bytes memory uniswapPath = _toUniswapPath(reversedPath, _reversePoolPath(poolPaths[j]));
+                bytes memory uniswapPath = _toUniswapPath(reversedPath, poolPaths[j]);
                 try quoter.quoteExactOutput{gas: QUOTE_GAS}(uniswapPath, makerTokenAmounts[i]) returns (
                     uint256 sellAmount,
                     uint160[] memory /* sqrtPriceX96AfterList */,
@@ -184,7 +184,7 @@ contract UniswapV3Sampler {
                     if (topSellAmount == 0 || topSellAmount >= sellAmount) {
                         topSellAmount = sellAmount;
                         // But the output path should still be encoded for sells.
-                        uniswapPaths[i] = _toUniswapPath(path, poolPaths[j]);
+                        uniswapPaths[i] = _toUniswapPath(path, _reversePoolPath(poolPaths[j]));
                         uniswapGasUsed[i] = gasUsed;
                     }
                 } catch {}


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
-->

# Description
Updating the UniswapV3 buy sampler to have the correct pool path order. Previously, the pool path seems to have been reversed resulting in incorrect fees being chosen when building a UniswapV3 buy path. This PR adjusts the pool path to have the correct order

<!--- Describe your changes in detail -->

# Testing & Simbot Run
[Mainnet](https://metabase.spaceship.0x.org/dashboard/186?run_id=UniswapV3-buy-sampler-reverse-fix-p3&adjusted_amount_bought_win_tolerance__bps_=1.0)


<!--- If your changes affect `swap` API (e.g. adding a new liquidity source, changes sampling or routing logic) include a link to Simbot run(s). -->

# Checklist

-   [ ] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [ ] Add tests to cover changes as needed.
-   [ ] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
