### PR TITLE
feat: Introduce swap debug mode [LIT-841]

### DIFF
--- a/src/asset-swapper/swap_quoter.ts
+++ b/src/asset-swapper/swap_quoter.ts
@@ -359,7 +359,8 @@ function createSwapQuote(
     });
 
     // Put together the swap quote
-    const { makerTokenDecimals, takerTokenDecimals, blockNumber } = optimizerResult.marketSideLiquidity;
+    const { makerTokenDecimals, takerTokenDecimals, blockNumber, samplerGasUsage } =
+        optimizerResult.marketSideLiquidity;
     const swapQuote = {
         makerToken,
         takerToken,
@@ -375,6 +376,7 @@ function createSwapQuote(
         quoteReport,
         extendedQuoteReportSources,
         blockNumber,
+        samplerGasUsage,
     };
 
     if (operation === MarketOperation.Buy) {

--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -211,14 +211,6 @@ export interface IPath {
     getSlippedOrdersByType(maxSlippage: number): OptimizedOrdersByType;
 }
 
-/**
- * takerToken: Address of the taker asset.
- * makerToken: Address of the maker asset.
- * gasPrice: gas price used to determine protocolFee amount, default to ethGasStation fast amount.
- * orders: An array of objects conforming to OptimizedMarketOrder. These orders can be used to cover the requested assetBuyAmount plus slippage.
- * bestCaseQuoteInfo: Info about the best case price for the asset.
- * worstCaseQuoteInfo: Info about the worst case price for the asset.
- */
 interface SwapQuoteBase {
     takerToken: string;
     makerToken: string;
@@ -234,6 +226,7 @@ interface SwapQuoteBase {
     takerAmountPerEth: BigNumber;
     makerAmountPerEth: BigNumber;
     blockNumber: number;
+    samplerGasUsage: number;
 }
 
 /**

--- a/src/asset-swapper/utils/market_operation_utils/types.ts
+++ b/src/asset-swapper/utils/market_operation_utils/types.ts
@@ -315,6 +315,7 @@ export interface MarketSideLiquidity {
     quotes: RawQuotes;
     isRfqSupported: boolean;
     blockNumber: number;
+    samplerGasUsage: number;
 }
 
 export interface PathContext {

--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -376,6 +376,7 @@ const parseSwapQuoteRequestParams = (req: express.Request, endpoint: 'price' | '
     // Whether the entire callers balance should be sold, used for contracts where the
     // amount available is non-deterministic
     const shouldSellEntireBalance = req.query.shouldSellEntireBalance === 'true' ? true : false;
+    const isDebugEnabled = req.query.debug === 'true' ? true : false;
 
     // Parse tokens and eth wrap/unwraps
     const sellTokenRaw = req.query.sellToken as string;
@@ -546,6 +547,7 @@ const parseSwapQuoteRequestParams = (req: express.Request, endpoint: 'price' | '
         takerAddress: takerAddress as string,
         enableSlippageProtection,
         priceImpactProtectionPercentage,
+        isDebugEnabled,
     };
 };
 

--- a/src/services/meta_transaction_service.ts
+++ b/src/services/meta_transaction_service.ts
@@ -220,6 +220,7 @@ export class MetaTransactionService implements IMetaTransactionService {
             sellToken: params.sellTokenAddress,
             shouldSellEntireBalance: false,
             skipValidation: true,
+            isDebugEnabled: false,
         };
 
         const quote = await this._swapService.calculateSwapQuoteAsync(quoteParams);
@@ -295,6 +296,7 @@ export class MetaTransactionService implements IMetaTransactionService {
             shouldSellEntireBalance: false,
             skipValidation: true,
             affiliateFee,
+            isDebugEnabled: false,
         };
 
         const quote = await this._swapService.calculateSwapQuoteAsync(quoteParams);

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -535,6 +535,7 @@ export class SwapService implements ISwapService {
             buyTokenToEthRate,
             quoteReport,
             blockNumber: swapQuote.blockNumber,
+            debugData: params.isDebugEnabled ? { samplerGasUsage: swapQuote.samplerGasUsage } : undefined,
         };
 
         if (apiSwapQuote.buyAmount.lte(new BigNumber(0))) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,6 +148,9 @@ interface QuoteBase {
     // Our calculated price impact or null if we were unable to
     // to calculate any price impact
     estimatedPriceImpact: BigNumber | null;
+    debugData?: {
+        samplerGasUsage: number;
+    };
 }
 
 export interface GetSwapQuoteResponseLiquiditySource {
@@ -226,6 +229,9 @@ export interface GetSwapQuoteParams extends SwapQuoteParamsBase {
     origin?: string;
     // Whether the optimal route accounts for expected slippage for each liquidity source
     enableSlippageProtection?: boolean;
+
+    // Non-functional parameters:
+    isDebugEnabled: boolean;
 }
 
 // GET /swap/price

--- a/src/utils/sampler_metrics.ts
+++ b/src/utils/sampler_metrics.ts
@@ -27,16 +27,21 @@ export const SAMPLER_METRICS = {
     /**
      * Logs the gas information performed during a sampler call.
      *
-     * @param data.side The market side
-     * @param data.gasBefore The gas remaining measured before any operations have been performed
-     * @param data.gasAfter The gas remaining measured after all operations have been performed
+     * @param side The market side
+     * @param gasLimit The gas limit (gas remaining measured before any operations have been performed)
+     * @param gasLeft The gas remaining measured after all operations have been performed
      */
-    logGasDetails: (data: { side: 'buy' | 'sell'; gasBefore: BigNumber; gasAfter: BigNumber }): void => {
-        const { side, gasBefore, gasAfter } = data;
-        const gasUsed = gasBefore.minus(gasAfter);
-
+    logGasDetails: ({
+        side,
+        gasLimit,
+        gasUsed,
+    }: {
+        side: 'buy' | 'sell';
+        gasLimit: BigNumber;
+        gasUsed: BigNumber;
+    }): void => {
         SAMPLER_GAS_USED_SUMMARY.observe({ side }, gasUsed.toNumber());
-        SAMPLER_GAS_LIMIT_SUMMARY.observe(gasBefore.toNumber());
+        SAMPLER_GAS_LIMIT_SUMMARY.observe(gasLimit.toNumber());
     },
 
     /**

--- a/test/asset-swapper/comparison_price_test.ts
+++ b/test/asset-swapper/comparison_price_test.ts
@@ -67,6 +67,7 @@ const buyMarketSideLiquidity: MarketSideLiquidity = {
     quoteSourceFilters: new SourceFilters(),
     isRfqSupported: false,
     blockNumber: 1337420,
+    samplerGasUsage: 1_000_000,
 };
 
 const sellMarketSideLiquidity: MarketSideLiquidity = {
@@ -89,6 +90,7 @@ const sellMarketSideLiquidity: MarketSideLiquidity = {
     quoteSourceFilters: new SourceFilters(),
     isRfqSupported: false,
     blockNumber: 1337420,
+    samplerGasUsage: 1_000_000,
 };
 
 describe('getComparisonPrices', async () => {

--- a/test/asset-swapper/test_utils/test_data.ts
+++ b/test/asset-swapper/test_utils/test_data.ts
@@ -241,6 +241,7 @@ export function createSwapQuote({
         takerAmountPerEth: takerAmountPerEth || new BigNumber(0),
         makerAmountPerEth: makerAmountPerEth || new BigNumber(0),
         blockNumber: 424242,
+        samplerGasUsage: 1_000_000,
     };
 }
 

--- a/test/utils/mocks.ts
+++ b/test/utils/mocks.ts
@@ -58,4 +58,5 @@ export const randomSellQuote: SwapQuote = {
     takerAmountPerEth: new BigNumber(0),
     makerAmountPerEth: new BigNumber(0),
     blockNumber: 1337420,
+    samplerGasUsage: 1_000_000,
 };


### PR DESCRIPTION
# Description

When query param `debug=true` is set some debug data (sampler gas usage to begin with) is returned as a part of the response.

Example: 
```
	"debugData": {
		"samplerGasUsage": 108263697
	},
```

# Testing & Simbot Run

* [Simbot run](https://metabase.spaceship.0x.org/dashboard/186?run_id=2023-feb-swap-debug&adjusted_amount_bought_win_tolerance__bps_=1.0)

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
