### PR TITLE
fix: Add missing Arbitrum token adjacency graph [LIT-767]

### DIFF
--- a/src/asset-swapper/utils/market_operation_utils/constants.ts
+++ b/src/asset-swapper/utils/market_operation_utils/constants.ts
@@ -1082,6 +1082,9 @@ export const DEFAULT_TOKEN_ADJACENCY_GRAPH_BY_CHAIN_ID = valueByChainId<TokenAdj
             DEFAULT_INTERMEDIATE_TOKENS_BY_CHAIN_ID[ChainId.Fantom],
         ).build(),
         [ChainId.Celo]: new TokenAdjacencyGraphBuilder(DEFAULT_INTERMEDIATE_TOKENS_BY_CHAIN_ID[ChainId.Celo]).build(),
+        [ChainId.Arbitrum]: new TokenAdjacencyGraphBuilder(
+            DEFAULT_INTERMEDIATE_TOKENS_BY_CHAIN_ID[ChainId.Arbitrum],
+        ).build(),
         [ChainId.Optimism]: new TokenAdjacencyGraphBuilder(DEFAULT_INTERMEDIATE_TOKENS_BY_CHAIN_ID[ChainId.Optimism])
             .tap((builder) => {
                 // Synthetix Atomic Swap


### PR DESCRIPTION
# Description

Arbitrum token adjacency graph was not previously defined. 

# Testing & Simbot Run

* [sanity simbot run](https://metabase.spaceship.0x.org/dashboard/186?run_id=kyu-arb-usds-fix)

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
