### PR TITLE
chore: Move `asset-swapper` options out of `config.ts` [LIT-708]

### DIFF
--- a/src/handlers/swap_handlers.ts
+++ b/src/handlers/swap_handlers.ts
@@ -7,7 +7,7 @@ import { Kafka, Producer } from 'kafkajs';
 import _ = require('lodash');
 import { Counter, Histogram } from 'prom-client';
 
-import { ChainId, ERC20BridgeSource, RfqRequestOpts, SwapQuoterError } from '../asset-swapper';
+import { ERC20BridgeSource, RfqRequestOpts, SwapQuoterError } from '../asset-swapper';
 import {
     NATIVE_FEE_TOKEN_BY_CHAIN_ID,
     SELL_SOURCE_FILTER_BY_CHAIN_ID,
@@ -48,6 +48,7 @@ import { parseUtils } from '../utils/parse_utils';
 import { publishQuoteReport } from '../utils/quote_report_utils';
 import { schemaUtils } from '../utils/schema_utils';
 import { GasPriceUtils } from '../asset-swapper';
+import { ChainId } from '@0x/contract-addresses';
 
 let kafkaProducer: Producer | undefined;
 if (KAFKA_BROKERS !== undefined) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,0 +1,119 @@
+import { ChainId } from '@0x/contract-addresses';
+import { BigNumber } from '@0x/utils';
+
+import {
+    BlockParamLiteral,
+    DEFAULT_TOKEN_ADJACENCY_GRAPH_BY_CHAIN_ID,
+    OrderPrunerPermittedFeeTypes,
+    SamplerOverrides,
+    SOURCE_FLAGS,
+    SwapQuoteRequestOpts,
+    SwapQuoterOpts,
+    SwapQuoterRfqOpts,
+} from './asset-swapper';
+import {
+    CHAIN_ID,
+    RFQT_INTEGRATORS,
+    RFQT_TX_ORIGIN_BLACKLIST,
+    SAMPLE_DISTRIBUTION_BASE,
+    ZERO_EX_GAS_API_URL,
+} from './config';
+import { DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE, QUOTE_ORDER_EXPIRATION_BUFFER_MS, TX_BASE_GAS } from './constants';
+
+const FILL_QUOTE_TRANSFORMER_GAS_OVERHEAD = new BigNumber(150e3);
+const EXCHANGE_PROXY_OVERHEAD_NO_VIP = () => FILL_QUOTE_TRANSFORMER_GAS_OVERHEAD;
+const MULTIPLEX_BATCH_FILL_SOURCE_FLAGS =
+    SOURCE_FLAGS.Uniswap_V2 |
+    SOURCE_FLAGS.SushiSwap |
+    SOURCE_FLAGS.RfqOrder |
+    SOURCE_FLAGS.Uniswap_V3 |
+    SOURCE_FLAGS.OtcOrder;
+const MULTIPLEX_MULTIHOP_FILL_SOURCE_FLAGS = SOURCE_FLAGS.Uniswap_V2 | SOURCE_FLAGS.SushiSwap | SOURCE_FLAGS.Uniswap_V3;
+const EXCHANGE_PROXY_OVERHEAD_FULLY_FEATURED = (sourceFlags: bigint) => {
+    if ([SOURCE_FLAGS.Uniswap_V2, SOURCE_FLAGS.SushiSwap].includes(sourceFlags)) {
+        // Uniswap and forks VIP
+        return TX_BASE_GAS;
+    } else if (
+        [
+            SOURCE_FLAGS.SushiSwap,
+            SOURCE_FLAGS.PancakeSwap,
+            SOURCE_FLAGS.PancakeSwap_V2,
+            SOURCE_FLAGS.BakerySwap,
+            SOURCE_FLAGS.ApeSwap,
+        ].includes(sourceFlags) &&
+        CHAIN_ID === ChainId.BSC
+    ) {
+        // PancakeSwap and forks VIP
+        return TX_BASE_GAS;
+    } else if (SOURCE_FLAGS.Uniswap_V3 === sourceFlags) {
+        // Uniswap V3 VIP
+        return TX_BASE_GAS.plus(5e3);
+    } else if (SOURCE_FLAGS.Curve === sourceFlags) {
+        // Curve pseudo-VIP
+        return TX_BASE_GAS.plus(40e3);
+    } else if (SOURCE_FLAGS.RfqOrder === sourceFlags) {
+        // RFQ VIP
+        return TX_BASE_GAS.plus(5e3);
+    } else if (SOURCE_FLAGS.OtcOrder === sourceFlags) {
+        // OtcOrder VIP
+        // NOTE: Should be 15k cheaper after the first tx from txOrigin than RfqOrder
+        // Use 5k less for now as not to over bias
+        return TX_BASE_GAS;
+    } else if ((MULTIPLEX_BATCH_FILL_SOURCE_FLAGS | sourceFlags) === MULTIPLEX_BATCH_FILL_SOURCE_FLAGS) {
+        if ((sourceFlags & SOURCE_FLAGS.OtcOrder) === SOURCE_FLAGS.OtcOrder) {
+            // Multiplex that has OtcOrder
+            return TX_BASE_GAS.plus(10e3);
+        }
+        // Multiplex batch fill
+        return TX_BASE_GAS.plus(15e3);
+    } else if (
+        (MULTIPLEX_MULTIHOP_FILL_SOURCE_FLAGS | sourceFlags) ===
+        (MULTIPLEX_MULTIHOP_FILL_SOURCE_FLAGS | SOURCE_FLAGS.MultiHop)
+    ) {
+        // Multiplex multi-hop fill
+        return TX_BASE_GAS.plus(25e3);
+    } else {
+        return FILL_QUOTE_TRANSFORMER_GAS_OVERHEAD;
+    }
+};
+
+const NEON_ROUTER_NUM_SAMPLES = 14;
+// TODO(kimpers): Due to an issue with the Rust router we want to use equidistant samples when using the Rust router
+
+export const ASSET_SWAPPER_MARKET_ORDERS_OPTS: Partial<SwapQuoteRequestOpts> = {
+    bridgeSlippage: DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE,
+    numSamples: 13,
+    sampleDistributionBase: SAMPLE_DISTRIBUTION_BASE,
+    neonRouterNumSamples: NEON_ROUTER_NUM_SAMPLES,
+    exchangeProxyOverhead: EXCHANGE_PROXY_OVERHEAD_FULLY_FEATURED,
+    shouldGenerateQuoteReport: true,
+};
+
+export const ASSET_SWAPPER_MARKET_ORDERS_OPTS_NO_VIP: Partial<SwapQuoteRequestOpts> = {
+    ...ASSET_SWAPPER_MARKET_ORDERS_OPTS,
+    exchangeProxyOverhead: EXCHANGE_PROXY_OVERHEAD_NO_VIP,
+};
+
+const SAMPLER_OVERRIDES: SamplerOverrides | undefined = (() => {
+    switch (CHAIN_ID) {
+        case ChainId.Ganache:
+            return { overrides: {}, block: BlockParamLiteral.Latest };
+        default:
+            return undefined;
+    }
+})();
+
+const SWAP_QUOTER_RFQT_OPTS: SwapQuoterRfqOpts = {
+    integratorsWhitelist: RFQT_INTEGRATORS,
+    txOriginBlacklist: RFQT_TX_ORIGIN_BLACKLIST,
+};
+
+export const SWAP_QUOTER_OPTS: Partial<SwapQuoterOpts> = {
+    chainId: CHAIN_ID,
+    expiryBufferMs: QUOTE_ORDER_EXPIRATION_BUFFER_MS,
+    rfqt: SWAP_QUOTER_RFQT_OPTS,
+    zeroExGasApiUrl: ZERO_EX_GAS_API_URL,
+    permittedOrderFeeTypes: new Set([OrderPrunerPermittedFeeTypes.NoFees]),
+    samplerOverrides: SAMPLER_OVERRIDES,
+    tokenAdjacencyGraph: DEFAULT_TOKEN_ADJACENCY_GRAPH_BY_CHAIN_ID[CHAIN_ID],
+};

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -16,7 +16,6 @@ import {
     artifacts,
     AssetSwapperContractAddresses,
     BlockParamLiteral,
-    ChainId,
     ContractAddresses,
     FakeTakerContract,
     GetMarketOrdersRfqOpts,
@@ -36,17 +35,19 @@ import { ExchangeProxyContractOpts } from '../asset-swapper/types';
 import {
     ALT_RFQ_MM_API_KEY,
     ALT_RFQ_MM_ENDPOINT,
-    ASSET_SWAPPER_MARKET_ORDERS_OPTS,
-    ASSET_SWAPPER_MARKET_ORDERS_OPTS_NO_VIP,
     CHAIN_HAS_VIPS,
     CHAIN_ID,
     RFQT_REQUEST_MAX_RESPONSE_MS,
-    SWAP_QUOTER_OPTS,
     UNWRAP_QUOTE_GAS,
     WRAP_QUOTE_GAS,
     ZERO_EX_FEE_RECIPIENT_ADDRESS,
     ZERO_EX_FEE_TOKENS,
 } from '../config';
+import {
+    ASSET_SWAPPER_MARKET_ORDERS_OPTS,
+    ASSET_SWAPPER_MARKET_ORDERS_OPTS_NO_VIP,
+    SWAP_QUOTER_OPTS,
+} from '../options';
 import {
     DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE,
     DEFAULT_VALIDATION_GAS_LIMIT,
@@ -81,6 +82,7 @@ import { serviceUtils, getBuyTokenPercentageFeeOrZero } from '../utils/service_u
 import { SlippageModelFillAdjustor } from '../utils/slippage_model_fill_adjustor';
 import { SlippageModelManager } from '../utils/slippage_model_manager';
 import { utils } from '../utils/utils';
+import { ChainId } from '@0x/contract-addresses';
 
 const PRICE_IMPACT_TOO_HIGH = new Counter({
     name: 'price_impact_too_high',

--- a/test/swap_test.ts
+++ b/test/swap_test.ts
@@ -14,7 +14,7 @@ import supertest from 'supertest';
 import { getAppAsync } from '../src/app';
 import { getDefaultAppDependenciesAsync } from '../src/runners/utils';
 import { AppDependencies } from '../src/types';
-import { BUY_SOURCE_FILTER_BY_CHAIN_ID, ChainId, ERC20BridgeSource, LimitOrderFields } from '../src/asset-swapper';
+import { BUY_SOURCE_FILTER_BY_CHAIN_ID, ERC20BridgeSource, LimitOrderFields } from '../src/asset-swapper';
 import * as config from '../src/config';
 import { AFFILIATE_FEE_TRANSFORMER_GAS, GAS_LIMIT_BUFFER_MULTIPLIER, SWAP_PATH } from '../src/constants';
 import { getDBConnectionOrThrow } from '../src/db_connection';
@@ -41,6 +41,7 @@ import { constructRoute, httpGetAsync } from './utils/http_utils';
 import { MockOrderWatcher } from './utils/mock_order_watcher';
 import { getRandomSignedLimitOrderAsync } from './utils/orders';
 import { StatusCodes } from 'http-status-codes';
+import { ChainId } from '@0x/contract-addresses';
 
 // Force reload of the app avoid variables being polluted between test suites
 // Warning: You probably don't want to move this


### PR DESCRIPTION
# Description

* As `logger.ts` depends on `config.ts`, `config.ts` depending on `asset-swapper` makes it difficult to avoid circular dependency.

# Testing & Simbot Run

* n/a

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
