### PR TITLE
chore: only collect positive slippage fees on allowed buy tokens

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -240,13 +240,16 @@ export const FEE_RECIPIENT_ADDRESS = _.isEmpty(process.env.FEE_RECIPIENT_ADDRESS
     : assertEnvVarType('FEE_RECIPIENT_ADDRESS', process.env.FEE_RECIPIENT_ADDRESS, EnvVarType.ETHAddressHex);
 
 // The fee recipient for 0x
-export const ZERO_EX_FEE_RECIPIENT_ADDRESS = _.isEmpty(process.env.ZERO_EX_FEE_RECIPIENT_ADDRESS)
-    ? NULL_ADDRESS
-    : assertEnvVarType(
-          'ZERO_EX_FEE_RECIPIENT_ADDRESS',
-          process.env.ZERO_EX_FEE_RECIPIENT_ADDRESS,
-          EnvVarType.ETHAddressHex,
-      );
+export const ZERO_EX_FEE_RECIPIENT_ADDRESS: string = resolveEnvVar<string>(
+    'ZERO_EX_FEE_RECIPIENT_ADDRESS',
+    EnvVarType.ETHAddressHex,
+    NULL_ADDRESS,
+);
+
+// The set of fee tokens for 0x
+export const ZERO_EX_FEE_TOKENS: Set<string> = new Set(
+    resolveEnvVar<string[]>('ZERO_EX_FEE_TOKENS', EnvVarType.JsonStringList, []).map((addr) => addr.toLowerCase()),
+);
 
 // A flat fee that should be charged to the order taker
 export const TAKER_FEE_UNIT_AMOUNT = _.isEmpty(process.env.TAKER_FEE_UNIT_AMOUNT)

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -378,16 +378,17 @@ export class SwapService implements ISwapService {
             },
         ];
 
-        // By default, add a positive slippage fee for allowed tokens.
+        // By default, add a positive slippage fee for allowed pairs.
         // Integrators may turn this off by setting positiveSlippagePercent to 0
         // NOTE that we do not yet allow for a specified percent of the positive slippage to be taken, it's all or nothing.
         // TODO: customize the positive slippage by the percent
-        const isBuyTokenAllowed = ZERO_EX_FEE_TOKENS.has(buyToken.toLowerCase());
+        const isPairAllowed =
+            ZERO_EX_FEE_TOKENS.has(buyToken.toLowerCase()) && ZERO_EX_FEE_TOKENS.has(sellToken.toLowerCase());
         const isDefaultPositiveSlippageFee = integrator?.positiveSlippagePercent === undefined;
         const isPostiveSlippageEnabled =
             integrator?.positiveSlippagePercent !== undefined && integrator.positiveSlippagePercent > 0; // 0 is falsy, must check undefined explicitly
         const positiveSlippageFee =
-            isBuyTokenAllowed && (isDefaultPositiveSlippageFee || isPostiveSlippageEnabled)
+            isPairAllowed && (isDefaultPositiveSlippageFee || isPostiveSlippageEnabled)
                 ? {
                       recipient: integrator?.feeRecipient || ZERO_EX_FEE_RECIPIENT_ADDRESS,
                       feeType: AffiliateFeeType.PositiveSlippageFee,

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -45,6 +45,7 @@ import {
     UNWRAP_QUOTE_GAS,
     WRAP_QUOTE_GAS,
     ZERO_EX_FEE_RECIPIENT_ADDRESS,
+    ZERO_EX_FEE_TOKENS,
 } from '../config';
 import {
     DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE,
@@ -377,15 +378,16 @@ export class SwapService implements ISwapService {
             },
         ];
 
-        // By default, add a positive slippage fee.
+        // By default, add a positive slippage fee for allowed tokens.
         // Integrators may turn this off by setting positiveSlippagePercent to 0
         // NOTE that we do not yet allow for a specified percent of the positive slippage to be taken, it's all or nothing.
         // TODO: customize the positive slippage by the percent
+        const isBuyTokenAllowed = ZERO_EX_FEE_TOKENS.has(buyToken.toLowerCase());
         const isDefaultPositiveSlippageFee = integrator?.positiveSlippagePercent === undefined;
         const isPostiveSlippageEnabled =
             integrator?.positiveSlippagePercent !== undefined && integrator.positiveSlippagePercent > 0; // 0 is falsy, must check undefined explicitly
         const positiveSlippageFee =
-            isDefaultPositiveSlippageFee || isPostiveSlippageEnabled
+            isBuyTokenAllowed && (isDefaultPositiveSlippageFee || isPostiveSlippageEnabled)
                 ? {
                       recipient: integrator?.feeRecipient || ZERO_EX_FEE_RECIPIENT_ADDRESS,
                       feeType: AffiliateFeeType.PositiveSlippageFee,


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
-->

# Description

Restrict positive slippage collection to those in a configured set.

<!--- Describe your changes in detail -->

# Testing & Simbot Run

Simbot run looks good

<!--- If your changes affect `swap` API (e.g. adding a new liquidity source, changes sampling or routing logic) include a link to Simbot run(s). -->

# Checklist

-   [ ] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [ ] Add tests to cover changes as needed.
-   [ ] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
