### PR TITLE
feat: Add a partial `Multiplex+MultiHop` support in `SamplerOperations` and `PathOptimizer` [LIT-637]

### DIFF
--- a/src/asset-swapper/utils/market_operation_utils/sampler_operations.ts
+++ b/src/asset-swapper/utils/market_operation_utils/sampler_operations.ts
@@ -722,7 +722,7 @@ export class SamplerOperations {
         makerToken: string,
         takerToken: string,
         sellAmounts: BigNumber[],
-    ): BatchedOperation<DexSample<MultiHopFillData>[]> {
+    ): BatchedOperation<DexSample<MultiHopFillData>[][]> {
         const _sources = TWO_HOP_SOURCE_FILTERS.getAllowed(sources);
         if (_sources.length === 0) {
             return SamplerOperations.constant([]);
@@ -769,14 +769,13 @@ export class SamplerOperations {
         return this._createBatch(
             subOps,
             (samples: BigNumber[][]) => {
-                return subOps.map((op, i) => {
-                    // TODO(kyu-c): make it return DexSample<MultiHopFillData>[][] once it actually samples more than 1 point.
-                    return {
+                return subOps.map((op, subOpsIndex) => {
+                    return samples[subOpsIndex].map((output, sampleIndex) => ({
                         source: op.source,
-                        output: samples[i][0],
-                        input: sellAmounts[0],
+                        output,
+                        input: sellAmounts[sampleIndex],
                         fillData: op.fillData,
-                    };
+                    }));
                 });
             },
             () => {
@@ -791,7 +790,7 @@ export class SamplerOperations {
         makerToken: string,
         takerToken: string,
         buyAmounts: BigNumber[],
-    ): BatchedOperation<DexSample<MultiHopFillData>[]> {
+    ): BatchedOperation<DexSample<MultiHopFillData>[][]> {
         const _sources = TWO_HOP_SOURCE_FILTERS.getAllowed(sources);
         if (_sources.length === 0) {
             return SamplerOperations.constant([]);
@@ -836,14 +835,15 @@ export class SamplerOperations {
         return this._createBatch(
             subOps,
             (samples: BigNumber[][]) => {
-                // TODO(kyu-c): make it return DexSample<MultiHopFillData>[][] once it actually samples more than 1 point.
-                return subOps.map((op, i) => {
-                    return {
-                        source: op.source,
-                        output: samples[i][0],
-                        input: buyAmounts[0],
-                        fillData: op.fillData,
-                    };
+                return subOps.map((op, subOpIndex) => {
+                    return samples[subOpIndex].map((output, sampleIndex) => {
+                        return {
+                            source: op.source,
+                            output,
+                            input: buyAmounts[sampleIndex],
+                            fillData: op.fillData,
+                        };
+                    });
                 });
             },
             () => {

--- a/src/asset-swapper/utils/market_operation_utils/types.ts
+++ b/src/asset-swapper/utils/market_operation_utils/types.ts
@@ -333,7 +333,7 @@ export interface PathContext {
 export interface RawQuotes {
     nativeOrders: NativeOrderWithFillableAmounts[];
     rfqtIndicativeQuotes: V4RFQIndicativeQuoteMM[];
-    twoHopQuotes: DexSample<MultiHopFillData>[];
+    twoHopQuotes: DexSample<MultiHopFillData>[][];
     dexQuotes: DexSample<FillData>[][];
 }
 

--- a/src/asset-swapper/utils/quote_report_generator.ts
+++ b/src/asset-swapper/utils/quote_report_generator.ts
@@ -135,7 +135,11 @@ export function generateExtendedQuoteReportSources(
     );
 
     // MultiHop
-    sourcesConsidered.push(...quotes.twoHopQuotes.map((quote) => multiHopSampleToReportSource(quote, marketOperation)));
+    sourcesConsidered.push(
+        ..._.flatMap(quotes.twoHopQuotes, (samples) => {
+            return samples.map((sample) => multiHopSampleToReportSource(sample, marketOperation));
+        }),
+    );
 
     // Dex Quotes
     sourcesConsidered.push(


### PR DESCRIPTION
# Description

Add a partial `Multiplex+MultiHop` support in `SamplerOperations` and `PathOptimizer`
* NOTE: this only adds `Multiplex+MultiHop` supports to some of the components. It is a no-op change until `MarketOperationUtils` actually starts sampling multiple amounts for two-hop.

# Testing & Simbot Run

* Added a unit test for `PathOptimizer`
* [simbot run](https://metabase.spaceship.0x.org/dashboard/186?run_id=2023-jan-mult-two-hop-samples&adjusted_amount_bought_win_tolerance__bps_=1.0)

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
