### PR TITLE
refactor: Simplify `ExchangeProxySwapQuoteConsumer` constructor [LIT-760]

### DIFF
--- a/src/asset-swapper/quote_consumers/quote_consumer_utils.ts
+++ b/src/asset-swapper/quote_consumers/quote_consumer_utils.ts
@@ -1,4 +1,6 @@
-import { FillQuoteTransformerData, FillQuoteTransformerOrderType } from '@0x/protocol-utils';
+import { ContractAddresses } from '@0x/contract-addresses';
+import { IZeroExContract } from '@0x/contract-wrappers';
+import { FillQuoteTransformerData, FillQuoteTransformerOrderType, findTransformerNonce } from '@0x/protocol-utils';
 
 import {
     ExchangeProxyContractOpts,
@@ -17,6 +19,7 @@ import {
     createBridgeDataForBridgeOrder,
     getErc20BridgeSourceToBridgeSource,
 } from '../utils/market_operation_utils/orders';
+import { TransformerNonces } from './types';
 
 const MULTIPLEX_BATCH_FILL_SOURCES = [
     ERC20BridgeSource.UniswapV2,
@@ -24,6 +27,15 @@ const MULTIPLEX_BATCH_FILL_SOURCES = [
     ERC20BridgeSource.Native,
     ERC20BridgeSource.UniswapV3,
 ];
+
+export function createExchangeProxyWithoutProvider(exchangeProxyAddress: string): IZeroExContract {
+    const fakeProvider = {
+        sendAsync(): void {
+            return;
+        },
+    };
+    return new IZeroExContract(exchangeProxyAddress, fakeProvider);
+}
 
 /**
  * Returns true iff a quote can be filled via `MultiplexFeature.batchFill`.
@@ -183,7 +195,7 @@ export function getFQTTransformerDataFromOptimizedOrders(
 }
 
 /**
- * Returns true if swap quote must go through `tranformERC20`.
+ * Returns true if swap quote must go through `transformERC20`.
  */
 export function requiresTransformERC20(opts: ExchangeProxyContractOpts): boolean {
     // Is a mtx.
@@ -199,4 +211,29 @@ export function requiresTransformERC20(opts: ExchangeProxyContractOpts): boolean
         return true;
     }
     return false;
+}
+
+export function getTransformerNonces(contractAddresses: ContractAddresses): TransformerNonces {
+    return {
+        wethTransformer: findTransformerNonce(
+            contractAddresses.transformers.wethTransformer,
+            contractAddresses.exchangeProxyTransformerDeployer,
+        ),
+        payTakerTransformer: findTransformerNonce(
+            contractAddresses.transformers.payTakerTransformer,
+            contractAddresses.exchangeProxyTransformerDeployer,
+        ),
+        fillQuoteTransformer: findTransformerNonce(
+            contractAddresses.transformers.fillQuoteTransformer,
+            contractAddresses.exchangeProxyTransformerDeployer,
+        ),
+        affiliateFeeTransformer: findTransformerNonce(
+            contractAddresses.transformers.affiliateFeeTransformer,
+            contractAddresses.exchangeProxyTransformerDeployer,
+        ),
+        positiveSlippageFeeTransformer: findTransformerNonce(
+            contractAddresses.transformers.positiveSlippageFeeTransformer,
+            contractAddresses.exchangeProxyTransformerDeployer,
+        ),
+    };
 }

--- a/src/asset-swapper/quote_consumers/types.ts
+++ b/src/asset-swapper/quote_consumers/types.ts
@@ -1,0 +1,7 @@
+export interface TransformerNonces {
+    wethTransformer: number;
+    payTakerTransformer: number;
+    fillQuoteTransformer: number;
+    affiliateFeeTransformer: number;
+    positiveSlippageFeeTransformer: number;
+}

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -231,7 +231,7 @@ export class SwapService implements ISwapService {
         }
         this._swapQuoter = new SwapQuoter(this._provider, orderbook, this._swapQuoterOpts);
 
-        this._swapQuoteConsumer = ExchangeProxySwapQuoteConsumer.create(CHAIN_ID);
+        this._swapQuoteConsumer = ExchangeProxySwapQuoteConsumer.create(CHAIN_ID, contractAddresses);
         this._web3Wrapper = new Web3Wrapper(this._provider);
 
         this._contractAddresses = contractAddresses;

--- a/test/asset-swapper/exchange_proxy_swap_quote_consumer_test.ts
+++ b/test/asset-swapper/exchange_proxy_swap_quote_consumer_test.ts
@@ -78,7 +78,7 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
     let consumer: ExchangeProxySwapQuoteConsumer;
 
     before(() => {
-        consumer = new ExchangeProxySwapQuoteConsumer(CHAIN_ID, contractAddresses);
+        consumer = ExchangeProxySwapQuoteConsumer.create(CHAIN_ID, contractAddresses);
     });
 
     function getRandomOrder(orderFields?: Partial<LimitOrderFields>): LimitOrderFields {


### PR DESCRIPTION
# Description
Simplify `ExchangeProxySwapQuoteConsumer` constructor
* Move dependency creations logic to the static factory method

# Testing & Simbot Run

* Updated unit test to use the static factory method.

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
