### PR TITLE
chore: Rename UniswapV3 fill data related types

### DIFF
--- a/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
+++ b/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
@@ -24,7 +24,7 @@ import {
     CURVE_LIQUIDITY_PROVIDER_BY_CHAIN_ID,
     NATIVE_FEE_TOKEN_BY_CHAIN_ID,
 } from '../utils/market_operation_utils/constants';
-import { CurveFillData, FinalUniswapV3FillData, UniswapV2FillData } from '../utils/market_operation_utils/types';
+import { CurveFillData, FinalPathFillData, UniswapV2FillData } from '../utils/market_operation_utils/types';
 
 import {
     ERC20BridgeSource,
@@ -119,19 +119,19 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
             this.chainId === ChainId.Mainnet &&
             isDirectSwapCompatible(quote.path, optsWithDefaults, [ERC20BridgeSource.UniswapV3])
         ) {
-            const fillData = (slippedOrders[0] as OptimizedMarketBridgeOrder<FinalUniswapV3FillData>).fillData;
+            const fillData = (slippedOrders[0] as OptimizedMarketBridgeOrder<FinalPathFillData>).fillData;
             let _calldataHexString;
             if (isFromETH) {
                 _calldataHexString = this.exchangeProxy
-                    .sellEthForTokenToUniswapV3(fillData.uniswapPath, minBuyAmount, NULL_ADDRESS)
+                    .sellEthForTokenToUniswapV3(fillData.path, minBuyAmount, NULL_ADDRESS)
                     .getABIEncodedTransactionData();
             } else if (isToETH) {
                 _calldataHexString = this.exchangeProxy
-                    .sellTokenForEthToUniswapV3(fillData.uniswapPath, sellAmount, minBuyAmount, NULL_ADDRESS)
+                    .sellTokenForEthToUniswapV3(fillData.path, sellAmount, minBuyAmount, NULL_ADDRESS)
                     .getABIEncodedTransactionData();
             } else {
                 _calldataHexString = this.exchangeProxy
-                    .sellTokenForTokenToUniswapV3(fillData.uniswapPath, sellAmount, minBuyAmount, NULL_ADDRESS)
+                    .sellTokenForTokenToUniswapV3(fillData.path, sellAmount, minBuyAmount, NULL_ADDRESS)
                     .getABIEncodedTransactionData();
             }
             return {
@@ -365,11 +365,11 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
                     });
                     break switch_statement;
                 case ERC20BridgeSource.UniswapV3: {
-                    const fillData = (order as OptimizedMarketBridgeOrder<FinalUniswapV3FillData>).fillData;
+                    const fillData = (order as OptimizedMarketBridgeOrder<FinalPathFillData>).fillData;
                     subcalls.push({
                         id: MultiplexSubcall.UniswapV3,
                         sellAmount: order.takerAmount,
-                        data: fillData.uniswapPath,
+                        data: fillData.path,
                     });
                     break switch_statement;
                 }
@@ -458,7 +458,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
                 case ERC20BridgeSource.UniswapV3:
                     subcalls.push({
                         id: MultiplexSubcall.UniswapV3,
-                        data: (order.fillData as FinalUniswapV3FillData).uniswapPath,
+                        data: (order.fillData as FinalPathFillData).path,
                     });
                     break;
                 default:

--- a/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
+++ b/src/asset-swapper/quote_consumers/exchange_proxy_swap_quote_consumer.ts
@@ -24,7 +24,7 @@ import {
     CURVE_LIQUIDITY_PROVIDER_BY_CHAIN_ID,
     NATIVE_FEE_TOKEN_BY_CHAIN_ID,
 } from '../utils/market_operation_utils/constants';
