### PR TITLE
refactor: Use the standard logger in `swap_quoter.ts` [LIT-852]

### DIFF
--- a/src/asset-swapper/swap_quoter.ts
+++ b/src/asset-swapper/swap_quoter.ts
@@ -8,6 +8,7 @@ import * as _ from 'lodash';
 import { artifacts } from '../artifacts';
 import { RfqClient } from '../utils/rfq_client';
 import { ERC20BridgeSamplerContract } from '../wrappers';
+import { logger } from '../logger';
 
 import { constants } from './constants';
 import {
@@ -298,27 +299,23 @@ export class SwapQuoter {
 
         // If an integrator ID was provided, but the ID is not whitelisted, raise a warning and disable RFQ
         if (!this._isIntegratorIdWhitelisted(integrator.integratorId)) {
-            if (this._rfqtOptions && this._rfqtOptions.warningLogger) {
-                this._rfqtOptions.warningLogger(
-                    {
-                        ...integrator,
-                    },
-                    'Attempt at using an RFQ API key that is not whitelisted. Disabling RFQ for the request lifetime.',
-                );
-            }
+            logger.warn(
+                {
+                    ...integrator,
+                },
+                'Attempt at using an RFQ API key that is not whitelisted. Disabling RFQ for the request lifetime.',
+            );
             return undefined;
         }
 
         // If the requested tx origin is blacklisted, raise a warning and disable RFQ
         if (this._isTxOriginBlacklisted(txOrigin)) {
-            if (this._rfqtOptions && this._rfqtOptions.warningLogger) {
-                this._rfqtOptions.warningLogger(
-                    {
-                        txOrigin,
-                    },
-                    'Attempt at using a tx Origin that is blacklisted. Disabling RFQ for the request lifetime.',
-                );
-            }
+            logger.warn(
+                {
+                    txOrigin,
+                },
+                'Attempt at using a tx Origin that is blacklisted. Disabling RFQ for the request lifetime.',
+            );
             return undefined;
         }
 

--- a/src/asset-swapper/types.ts
+++ b/src/asset-swapper/types.ts
@@ -329,7 +329,6 @@ export interface Integrator {
 export interface SwapQuoterRfqOpts {
     integratorsWhitelist: Integrator[];
     txOriginBlacklist: Set<string>;
-    warningLogger?: LogFunction;
 }
 
 export type AssetSwapperContractAddresses = ContractAddresses;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,9 +1,6 @@
 import { pino } from '@0x/api-utils';
 
-import { LOGGER_INCLUDE_TIMESTAMP, LOG_LEVEL, MAX_ORDER_EXPIRATION_BUFFER_SECONDS } from './config';
-import { ONE_SECOND_MS } from './constants';
-import { ExpiredOrderError } from './errors';
-import { SRAOrder } from './types';
+import { LOGGER_INCLUDE_TIMESTAMP, LOG_LEVEL } from './config';
 
 export const logger = pino({
     formatters: {
@@ -14,21 +11,3 @@ export const logger = pino({
     level: LOG_LEVEL,
     timestamp: LOGGER_INCLUDE_TIMESTAMP,
 });
-
-/**
- * If the max age of expired orders exceeds the configured threshold, this function
- * logs an error capturing the details of the expired orders
- */
-export function alertOnExpiredOrders(expired: SRAOrder[], details?: string): void {
-    const maxExpirationTimeSeconds = Date.now() / ONE_SECOND_MS + MAX_ORDER_EXPIRATION_BUFFER_SECONDS;
-    let idx = 0;
-    if (
-        expired.find((order, i) => {
-            idx = i;
-            return order.order.expiry.toNumber() > maxExpirationTimeSeconds;
-        })
-    ) {
-        const error = new ExpiredOrderError(expired[idx].order, MAX_ORDER_EXPIRATION_BUFFER_SECONDS, details);
-        logger.error(error);
-    }
-}

--- a/src/services/swap_service.ts
+++ b/src/services/swap_service.ts
@@ -214,11 +214,6 @@ export class SwapService implements ISwapService {
 
         this._swapQuoterOpts = {
             ...SWAP_QUOTER_OPTS,
-            rfqt: {
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- TODO: fix me!
-                ...SWAP_QUOTER_OPTS.rfqt!,
-                warningLogger: logger.warn.bind(logger),
-            },
             contractAddresses,
         };
 


### PR DESCRIPTION
# Description

* Move orderbook specific log function out of `logger.ts`
* Use standard logger in `swap_quoter.ts`

# Testing & Simbot Run

<!--- If your changes affect `swap` API (e.g. adding a new liquidity source, changes sampling or routing logic) include a link to Simbot run(s). -->

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
