### PR TITLE
fix: Fix enum value of `MultiplexSubcall` in the encoder

### DIFF
--- a/src/asset-swapper/quote_consumers/multiplex_encoders.ts
+++ b/src/asset-swapper/quote_consumers/multiplex_encoders.ts
@@ -2,14 +2,15 @@ import { OtcOrder, RfqOrder, SIGNATURE_ABI } from '@0x/protocol-utils';
 import { AbiEncoder } from '@0x/utils';
 
 export enum MultiplexSubcall {
-    Invalid,
-    Rfq,
-    Otc,
-    UniswapV2,
-    UniswapV3,
-    TransformERC20,
-    BatchSell,
-    MultiHopSell,
+    Invalid = 0,
+    Rfq = 1,
+    Otc = 2,
+    UniswapV2 = 3,
+    UniswapV3 = 4,
+    LiquidityProvider = 5,
+    TransformERC20 = 6,
+    BatchSell = 7,
+    MultiHopSell = 8,
 }
 export const multiplexTransformERC20Encoder = AbiEncoder.create([
     {


### PR DESCRIPTION
# Description

Fix the enum value of `MultiplexSubcall` in `multiplex_encoder.ts` (regression from #1074 which deleted one of the enum values and thereby shifted the subsequent enum value by -1).

# Testing & Simbot Run

<!--- If your changes affect `swap` API (e.g. adding a new liquidity source, changes sampling or routing logic) include a link to Simbot run(s). -->

# Checklist

-   [ ] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [ ] Add tests to cover changes as needed.
-   [ ] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