-import { CurveFillData, FinalPathFillData, UniswapV2FillData } from '../utils/market_operation_utils/types';
+import { CurveFillData, FinalTickDEXMultiPathFillData, UniswapV2FillData } from '../utils/market_operation_utils/types';
 
 import {
     ERC20BridgeSource,
@@ -119,7 +119,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
             this.chainId === ChainId.Mainnet &&
             isDirectSwapCompatible(quote.path, optsWithDefaults, [ERC20BridgeSource.UniswapV3])
         ) {
-            const fillData = (slippedOrders[0] as OptimizedMarketBridgeOrder<FinalPathFillData>).fillData;
+            const fillData = (slippedOrders[0] as OptimizedMarketBridgeOrder<FinalTickDEXMultiPathFillData>).fillData;
             let _calldataHexString;
             if (isFromETH) {
                 _calldataHexString = this.exchangeProxy
@@ -365,7 +365,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
                     });
                     break switch_statement;
                 case ERC20BridgeSource.UniswapV3: {
-                    const fillData = (order as OptimizedMarketBridgeOrder<FinalPathFillData>).fillData;
+                    const fillData = (order as OptimizedMarketBridgeOrder<FinalTickDEXMultiPathFillData>).fillData;
                     subcalls.push({
                         id: MultiplexSubcall.UniswapV3,
                         sellAmount: order.takerAmount,
@@ -458,7 +458,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumer {
                 case ERC20BridgeSource.UniswapV3:
                     subcalls.push({
                         id: MultiplexSubcall.UniswapV3,
-                        data: (order.fillData as FinalPathFillData).path,
+                        data: (order.fillData as FinalTickDEXMultiPathFillData).path,
                     });
                     break;
                 default:

--- a/src/asset-swapper/utils/market_operation_utils/constants.ts
+++ b/src/asset-swapper/utils/market_operation_utils/constants.ts
@@ -16,7 +16,7 @@ import {
     CurveFunctionSelectors,
     CurveInfo,
     DODOFillData,
-    FinalPathFillData,
+    FinalTickDEXMultiPathFillData,
     isFinalPathFillData,
     LidoFillData,
     LidoInfo,
@@ -26,7 +26,7 @@ import {
     PsmInfo,
     SynthetixFillData,
     UniswapV2FillData,
-    MultiPathFillData,
+    TickDEXMultiPathFillData,
     WOOFiFillData,
 } from './types';
 
@@ -2019,7 +2019,7 @@ export const DEFAULT_GAS_SCHEDULE: GasSchedule = {
         return gas;
     },
     [ERC20BridgeSource.UniswapV3]: (fillData?: FillData) => {
-        const uniFillData = fillData as MultiPathFillData | FinalPathFillData;
+        const uniFillData = fillData as TickDEXMultiPathFillData | FinalTickDEXMultiPathFillData;
         // NOTE: This base value was heuristically chosen by looking at how much it generally
         // underestimated gas usage
         const base = 34e3; // 34k base

--- a/src/asset-swapper/utils/market_operation_utils/constants.ts
+++ b/src/asset-swapper/utils/market_operation_utils/constants.ts
@@ -16,8 +16,8 @@ import {
     CurveFunctionSelectors,
     CurveInfo,
     DODOFillData,
-    FinalUniswapV3FillData,
-    isFinalUniswapV3FillData,
+    FinalPathFillData,
+    isFinalPathFillData,
     LidoFillData,
     LidoInfo,
     MakerPsmFillData,
@@ -26,7 +26,7 @@ import {
     PsmInfo,
     SynthetixFillData,
     UniswapV2FillData,
-    UniswapV3FillData,
+    MultiPathFillData,
     WOOFiFillData,
 } from './types';
 
@@ -2019,12 +2019,12 @@ export const DEFAULT_GAS_SCHEDULE: GasSchedule = {
         return gas;
     },
     [ERC20BridgeSource.UniswapV3]: (fillData?: FillData) => {
-        const uniFillData = fillData as UniswapV3FillData | FinalUniswapV3FillData;
+        const uniFillData = fillData as MultiPathFillData | FinalPathFillData;
         // NOTE: This base value was heuristically chosen by looking at how much it generally
         // underestimated gas usage
         const base = 34e3; // 34k base
         let gas = base;
-        if (isFinalUniswapV3FillData(uniFillData)) {
+        if (isFinalPathFillData(uniFillData)) {
             gas += uniFillData.gasUsed;
         } else {
             // NOTE: We don't actually know which of the paths would be used in the router

--- a/src/asset-swapper/utils/market_operation_utils/orders.ts
+++ b/src/asset-swapper/utils/market_operation_utils/orders.ts
@@ -29,7 +29,7 @@ import {
     CurveFillData,
     DexSample,
     DODOFillData,
-    FinalPathFillData,
+    FinalTickDEXMultiPathFillData,
     GenericRouterFillData,
     GMXFillData,
     KyberDmmFillData,
@@ -42,7 +42,7 @@ import {
     ShellFillData,
     SynthetixFillData,
     UniswapV2FillData,
-    MultiPathFillData,
+    TickDEXMultiPathFillData,
     PathAmount,
     VelodromeFillData,
     WOOFiFillData,
@@ -327,7 +327,7 @@ export function createBridgeDataForBridgeOrder(order: OptimizedMarketBridgeOrder
             break;
         }
         case ERC20BridgeSource.UniswapV3: {
-            const uniswapV3FillData = (order as OptimizedMarketBridgeOrder<FinalPathFillData>).fillData;
+            const uniswapV3FillData = (order as OptimizedMarketBridgeOrder<FinalTickDEXMultiPathFillData>).fillData;
             bridgeData = encoder.encode([uniswapV3FillData.router, uniswapV3FillData.path]);
             break;
         }
@@ -594,9 +594,9 @@ function toFillBase(fill: Fill): FillBase {
 function createFinalBridgeOrderFillDataFromCollapsedFill(fill: Fill): FillData {
     switch (fill.source) {
         case ERC20BridgeSource.UniswapV3: {
-            const fd = fill.fillData as MultiPathFillData;
+            const fd = fill.fillData as TickDEXMultiPathFillData;
             const { path: uniswapPath, gasUsed } = getBestUniswapV3PathAmountForInputAmount(fd, fill.input);
-            const finalFillData: FinalPathFillData = {
+            const finalFillData: FinalTickDEXMultiPathFillData = {
                 router: fd.router,
                 tokenAddressPath: fd.tokenAddressPath,
                 path: uniswapPath,
@@ -610,7 +610,7 @@ function createFinalBridgeOrderFillDataFromCollapsedFill(fill: Fill): FillData {
     return fill.fillData;
 }
 
-function getBestUniswapV3PathAmountForInputAmount(fillData: MultiPathFillData, inputAmount: BigNumber): PathAmount {
+function getBestUniswapV3PathAmountForInputAmount(fillData: TickDEXMultiPathFillData, inputAmount: BigNumber): PathAmount {
     if (fillData.pathAmounts.length === 0) {
         throw new Error(`No Uniswap V3 paths`);
     }

--- a/src/asset-swapper/utils/market_operation_utils/orders.ts
+++ b/src/asset-swapper/utils/market_operation_utils/orders.ts
@@ -610,7 +610,10 @@ function createFinalBridgeOrderFillDataFromCollapsedFill(fill: Fill): FillData {
     return fill.fillData;
 }
 
-function getBestUniswapV3PathAmountForInputAmount(fillData: TickDEXMultiPathFillData, inputAmount: BigNumber): PathAmount {
+function getBestUniswapV3PathAmountForInputAmount(
+    fillData: TickDEXMultiPathFillData,
+    inputAmount: BigNumber,
+): PathAmount {
     if (fillData.pathAmounts.length === 0) {
         throw new Error(`No Uniswap V3 paths`);
     }

--- a/src/asset-swapper/utils/market_operation_utils/orders.ts
+++ b/src/asset-swapper/utils/market_operation_utils/orders.ts
@@ -610,10 +610,7 @@ function createFinalBridgeOrderFillDataFromCollapsedFill(fill: Fill): FillData {
     return fill.fillData;
 }
 
-function getBestUniswapV3PathAmountForInputAmount(
-    fillData: MultiPathFillData,
-    inputAmount: BigNumber,
-): PathAmount {
+function getBestUniswapV3PathAmountForInputAmount(fillData: MultiPathFillData, inputAmount: BigNumber): PathAmount {
     if (fillData.pathAmounts.length === 0) {
         throw new Error(`No Uniswap V3 paths`);
     }

--- a/src/asset-swapper/utils/market_operation_utils/orders.ts
+++ b/src/asset-swapper/utils/market_operation_utils/orders.ts
@@ -29,7 +29,7 @@ import {
     CurveFillData,
     DexSample,
     DODOFillData,
-    FinalUniswapV3FillData,
+    FinalPathFillData,
     GenericRouterFillData,
     GMXFillData,
     KyberDmmFillData,
@@ -42,8 +42,8 @@ import {
     ShellFillData,
     SynthetixFillData,
     UniswapV2FillData,
-    UniswapV3FillData,
-    UniswapV3PathAmount,
+    MultiPathFillData,
+    PathAmount,
     VelodromeFillData,
     WOOFiFillData,
 } from './types';
@@ -327,8 +327,8 @@ export function createBridgeDataForBridgeOrder(order: OptimizedMarketBridgeOrder
             break;
         }
         case ERC20BridgeSource.UniswapV3: {
-            const uniswapV3FillData = (order as OptimizedMarketBridgeOrder<FinalUniswapV3FillData>).fillData;
-            bridgeData = encoder.encode([uniswapV3FillData.router, uniswapV3FillData.uniswapPath]);
+            const uniswapV3FillData = (order as OptimizedMarketBridgeOrder<FinalPathFillData>).fillData;
+            bridgeData = encoder.encode([uniswapV3FillData.router, uniswapV3FillData.path]);
             break;
         }
         case ERC20BridgeSource.KyberDmm: {
@@ -594,12 +594,12 @@ function toFillBase(fill: Fill): FillBase {
 function createFinalBridgeOrderFillDataFromCollapsedFill(fill: Fill): FillData {
     switch (fill.source) {
         case ERC20BridgeSource.UniswapV3: {
-            const fd = fill.fillData as UniswapV3FillData;
-            const { uniswapPath, gasUsed } = getBestUniswapV3PathAmountForInputAmount(fd, fill.input);
-            const finalFillData: FinalUniswapV3FillData = {
+            const fd = fill.fillData as MultiPathFillData;
+            const { path: uniswapPath, gasUsed } = getBestUniswapV3PathAmountForInputAmount(fd, fill.input);
+            const finalFillData: FinalPathFillData = {
                 router: fd.router,
                 tokenAddressPath: fd.tokenAddressPath,
-                uniswapPath,
+                path: uniswapPath,
                 gasUsed,
             };
             return finalFillData;
@@ -611,9 +611,9 @@ function createFinalBridgeOrderFillDataFromCollapsedFill(fill: Fill): FillData {
 }
 
 function getBestUniswapV3PathAmountForInputAmount(
-    fillData: UniswapV3FillData,
+    fillData: MultiPathFillData,
     inputAmount: BigNumber,
-): UniswapV3PathAmount {
+): PathAmount {
     if (fillData.pathAmounts.length === 0) {
         throw new Error(`No Uniswap V3 paths`);
     }

--- a/src/asset-swapper/utils/market_operation_utils/types.ts
+++ b/src/asset-swapper/utils/market_operation_utils/types.ts
@@ -211,9 +211,7 @@ export interface KyberDmmFillData extends UniswapV2FillData {
 /**
  * Determines whether FillData is UniswapV3FillData or FinalUniswapV3FillData
  */
-export function isFinalPathFillData(
-    data: MultiPathFillData | FinalPathFillData,
-): data is FinalPathFillData {
+export function isFinalPathFillData(data: MultiPathFillData | FinalPathFillData): data is FinalPathFillData {
     return !!(data as FinalPathFillData).path;
 }
 

--- a/src/asset-swapper/utils/market_operation_utils/types.ts
+++ b/src/asset-swapper/utils/market_operation_utils/types.ts
@@ -198,7 +198,7 @@ export interface PathAmount {
     inputAmount: BigNumber;
     gasUsed: number;
 }
-export interface MultiPathFillData extends FillData {
+export interface TickDEXMultiPathFillData extends FillData {
     tokenAddressPath: string[];
     router: string;
     pathAmounts: PathAmount[];
@@ -211,11 +211,11 @@ export interface KyberDmmFillData extends UniswapV2FillData {
 /**
  * Determines whether FillData is UniswapV3FillData or FinalUniswapV3FillData
  */
-export function isFinalPathFillData(data: MultiPathFillData | FinalPathFillData): data is FinalPathFillData {
-    return !!(data as FinalPathFillData).path;
+export function isFinalPathFillData(data: TickDEXMultiPathFillData | FinalTickDEXMultiPathFillData): data is FinalTickDEXMultiPathFillData {
+    return !!(data as FinalTickDEXMultiPathFillData).path;
 }
 
-export interface FinalPathFillData extends Omit<MultiPathFillData, 'pathAmounts'> {
+export interface FinalTickDEXMultiPathFillData extends Omit<TickDEXMultiPathFillData, 'pathAmounts'> {
     // The encoded path that can fll the maximum input amount.
     path: string;
     gasUsed: number;

--- a/src/asset-swapper/utils/market_operation_utils/types.ts
+++ b/src/asset-swapper/utils/market_operation_utils/types.ts
@@ -211,7 +211,9 @@ export interface KyberDmmFillData extends UniswapV2FillData {
 /**
  * Determines whether FillData is UniswapV3FillData or FinalUniswapV3FillData
  */
-export function isFinalPathFillData(data: TickDEXMultiPathFillData | FinalTickDEXMultiPathFillData): data is FinalTickDEXMultiPathFillData {
+export function isFinalPathFillData(
+    data: TickDEXMultiPathFillData | FinalTickDEXMultiPathFillData,
+): data is FinalTickDEXMultiPathFillData {
     return !!(data as FinalTickDEXMultiPathFillData).path;
 }
 

--- a/src/asset-swapper/utils/market_operation_utils/types.ts
+++ b/src/asset-swapper/utils/market_operation_utils/types.ts
@@ -208,9 +208,6 @@ export interface KyberDmmFillData extends UniswapV2FillData {
     poolsPath: string[];
 }
 
-/**
- * Determines whether FillData is UniswapV3FillData or FinalUniswapV3FillData
- */
 export function isFinalPathFillData(
     data: TickDEXMultiPathFillData | FinalTickDEXMultiPathFillData,
 ): data is FinalTickDEXMultiPathFillData {

--- a/src/asset-swapper/utils/market_operation_utils/types.ts
+++ b/src/asset-swapper/utils/market_operation_utils/types.ts
@@ -193,16 +193,15 @@ export interface HopInfo {
     returnData: string;
 }
 
-export interface UniswapV3PathAmount {
-    uniswapPath: string;
+export interface PathAmount {
+    path: string;
     inputAmount: BigNumber;
     gasUsed: number;
 }
-export interface UniswapV3FillData extends FillData {
+export interface MultiPathFillData extends FillData {
     tokenAddressPath: string[];
     router: string;
-    pathAmounts: UniswapV3PathAmount[];
-    // Only needed for gas estimation.
+    pathAmounts: PathAmount[];
 }
 
 export interface KyberDmmFillData extends UniswapV2FillData {
@@ -212,15 +211,15 @@ export interface KyberDmmFillData extends UniswapV2FillData {
 /**
  * Determines whether FillData is UniswapV3FillData or FinalUniswapV3FillData
  */
-export function isFinalUniswapV3FillData(
-    data: UniswapV3FillData | FinalUniswapV3FillData,
-): data is FinalUniswapV3FillData {
-    return !!(data as FinalUniswapV3FillData).uniswapPath;
+export function isFinalPathFillData(
+    data: MultiPathFillData | FinalPathFillData,
+): data is FinalPathFillData {
+    return !!(data as FinalPathFillData).path;
 }
 
-export interface FinalUniswapV3FillData extends Omit<UniswapV3FillData, 'pathAmounts'> {
-    // The uniswap-encoded path that can fll the maximum input amount.
-    uniswapPath: string;
+export interface FinalPathFillData extends Omit<MultiPathFillData, 'pathAmounts'> {
+    // The encoded path that can fll the maximum input amount.
+    path: string;
     gasUsed: number;
 }
 

--- a/src/samplers/uniswapv3_sampler.ts
+++ b/src/samplers/uniswapv3_sampler.ts
@@ -4,7 +4,7 @@ import { UNISWAPV3_CONFIG_BY_CHAIN_ID } from '../asset-swapper/utils/market_oper
 import { SamplerContractOperation } from '../asset-swapper/utils/market_operation_utils/sampler_contract_operation';
 import {
     SourceQuoteOperation,
-    MultiPathFillData,
+    TickDEXMultiPathFillData,
     PathAmount,
 } from '../asset-swapper/utils/market_operation_utils/types';
 
@@ -13,7 +13,7 @@ interface BridgeSampler<TFillData extends FillData> {
     createSampleBuysOperation(tokenAddressPath: string[], amounts: BigNumber[]): SourceQuoteOperation<TFillData>;
 }
 
-export class UniswapV3Sampler implements BridgeSampler<MultiPathFillData> {
+export class UniswapV3Sampler implements BridgeSampler<TickDEXMultiPathFillData> {
     private readonly source: ERC20BridgeSource = ERC20BridgeSource.UniswapV3;
     private readonly samplerContract: ERC20BridgeSamplerContract;
     private readonly chainId: ChainId;
@@ -29,7 +29,7 @@ export class UniswapV3Sampler implements BridgeSampler<MultiPathFillData> {
     createSampleSellsOperation(
         tokenAddressPath: string[],
         amounts: BigNumber[],
-    ): SourceQuoteOperation<MultiPathFillData> {
+    ): SourceQuoteOperation<TickDEXMultiPathFillData> {
         return this.createSamplerOperation(
             this.samplerContract.sampleSellsFromUniswapV3,
             'sampleSellsFromUniswapV3',
@@ -41,7 +41,7 @@ export class UniswapV3Sampler implements BridgeSampler<MultiPathFillData> {
     createSampleBuysOperation(
         tokenAddressPath: string[],
         amounts: BigNumber[],
-    ): SourceQuoteOperation<MultiPathFillData> {
+    ): SourceQuoteOperation<TickDEXMultiPathFillData> {
         return this.createSamplerOperation(
             this.samplerContract.sampleBuysFromUniswapV3,
             'sampleBuysFromUniswapV3',
@@ -71,13 +71,13 @@ export class UniswapV3Sampler implements BridgeSampler<MultiPathFillData> {
         samplerMethodName: string,
         tokenAddressPath: string[],
         amounts: BigNumber[],
-    ): SourceQuoteOperation<MultiPathFillData> {
+    ): SourceQuoteOperation<TickDEXMultiPathFillData> {
         return new SamplerContractOperation({
             source: this.source,
             contract: this.samplerContract,
             function: samplerFunction,
             params: [this.factoryAddress, tokenAddressPath, amounts],
-            callback: (callResults: string, fillData: MultiPathFillData): BigNumber[] => {
+            callback: (callResults: string, fillData: TickDEXMultiPathFillData): BigNumber[] => {
                 const [paths, gasUsed, samples] = this.samplerContract.getABIDecodedReturnData<
                     [string[], BigNumber[], BigNumber[]]
                 >(samplerMethodName, callResults);

--- a/src/samplers/uniswapv3_sampler.ts
+++ b/src/samplers/uniswapv3_sampler.ts
@@ -4,8 +4,8 @@ import { UNISWAPV3_CONFIG_BY_CHAIN_ID } from '../asset-swapper/utils/market_oper
 import { SamplerContractOperation } from '../asset-swapper/utils/market_operation_utils/sampler_contract_operation';
 import {
     SourceQuoteOperation,
-    UniswapV3FillData,
-    UniswapV3PathAmount,
+    MultiPathFillData,
+    PathAmount,
 } from '../asset-swapper/utils/market_operation_utils/types';
 
 interface BridgeSampler<TFillData extends FillData> {
@@ -13,7 +13,7 @@ interface BridgeSampler<TFillData extends FillData> {
     createSampleBuysOperation(tokenAddressPath: string[], amounts: BigNumber[]): SourceQuoteOperation<TFillData>;
 }
 
-export class UniswapV3Sampler implements BridgeSampler<UniswapV3FillData> {
+export class UniswapV3Sampler implements BridgeSampler<MultiPathFillData> {
     private readonly source: ERC20BridgeSource = ERC20BridgeSource.UniswapV3;
     private readonly samplerContract: ERC20BridgeSamplerContract;
     private readonly chainId: ChainId;
@@ -29,7 +29,7 @@ export class UniswapV3Sampler implements BridgeSampler<UniswapV3FillData> {
     createSampleSellsOperation(
         tokenAddressPath: string[],
         amounts: BigNumber[],
-    ): SourceQuoteOperation<UniswapV3FillData> {
+    ): SourceQuoteOperation<MultiPathFillData> {
         return this.createSamplerOperation(
             this.samplerContract.sampleSellsFromUniswapV3,
             'sampleSellsFromUniswapV3',
@@ -41,7 +41,7 @@ export class UniswapV3Sampler implements BridgeSampler<UniswapV3FillData> {
     createSampleBuysOperation(
         tokenAddressPath: string[],
         amounts: BigNumber[],
-    ): SourceQuoteOperation<UniswapV3FillData> {
+    ): SourceQuoteOperation<MultiPathFillData> {
         return this.createSamplerOperation(
             this.samplerContract.sampleBuysFromUniswapV3,
             'sampleBuysFromUniswapV3',
@@ -54,9 +54,9 @@ export class UniswapV3Sampler implements BridgeSampler<UniswapV3FillData> {
         amounts: BigNumber[],
         paths: string[],
         gasUsed: BigNumber[],
-    ): UniswapV3PathAmount[] {
-        return paths.map((uniswapPath, i) => ({
-            uniswapPath,
+    ): PathAmount[] {
+        return paths.map((path, i) => ({
+            path,
             inputAmount: amounts[i],
             gasUsed: gasUsed[i].toNumber(),
         }));
@@ -71,13 +71,13 @@ export class UniswapV3Sampler implements BridgeSampler<UniswapV3FillData> {
         samplerMethodName: string,
         tokenAddressPath: string[],
         amounts: BigNumber[],
-    ): SourceQuoteOperation<UniswapV3FillData> {
+    ): SourceQuoteOperation<MultiPathFillData> {
         return new SamplerContractOperation({
             source: this.source,
             contract: this.samplerContract,
             function: samplerFunction,
             params: [this.factoryAddress, tokenAddressPath, amounts],
-            callback: (callResults: string, fillData: UniswapV3FillData): BigNumber[] => {
+            callback: (callResults: string, fillData: MultiPathFillData): BigNumber[] => {
                 const [paths, gasUsed, samples] = this.samplerContract.getABIDecodedReturnData<
                     [string[], BigNumber[], BigNumber[]]
                 >(samplerMethodName, callResults);


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
-->

# Description

These types will be reused for other tick-based AMMs. Rename to more generic names.

<!--- Describe your changes in detail -->

# Testing & Simbot Run

<!--- If your changes affect `swap` API (e.g. adding a new liquidity source, changes sampling or routing logic) include a link to Simbot run(s). -->

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
