### PR TITLE
fix: removing paused Saddle BTC pool [LIT-857]

### DIFF
--- a/src/asset-swapper/utils/market_operation_utils/constants.ts
+++ b/src/asset-swapper/utils/market_operation_utils/constants.ts
@@ -698,7 +698,6 @@ export const REBASING_TOKENS = Set.of(MAINNET_TOKENS.stETH);
 const SADDLE_MAINNET_POOLS = {
     // swaps
     stablesV2: '0xacb83e0633d6605c5001e2ab59ef3c745547c8c7',
-    bitcoinsV2: '0xdf3309771d2bf82cb2b6c56f9f5365c8bd97c4f2',
     alETH: '0xa6018520eaacc06c30ff2e1b3ee2c7c22e64196a',
     d4: '0xc69ddcd4dfef25d8a793241834d4cc4b3668ead6',
     '4Pool': '0x101cd330d088634b6f64c2eb4276e63bf1bbfde3',
@@ -1057,11 +1056,6 @@ export const SADDLE_MAINNET_INFOS: { [name: string]: CurveInfo } = {
     [SADDLE_MAINNET_POOLS.stablesV2]: createSaddleSwapPool({
         tokens: [MAINNET_TOKENS.DAI, MAINNET_TOKENS.USDC, MAINNET_TOKENS.USDT],
         pool: SADDLE_MAINNET_POOLS.stablesV2,
-        gasSchedule: 150e3,
-    }),
-    [SADDLE_MAINNET_POOLS.bitcoinsV2]: createSaddleSwapPool({
-        tokens: [MAINNET_TOKENS.WBTC, MAINNET_TOKENS.RenBTC, MAINNET_TOKENS.sBTC],
-        pool: SADDLE_MAINNET_POOLS.bitcoinsV2,
         gasSchedule: 150e3,
     }),
     [SADDLE_MAINNET_POOLS.alETH]: createSaddleSwapPool({


### PR DESCRIPTION
<!---
The PR title should follow [conventional commits](https://www.conventionalcommits.org/)
-->

# Description
The Saddle BTC pool on mainnet is paused, leading to a high revert rate.
<!--- Describe your changes in detail -->

# Testing & Simbot Run

<!--- If your changes affect `swap` API (e.g. adding a new liquidity source, changes sampling or routing logic) include a link to Simbot run(s). -->

# Checklist

-   [ ] Update 0x API documentation (gitbook) if needed (e.g. public facing API change).
-   [ ] Add tests to cover changes as needed.
-   [ ] All dependent changes (e.g. RFQ server, Gas Price Oracle) have been deployed (if any).
