### PR TITLE
refactor: Introduce `FeatureRule` and move `TransformERC20` calldata generation logic into a rule [LIT-760]

### DIFF
--- a/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
+++ b/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
@@ -47,6 +47,7 @@ import {
 import {
     createExchangeProxyWithoutProvider,
     getFQTTransformerDataFromOptimizedOrders,
+    getMaxQuoteSlippageRate,
     getTransformerNonces,
     isBuyQuote,
     isDirectSwapCompatible,
@@ -695,8 +696,4 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
                 .getABIEncodedTransactionData();
         }
     }
-}
-
-function getMaxQuoteSlippageRate(quote: MarketBuySwapQuote | MarketSellSwapQuote): number {
-    return quote.worstCaseQuoteInfo.slippage;
 }

--- a/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
+++ b/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
@@ -1,21 +1,17 @@
 import { ChainId, ContractAddresses } from '@0x/contract-addresses';
 import { IZeroExContract } from '@0x/contract-wrappers';
 import {
-    encodeAffiliateFeeTransformerData,
     encodeCurveLiquidityProviderData,
     encodeFillQuoteTransformerData,
     encodePayTakerTransformerData,
-    encodePositiveSlippageFeeTransformerData,
-    encodeWethTransformerData,
     ETH_TOKEN_ADDRESS,
     FillQuoteTransformerOrderType,
     FillQuoteTransformerSide,
 } from '@0x/protocol-utils';
 import { BigNumber } from '@0x/utils';
 
-import { constants, POSITIVE_SLIPPAGE_FEE_TRANSFORMER_GAS } from '../constants';
+import { constants } from '../constants';
 import {
-    AffiliateFeeType,
     CalldataInfo,
     ExchangeProxyContractOpts,
     MarketBuySwapQuote,
@@ -49,19 +45,14 @@ import {
     getFQTTransformerDataFromOptimizedOrders,
     getMaxQuoteSlippageRate,
     getTransformerNonces,
-    isBuyQuote,
     isDirectSwapCompatible,
     isMultiplexBatchFillCompatible,
     isMultiplexMultiHopFillCompatible,
     requiresTransformERC20,
 } from './quote_consumer_utils';
 import { TransformerNonces } from './types';
-
-// Transformation of `TransformERC20` feature.
-interface ERC20Transformation {
-    deploymentNonce: number;
-    data: string;
-}
+import { FeatureRuleRegistryImpl } from './feature_rules/feature_rule_registry';
+import { FeatureRuleRegistry } from './feature_rules/types';
 
 const MAX_UINT256 = new BigNumber(2).pow(256).minus(1);
 const { NULL_ADDRESS, ZERO_AMOUNT } = constants;
@@ -79,14 +70,16 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
     public static create(chainId: ChainId, contractAddresses: ContractAddresses): ExchangeProxySwapQuoteConsumer {
         const exchangeProxy = createExchangeProxyWithoutProvider(contractAddresses.exchangeProxy);
         const transformerNonces = getTransformerNonces(contractAddresses);
-        return new ExchangeProxySwapQuoteConsumer(chainId, contractAddresses, exchangeProxy, transformerNonces);
+        // NOTES: consider injecting registry instead of relying on FeatureRuleRegistryImpl.
+        const featureRuleRegistry = FeatureRuleRegistryImpl.create(chainId, contractAddresses);
+        return new ExchangeProxySwapQuoteConsumer(chainId, exchangeProxy, transformerNonces, featureRuleRegistry);
     }
 
     private constructor(
         private readonly chainId: ChainId,
-        private readonly contractAddresses: ContractAddresses,
         private readonly exchangeProxy: IZeroExContract,
         private readonly transformerNonces: TransformerNonces,
+        private readonly featureRuleRegistry: FeatureRuleRegistry,
     ) {}
 
     public getCalldataOrThrow(
@@ -97,7 +90,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
             ...constants.DEFAULT_EXCHANGE_PROXY_EXTENSION_CONTRACT_OPTS,
             ...opts,
         };
-        const { refundReceiver, affiliateFee, isFromETH, isToETH, shouldSellEntireBalance } = optsWithDefaults;
+        const { isFromETH, isToETH } = optsWithDefaults;
 
         const sellToken = quote.takerToken;
         const buyToken = quote.makerToken;
@@ -106,7 +99,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
             quote.bestCaseQuoteInfo.totalTakerAmount,
             quote.worstCaseQuoteInfo.totalTakerAmount,
         );
