### PR TITLE
fix: Fix `help` for `sampler_blocknumber`

### DIFF
--- a/src/utils/sampler_metrics.ts
+++ b/src/utils/sampler_metrics.ts
@@ -3,23 +3,23 @@ import { Gauge, Summary } from 'prom-client';
 
 const SAMPLER_GAS_USED_SUMMARY = new Summary({
     name: 'sampler_gas_used_summary',
-    help: 'Provides information about the gas used during a sampler call',
+    help: 'The gas used during a sampler call',
     labelNames: ['side'],
 });
 
 const SAMPLER_GAS_LIMIT_SUMMARY = new Summary({
     name: 'sampler_gas_limit_summary',
-    help: 'Provides information about the gas limit detected during a sampler call',
+    help: 'The gas limit detected during a sampler call',
 });
 
 const SAMPLER_BLOCK_NUMBER_GAUGE = new Gauge({
     name: 'sampler_blocknumber',
-    help: 'Provides information about the gas limit detected during a sampler call',
+    help: 'The block number of a sampler call',
 });
 
 const ROUTER_EXECUTION_TIME_SUMMARY = new Summary({
     name: 'router_execution_time',
-    help: 'Provides information about the execution time for routing related logic',
+    help: 'Execution time for routing related logic',
     labelNames: ['router', 'type'],
 });
 


### PR DESCRIPTION
# Description

* Fix `help` for `sampler_blocknumber`
* Shorten `help` for others.

# Testing & Simbot Run

<!--- If your changes affect `swap` API (e.g. adding a new liquidity source, changes sampling or routing logic) include a link to Simbot run(s). -->

# Checklist

-   [x] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [x] Add tests to cover changes as needed.
-   [x] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