-        let minBuyAmount = quote.worstCaseQuoteInfo.makerAmount;
+        const minBuyAmount = quote.worstCaseQuoteInfo.makerAmount;
         let ethAmount = quote.worstCaseQuoteInfo.protocolFeeInWeiAmount;
 
         if (isFromETH) {
@@ -348,179 +341,9 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
             };
         }
 
-        // Build up the transformations.
-        const transformations = [] as ERC20Transformation[];
-        // Create a WETH wrapper if coming from ETH.
-        // Don't add the wethTransformer to CELO. There is no wrap/unwrap logic for CELO.
-        if (isFromETH && this.chainId !== ChainId.Celo) {
-            transformations.push({
-                deploymentNonce: this.transformerNonces.wethTransformer,
-                data: encodeWethTransformerData({
-                    token: ETH_TOKEN_ADDRESS,
-                    amount: shouldSellEntireBalance ? MAX_UINT256 : sellAmount,
-                }),
-            });
-        }
+        // TODO(kyu-c): move the rest of the feature calldata generation logic to the rule/registry.
 
-        // If it's two hop we have an intermediate token this is needed to encode the individual FQT
-        // and we also want to ensure no dust amount is left in the flash wallet
-        const intermediateToken = quote.path.hasTwoHop() ? slippedOrders[0].makerToken : NULL_ADDRESS;
-        // This transformer will fill the quote.
-        if (quote.path.hasTwoHop()) {
-            const [firstHopOrder, secondHopOrder] = slippedOrders;
-            transformations.push({
-                deploymentNonce: this.transformerNonces.fillQuoteTransformer,
-                data: encodeFillQuoteTransformerData({
-                    side: FillQuoteTransformerSide.Sell,
-                    sellToken,
-                    buyToken: intermediateToken,
-                    ...getFQTTransformerDataFromOptimizedOrders([firstHopOrder]),
-                    refundReceiver: refundReceiver || NULL_ADDRESS,
-                    fillAmount: shouldSellEntireBalance ? MAX_UINT256 : firstHopOrder.takerAmount,
-                }),
-            });
-            transformations.push({
-                deploymentNonce: this.transformerNonces.fillQuoteTransformer,
-                data: encodeFillQuoteTransformerData({
-                    side: FillQuoteTransformerSide.Sell,
-                    buyToken,
-                    sellToken: intermediateToken,
-                    ...getFQTTransformerDataFromOptimizedOrders([secondHopOrder]),
-                    refundReceiver: refundReceiver || NULL_ADDRESS,
-                    fillAmount: MAX_UINT256,
-                }),
-            });
-        } else {
-            const fillAmount = isBuyQuote(quote) ? quote.makerTokenFillAmount : quote.takerTokenFillAmount;
-            transformations.push({
-                deploymentNonce: this.transformerNonces.fillQuoteTransformer,
-                data: encodeFillQuoteTransformerData({
-                    side: isBuyQuote(quote) ? FillQuoteTransformerSide.Buy : FillQuoteTransformerSide.Sell,
-                    sellToken,
-                    buyToken,
-                    ...getFQTTransformerDataFromOptimizedOrders(slippedOrders),
-                    refundReceiver: refundReceiver || NULL_ADDRESS,
-                    fillAmount: !isBuyQuote(quote) && shouldSellEntireBalance ? MAX_UINT256 : fillAmount,
-                }),
-            });
-        }
-        // Create a WETH unwrapper if going to ETH.
-        // Dont add the wethTransformer on CELO. There is no wrap/unwrap logic for CELO.
-        if (isToETH && this.chainId !== ChainId.Celo) {
-            transformations.push({
-                deploymentNonce: this.transformerNonces.wethTransformer,
-                data: encodeWethTransformerData({
-                    token: NATIVE_FEE_TOKEN_BY_CHAIN_ID[this.chainId],
-                    amount: MAX_UINT256,
-                }),
-            });
-        }
-
-        const { feeType, buyTokenFeeAmount, sellTokenFeeAmount, recipient: feeRecipient } = affiliateFee;
-        let gasOverhead = ZERO_AMOUNT;
-        if (feeType === AffiliateFeeType.PositiveSlippageFee && feeRecipient !== NULL_ADDRESS) {
-            // bestCaseAmountWithSurplus is used to cover gas cost of sending positive slipapge fee to fee recipient
-            // this helps avoid sending dust amounts which are not worth the gas cost to transfer
-            let bestCaseAmountWithSurplus = quote.bestCaseQuoteInfo.makerAmount
-                .plus(
-                    POSITIVE_SLIPPAGE_FEE_TRANSFORMER_GAS.multipliedBy(quote.gasPrice).multipliedBy(
-                        quote.makerAmountPerEth,
-                    ),
-                )
-                .integerValue();
-            // In the event makerAmountPerEth is unknown, we only allow for positive slippage which is greater than
-            // the best case amount
-            bestCaseAmountWithSurplus = BigNumber.max(bestCaseAmountWithSurplus, quote.bestCaseQuoteInfo.makerAmount);
-            transformations.push({
-                deploymentNonce: this.transformerNonces.positiveSlippageFeeTransformer,
-                data: encodePositiveSlippageFeeTransformerData({
-                    token: isToETH ? ETH_TOKEN_ADDRESS : buyToken,
-                    bestCaseAmount: BigNumber.max(bestCaseAmountWithSurplus, quote.bestCaseQuoteInfo.makerAmount),
-                    recipient: feeRecipient,
-                }),
-            });
-            // This may not be visible at eth_estimateGas time, so we explicitly add overhead
-            gasOverhead = POSITIVE_SLIPPAGE_FEE_TRANSFORMER_GAS;
-        } else if (feeType === AffiliateFeeType.PercentageFee && feeRecipient !== NULL_ADDRESS) {
-            // This transformer pays affiliate fees.
-            if (buyTokenFeeAmount.isGreaterThan(0)) {
-                transformations.push({
-                    deploymentNonce: this.transformerNonces.affiliateFeeTransformer,
-                    data: encodeAffiliateFeeTransformerData({
-                        fees: [
-                            {
-                                token: isToETH ? ETH_TOKEN_ADDRESS : buyToken,
-                                amount: buyTokenFeeAmount,
-                                recipient: feeRecipient,
-                            },
-                        ],
-                    }),
-                });
-                // Adjust the minimum buy amount by the fee.
-                minBuyAmount = BigNumber.max(0, minBuyAmount.minus(buyTokenFeeAmount));
-            }
-            if (sellTokenFeeAmount.isGreaterThan(0)) {
-                throw new Error('Affiliate fees denominated in sell token are not yet supported');
-            }
-        } else if (feeType === AffiliateFeeType.GaslessFee && feeRecipient !== NULL_ADDRESS) {
-            if (buyTokenFeeAmount.isGreaterThan(0)) {
-                transformations.push({
-                    deploymentNonce: this.transformerNonces.affiliateFeeTransformer,
-                    data: encodeAffiliateFeeTransformerData({
-                        fees: [
-                            {
-                                token: isToETH ? ETH_TOKEN_ADDRESS : buyToken,
-                                amount: buyTokenFeeAmount,
-                                recipient: feeRecipient,
-                            },
-                        ],
-                    }),
-                });
-                // Adjust the minimum buy amount by the fee.
-                minBuyAmount = BigNumber.max(0, minBuyAmount.minus(buyTokenFeeAmount));
-            }
-            if (sellTokenFeeAmount.isGreaterThan(0)) {
-                throw new Error('Affiliate fees denominated in sell token are not yet supported');
-            }
-        }
-
-        // Return any unspent sell tokens.
-        const payTakerTokens = [sellToken];
-        // Return any unspent intermediate tokens for two-hop swaps.
-        if (quote.path.hasTwoHop()) {
-            payTakerTokens.push(intermediateToken);
-        }
-        // Return any unspent ETH. If ETH is the buy token, it will
-        // be returned in TransformERC20Feature rather than PayTakerTransformer.
-        if (!isToETH) {
-            payTakerTokens.push(ETH_TOKEN_ADDRESS);
-        }
-        // The final transformer will send all funds to the taker.
-        transformations.push({
-            deploymentNonce: this.transformerNonces.payTakerTransformer,
-            data: encodePayTakerTransformerData({
-                tokens: payTakerTokens,
-                amounts: [],
-            }),
-        });
-        const TO_ETH_ADDRESS = this.chainId === ChainId.Celo ? this.contractAddresses.etherToken : ETH_TOKEN_ADDRESS;
-        const calldataHexString = this.exchangeProxy
-            .transformERC20(
-                isFromETH ? ETH_TOKEN_ADDRESS : sellToken,
-                isToETH ? TO_ETH_ADDRESS : buyToken,
-                shouldSellEntireBalance ? MAX_UINT256 : sellAmount,
-                minBuyAmount,
-                transformations,
-            )
-            .getABIEncodedTransactionData();
-
-        return {
-            calldataHexString,
-            ethAmount,
-            toAddress: this.exchangeProxy.address,
-            allowanceTarget: this.exchangeProxy.address,
-            gasOverhead,
-        };
+        return this.featureRuleRegistry.getTransformErc20Rule().createCalldata(quote, optsWithDefaults);
     }
 
     private encodeMultiplexBatchFillCalldata(quote: SwapQuote, opts: ExchangeProxyContractOpts): string {

--- a/src/asset-swapper/quote_consumers/feature_rules/feature_rule_registry.ts
+++ b/src/asset-swapper/quote_consumers/feature_rules/feature_rule_registry.ts
@@ -1,0 +1,15 @@
+import { ChainId, ContractAddresses } from '@0x/contract-addresses';
+import { TransformERC20Rule } from './transform_erc20_rule';
+import { FeatureRuleRegistry, FeatureRule } from './types';
+
+export class FeatureRuleRegistryImpl implements FeatureRuleRegistry {
+    public static create(chainId: ChainId, contractAddresses: ContractAddresses): FeatureRuleRegistry {
+        return new FeatureRuleRegistryImpl(TransformERC20Rule.create(chainId, contractAddresses));
+    }
+
+    private constructor(private readonly transformErc20Rule: TransformERC20Rule) {}
+
+    public getTransformErc20Rule(): FeatureRule {
+        return this.transformErc20Rule;
+    }
+}

--- a/src/asset-swapper/quote_consumers/feature_rules/transform_erc20_rule.ts
+++ b/src/asset-swapper/quote_consumers/feature_rules/transform_erc20_rule.ts
@@ -1,0 +1,251 @@
+import { ChainId, ContractAddresses } from '@0x/contract-addresses';
+import {
+    encodeAffiliateFeeTransformerData,
+    encodeFillQuoteTransformerData,
+    encodePayTakerTransformerData,
+    encodePositiveSlippageFeeTransformerData,
+    encodeWethTransformerData,
+    ETH_TOKEN_ADDRESS,
+    FillQuoteTransformerSide,
+} from '@0x/protocol-utils';
+import { AffiliateFeeType, CalldataInfo, ExchangeProxyContractOpts, SwapQuote } from '../../types';
+import { constants, POSITIVE_SLIPPAGE_FEE_TRANSFORMER_GAS } from '../../constants';
+import { FeatureRule } from './types';
+import { BigNumber } from '@0x/utils';
+import {
+    createExchangeProxyWithoutProvider,
+    getFQTTransformerDataFromOptimizedOrders,
+    getMaxQuoteSlippageRate,
+    getTransformerNonces,
+    isBuyQuote,
+} from '../quote_consumer_utils';
+import { NATIVE_FEE_TOKEN_BY_CHAIN_ID } from '../../utils/market_operation_utils/constants';
+import { IZeroExContract } from '@0x/contract-wrappers';
+import { TransformerNonces } from '../types';
+
+// Transformation of `TransformERC20` feature.
+interface ERC20Transformation {
+    deploymentNonce: number;
+    data: string;
+}
+
+const { NULL_ADDRESS, ZERO_AMOUNT } = constants;
+const MAX_UINT256 = new BigNumber(2).pow(256).minus(1);
+
+export class TransformERC20Rule implements FeatureRule {
+    public static create(chainId: ChainId, contractAddresses: ContractAddresses): TransformERC20Rule {
+        return new TransformERC20Rule(
+            chainId,
+            contractAddresses,
+            createExchangeProxyWithoutProvider(contractAddresses.exchangeProxy),
+            getTransformerNonces(contractAddresses),
+        );
+    }
+
+    private constructor(
+        private readonly chainId: ChainId,
+        private readonly contractAddresses: ContractAddresses,
+        private readonly exchangeProxy: IZeroExContract,
+        private readonly transformerNonces: TransformerNonces,
+    ) {}
+
+    // TransformERC20 is the most generic feature that is compatible with all kinds of swaps.
+    public isCompatible(): boolean {
+        return true;
+    }
+
+    public createCalldata(quote: SwapQuote, opts: ExchangeProxyContractOpts): CalldataInfo {
+        // TODO(kyu-c): further breakdown calldata creation logic.
+        const { refundReceiver, affiliateFee, isFromETH, isToETH, shouldSellEntireBalance } = opts;
+        const sellToken = quote.takerToken;
+        const buyToken = quote.makerToken;
+        // Take the bounds from the worst case
+        const sellAmount = BigNumber.max(
+            quote.bestCaseQuoteInfo.totalTakerAmount,
+            quote.worstCaseQuoteInfo.totalTakerAmount,
+        );
+        let minBuyAmount = quote.worstCaseQuoteInfo.makerAmount;
+        let ethAmount = quote.worstCaseQuoteInfo.protocolFeeInWeiAmount;
+
+        if (isFromETH) {
+            ethAmount = ethAmount.plus(sellAmount);
+        }
+
+        const maxSlippage = getMaxQuoteSlippageRate(quote);
+        const slippedOrders = quote.path.getSlippedOrders(maxSlippage);
+
+        // Build up the transformations.
+        const transformations = [] as ERC20Transformation[];
+        // Create a WETH wrapper if coming from ETH.
+        // Don't add the wethTransformer to CELO. There is no wrap/unwrap logic for CELO.
+        if (isFromETH && this.chainId !== ChainId.Celo) {
+            transformations.push({
+                deploymentNonce: this.transformerNonces.wethTransformer,
+                data: encodeWethTransformerData({
+                    token: ETH_TOKEN_ADDRESS,
+                    amount: shouldSellEntireBalance ? MAX_UINT256 : sellAmount,
+                }),
+            });
+        }
+
+        // If it's two hop we have an intermediate token this is needed to encode the individual FQT
+        // and we also want to ensure no dust amount is left in the flash wallet
+        const intermediateToken = quote.path.hasTwoHop() ? slippedOrders[0].makerToken : NULL_ADDRESS;
+        // This transformer will fill the quote.
+        if (quote.path.hasTwoHop()) {
+            const [firstHopOrder, secondHopOrder] = slippedOrders;
+            transformations.push({
+                deploymentNonce: this.transformerNonces.fillQuoteTransformer,
+                data: encodeFillQuoteTransformerData({
+                    side: FillQuoteTransformerSide.Sell,
+                    sellToken,
+                    buyToken: intermediateToken,
+                    ...getFQTTransformerDataFromOptimizedOrders([firstHopOrder]),
+                    refundReceiver: refundReceiver || NULL_ADDRESS,
+                    fillAmount: shouldSellEntireBalance ? MAX_UINT256 : firstHopOrder.takerAmount,
+                }),
+            });
+            transformations.push({
+                deploymentNonce: this.transformerNonces.fillQuoteTransformer,
+                data: encodeFillQuoteTransformerData({
+                    side: FillQuoteTransformerSide.Sell,
+                    buyToken,
+                    sellToken: intermediateToken,
+                    ...getFQTTransformerDataFromOptimizedOrders([secondHopOrder]),
+                    refundReceiver: refundReceiver || NULL_ADDRESS,
+                    fillAmount: MAX_UINT256,
+                }),
+            });
+        } else {
+            const fillAmount = isBuyQuote(quote) ? quote.makerTokenFillAmount : quote.takerTokenFillAmount;
+            transformations.push({
+                deploymentNonce: this.transformerNonces.fillQuoteTransformer,
+                data: encodeFillQuoteTransformerData({
+                    side: isBuyQuote(quote) ? FillQuoteTransformerSide.Buy : FillQuoteTransformerSide.Sell,
+                    sellToken,
+                    buyToken,
+                    ...getFQTTransformerDataFromOptimizedOrders(slippedOrders),
+                    refundReceiver: refundReceiver || NULL_ADDRESS,
+                    fillAmount: !isBuyQuote(quote) && shouldSellEntireBalance ? MAX_UINT256 : fillAmount,
+                }),
+            });
+        }
+        // Create a WETH unwrapper if going to ETH.
+        // Dont add the wethTransformer on CELO. There is no wrap/unwrap logic for CELO.
+        if (isToETH && this.chainId !== ChainId.Celo) {
+            transformations.push({
+                deploymentNonce: this.transformerNonces.wethTransformer,
+                data: encodeWethTransformerData({
+                    token: NATIVE_FEE_TOKEN_BY_CHAIN_ID[this.chainId],
+                    amount: MAX_UINT256,
+                }),
+            });
+        }
+
+        const { feeType, buyTokenFeeAmount, sellTokenFeeAmount, recipient: feeRecipient } = affiliateFee;
+        let gasOverhead = ZERO_AMOUNT;
+        if (feeType === AffiliateFeeType.PositiveSlippageFee && feeRecipient !== NULL_ADDRESS) {
+            // bestCaseAmountWithSurplus is used to cover gas cost of sending positive slipapge fee to fee recipient
+            // this helps avoid sending dust amounts which are not worth the gas cost to transfer
+            let bestCaseAmountWithSurplus = quote.bestCaseQuoteInfo.makerAmount
+                .plus(
+                    POSITIVE_SLIPPAGE_FEE_TRANSFORMER_GAS.multipliedBy(quote.gasPrice).multipliedBy(
+                        quote.makerAmountPerEth,
+                    ),
+                )
+                .integerValue();
+            // In the event makerAmountPerEth is unknown, we only allow for positive slippage which is greater than
+            // the best case amount
+            bestCaseAmountWithSurplus = BigNumber.max(bestCaseAmountWithSurplus, quote.bestCaseQuoteInfo.makerAmount);
+            transformations.push({
+                deploymentNonce: this.transformerNonces.positiveSlippageFeeTransformer,
+                data: encodePositiveSlippageFeeTransformerData({
+                    token: isToETH ? ETH_TOKEN_ADDRESS : buyToken,
+                    bestCaseAmount: BigNumber.max(bestCaseAmountWithSurplus, quote.bestCaseQuoteInfo.makerAmount),
+                    recipient: feeRecipient,
+                }),
+            });
+            // This may not be visible at eth_estimateGas time, so we explicitly add overhead
+            gasOverhead = POSITIVE_SLIPPAGE_FEE_TRANSFORMER_GAS;
+        } else if (feeType === AffiliateFeeType.PercentageFee && feeRecipient !== NULL_ADDRESS) {
+            // This transformer pays affiliate fees.
+            if (buyTokenFeeAmount.isGreaterThan(0)) {
+                transformations.push({
+                    deploymentNonce: this.transformerNonces.affiliateFeeTransformer,
+                    data: encodeAffiliateFeeTransformerData({
+                        fees: [
+                            {
+                                token: isToETH ? ETH_TOKEN_ADDRESS : buyToken,
+                                amount: buyTokenFeeAmount,
+                                recipient: feeRecipient,
+                            },
+                        ],
+                    }),
+                });
+                // Adjust the minimum buy amount by the fee.
+                minBuyAmount = BigNumber.max(0, minBuyAmount.minus(buyTokenFeeAmount));
+            }
+            if (sellTokenFeeAmount.isGreaterThan(0)) {
+                throw new Error('Affiliate fees denominated in sell token are not yet supported');
+            }
+        } else if (feeType === AffiliateFeeType.GaslessFee && feeRecipient !== NULL_ADDRESS) {
+            if (buyTokenFeeAmount.isGreaterThan(0)) {
+                transformations.push({
+                    deploymentNonce: this.transformerNonces.affiliateFeeTransformer,
+                    data: encodeAffiliateFeeTransformerData({
+                        fees: [
+                            {
+                                token: isToETH ? ETH_TOKEN_ADDRESS : buyToken,
+                                amount: buyTokenFeeAmount,
+                                recipient: feeRecipient,
+                            },
+                        ],
+                    }),
+                });
+                // Adjust the minimum buy amount by the fee.
+                minBuyAmount = BigNumber.max(0, minBuyAmount.minus(buyTokenFeeAmount));
+            }
+            if (sellTokenFeeAmount.isGreaterThan(0)) {
+                throw new Error('Affiliate fees denominated in sell token are not yet supported');
+            }
+        }
+
+        // Return any unspent sell tokens.
+        const payTakerTokens = [sellToken];
+        // Return any unspent intermediate tokens for two-hop swaps.
+        if (quote.path.hasTwoHop()) {
+            payTakerTokens.push(intermediateToken);
+        }
+        // Return any unspent ETH. If ETH is the buy token, it will
+        // be returned in TransformERC20Feature rather than PayTakerTransformer.
+        if (!isToETH) {
+            payTakerTokens.push(ETH_TOKEN_ADDRESS);
+        }
+        // The final transformer will send all funds to the taker.
+        transformations.push({
+            deploymentNonce: this.transformerNonces.payTakerTransformer,
+            data: encodePayTakerTransformerData({
+                tokens: payTakerTokens,
+                amounts: [],
+            }),
+        });
+        const TO_ETH_ADDRESS = this.chainId === ChainId.Celo ? this.contractAddresses.etherToken : ETH_TOKEN_ADDRESS;
+        const calldataHexString = this.exchangeProxy
+            .transformERC20(
+                isFromETH ? ETH_TOKEN_ADDRESS : sellToken,
+                isToETH ? TO_ETH_ADDRESS : buyToken,
+                shouldSellEntireBalance ? MAX_UINT256 : sellAmount,
+                minBuyAmount,
+                transformations,
+            )
+            .getABIEncodedTransactionData();
+
+        return {
+            calldataHexString,
+            ethAmount,
+            toAddress: this.exchangeProxy.address,
+            allowanceTarget: this.exchangeProxy.address,
+            gasOverhead,
+        };
+    }
+}

--- a/src/asset-swapper/quote_consumers/feature_rules/types.ts
+++ b/src/asset-swapper/quote_consumers/feature_rules/types.ts
@@ -1,0 +1,10 @@
+import { CalldataInfo, ExchangeProxyContractOpts, SwapQuote } from '../../types';
+
+export interface FeatureRule {
+    isCompatible(quote: SwapQuote, opts: ExchangeProxyContractOpts): boolean;
+    createCalldata(quote: SwapQuote, opts: ExchangeProxyContractOpts): CalldataInfo;
+}
+
+export interface FeatureRuleRegistry {
+    getTransformErc20Rule(): FeatureRule;
+}

--- a/src/asset-swapper/quote_consumers/quote_consumer_utils.ts
+++ b/src/asset-swapper/quote_consumers/quote_consumer_utils.ts
@@ -118,9 +118,10 @@ export function isDirectSwapCompatible(
     return true;
 }
 
-/**
- * Whether a quote is a market buy or not.
- */
+export function getMaxQuoteSlippageRate(quote: SwapQuote): number {
+    return quote.worstCaseQuoteInfo.slippage;
+}
+
 export function isBuyQuote(quote: SwapQuote): quote is MarketBuySwapQuote {
     return quote.type === MarketOperation.Buy;
 }


### PR DESCRIPTION
# Description

Introduce `FeatureRule` which is responsible for determining whether a quote is compatible for a exchange proxy feature. 
* Move `TransformERC20` calldata generation logic into a rule


# Testing & Simbot Run
* Existing `ExchangeProxySwapQuoteConsumer` tests have been moved to `transform_erc20_rule.ts` 
  * Unfortunately, there were no tests for non-`TransformERC20` features. 
* [Simbot run](https://metabase.spaceship.0x.org/dashboard/186?run_id=2023-01-ep-consumer-4)

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
